### PR TITLE
Fix doc titles and typos

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,9 +1,8 @@
-===========
 DEVELOPMENT
 ===========
 
 General
-=======
+-------
 
 GeoNature has been developped by Gil Deluermoz since 2010 with PHP/Symfony/ExtJS.
 
@@ -18,7 +17,7 @@ Maintainers :
 
 
 Architecture
-============
+------------
 
 - UsersHub and its Flask module (https://github.com/PnX-SI/UsersHub-authentification-module) are used to manage ``ref_users`` database schema
 - TaxHub (https://github.com/PnX-SI/TaxHub) is used to manage ``ref_taxonomy`` database schema. We also use TaxHub API to get information about taxons, species...
@@ -27,7 +26,7 @@ Architecture
 
 
 Database
-========
+--------
 
 In GeoNature V2, the whole database is still done with PostgreSQL/PostGIS but it has also been rebuilt. 
 
@@ -55,7 +54,7 @@ Here is a simplified model of the database (2017-12-15) :
 .. image :: https://raw.githubusercontent.com/PnX-SI/GeoNature/develop/docs/2017-12-15-GN2-MCD-simplifie.jpg
 
 Gestion des droits :
---------------------
+""""""""""""""""""""
 
 La gestion des droits est centralisée dans UsersHub. Dans la version 1 de GeoNature, il était possible d'attribuer des droits selon 6 niveaux à des rôles (utilisateurs ou groupes). Pour la version 2 de GeoNature, des évolutions ont été réalisées pour étendre les possibilités d'attribution de droits et les rendre plus génériques. 
 
@@ -72,7 +71,7 @@ Pour cela un système d'étiquettes (``utilisateurs.t_tags``) a été mis en pla
 - Il est aussi possible de ne pas utiliser UsersHub pour gérer les utilisateurs et de connecter GeoNature à un CAS (voir configuration). Actuellement ce paramétrage est fonctionnel en se connectant au CAS de l'INPN (MNHN)
 
 Nomenclatures :
----------------
+"""""""""""""""
 
 - Toutes les listes déroulantes sont gérées dans une table générique ``ref_nomenclatures.t_nomenclatures``
 - Elles s'appuient sur les nomenclatures du SINP (http://standards-sinp.mnhn.fr/nomenclature/) qui peuvent être désactivées ou completées
@@ -87,13 +86,13 @@ Nomenclatures :
 - Il existe aussi une table pour définir des valeurs par défaut de nomenclature générales (``ref_nomenclatures.defaults_nomenclatures_value``)
 
 Métadonnées :
--------------
+"""""""""""""
 
 - Elles sont gérées dans le schéma ``gn_meta`` basé sur le standard Métadonnées du SINP (http://standards-sinp.mnhn.fr/category/standards/metadonnees/)
 - Elles permettent de gérer des jeux de données, des cadres d'acquisition, des acteurs (propriétaire, financeur, producteur...) et des protocoles
 
 Données SIG :
--------------
+"""""""""""""
 
 - Le schéma ``ref_geo`` permet de gérer les données SIG (zonages, communes, MNT...) de manière centralisée, potentiellement partagé avec d'autres BDD
 - Il contient une table des zonages, des types de zonages, des communes, des grilles (mailles) et du MNT vectorisé (https://github.com/PnX-SI/GeoNature/issues/235)
@@ -103,44 +102,31 @@ Données SIG :
 
 
 Modularité
-==========
+----------
 
 Chaque module doit avoir son propre schéma dans la BDD, avec ses propres fichiers SQL de création comme le module Contact (OCCTAX) : https://github.com/PnX-SI/GeoNature/tree/develop/data/modules/contact
 
-<<<<<<< HEAD
-Côté backend chaque module a aussi son modèle et ses routes : https://github.com/PnX-SI/GeoNature/tree/develop/backend/src/modules/pr_contact
+Côté backend chaque module a aussi son modèle et ses routes : https://github.com/PnX-SI/GeoNature/tree/develop/backend/geonature/modules/pr_contact
 
-Idem côté FRONT, où chaque module a sa config et ses composants : https://github.com/PnX-SI/GeoNature/tree/develop/frontend/src/modules/contact
-=======
-Côté backend chaque module a aussi son modèle et ses routes : https://github.com/PnX-SI/GeoNature/tree/frontend-contact/backend/geonature/modules/pr_contact
-
-Idem côté FRONT, où chaque module a sa config et ses composants : https://github.com/PnX-SI/GeoNature/tree/frontend-contact/backend/geonature/modules/pr_contact
->>>>>>> validation
+Idem côté FRONT, où chaque module a sa config et ses composants : https://github.com/PnX-SI/GeoNature/tree/develop/backend/geonature/modules/pr_contact
 
 Mais en pouvant utiliser des composants du CORE comme expliqué ci-dessous.
 
 
 Configuration
-=============
+-------------
 
 Pour configurer GeoNature, actuellement il y a : 
 
-<<<<<<< HEAD
 - Une configuration pour l'installation : https://github.com/PnX-SI/GeoNature/blob/develop/config/settings.ini.sample
-- Une configuration globale du backend : https://github.com/PnX-SI/GeoNature/blob/develop/backend/custom_config.py.sample
-- Une configuration globale du frontend : https://github.com/PnX-SI/GeoNature/blob/develop/frontend/src/conf/app.config.sample.ts
-- Une configuration frontend par module : https://github.com/PnX-SI/GeoNature/blob/develop/frontend/src/modules/contact/contact.config.ts
-=======
-- Une configuration pour l'installation : https://github.com/PnX-SI/GeoNature/blob/frontend-contact/config/settings.ini.sample
-- Une configuration globale du backend : https://github.com/PnX-SI/GeoNature/blob/frontend-contact/backend/config.py.sample
-- Une configuration globale du frontend : https://github.com/PnX-SI/GeoNature/blob/frontend-contact/frontend/geonature/conf/app.config.sample.ts
-- Une configuration frontend par module : https://github.com/PnX-SI/GeoNature/blob/frontend-contact/frontend/geonature/modules/contact/contact.config.ts
->>>>>>> validation
+- Une configuration globale du backend : https://github.com/PnX-SI/GeoNature/blob/develop/backend/config.py.sample
+- Une configuration globale du frontend : https://github.com/PnX-SI/GeoNature/blob/develop/frontend/geonature/conf/app.config.sample.ts
+- Une configuration frontend par module : https://github.com/PnX-SI/GeoNature/blob/develop/frontend/geonature/modules/contact/contact.config.ts
 - Une table ``gn_meta.t_parameters`` pour des paramètres gérés dans la BDD
 
 
 API
-=============
+---
 
 GeoNature utilise : 
 
@@ -153,10 +139,10 @@ Pour avoir des infos et la documentation de ces API, on utilise PostMan. Documen
 
 
 Développement Frontend
-======================
+----------------------
 
 Modules
--------
+"""""""
 
 Bonnes pratiques:
 
@@ -212,7 +198,7 @@ Ce module peut s'appuyer sur une série de composants génériques intégrés da
         :``options``:
                 Objet permettant de paramettrer le plugin et les différentes formes dessinables (point, ligne, cercle etc...)
                 
-                Par défault le fichier ``leaflet-draw.option.ts` est passé au composant. Il est possible de surcharger l'objet pour activer/désactiver certaines formes. Voir `exemple <https://github.com/PnX-SI/GeoNature/blob/d3b0e1ba4f88494fd492bb5f24c3782756162124/frontend/geonature/modules/contact/contact-form/contact-form.component.ts#L22>`_ 
+                Par défault le fichier ``leaflet-draw.option.ts`` est passé au composant. Il est possible de surcharger l'objet pour activer/désactiver certaines formes. Voir `exemple <https://github.com/PnX-SI/GeoNature/blob/d3b0e1ba4f88494fd492bb5f24c3782756162124/frontend/geonature/modules/contact/contact-form/contact-form.component.ts#L22>`_ 
                 
         **Output**
         
@@ -247,7 +233,7 @@ Ce module peut s'appuyer sur une série de composants génériques intégrés da
 
 
 Outils d'aide à la qualité du code
-==================================
+----------------------------------
 
 Des outils d'amélioration du code pour les développeurs peuvent être utilisés : flake8, pylint, mypy, pytest, coverage.
 La documentation est générée avec sphinx.
@@ -265,7 +251,7 @@ est également disponible à la racine du projet.
 
 
 Installation
-------------
+""""""""""""
 
 ::
 
@@ -282,7 +268,7 @@ La documentation de ces outils est disponible en ligne :
 * http://www.sphinx-doc.org/en/stable/ -  Doc : http://www.sphinx-doc.org/en/stable/contents.html
 
 Usage
------
+"""""
 Pour utiliser ces outils il faut se placer dans le virtualenv
 
 ::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
-.. Geonature documentation master file, created by
+.. GeoNature documentation master file, created by
    sphinx-quickstart on Tue Jan 16 15:55:07 2018.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Geonature's documentation!
+Welcome to GeoNature's documentation!
 =====================================
 
 .. toctree::
@@ -14,6 +14,7 @@ Welcome to Geonature's documentation!
    development
    installation_developer
    install-mtes
+   user-manual
    CHANGELOG 
 
 

--- a/docs/install-mtes.rst
+++ b/docs/install-mtes.rst
@@ -1,4 +1,3 @@
-===============================
 SPECIFICITES INSTANCE NATIONALE
 ===============================
 
@@ -9,7 +8,7 @@ Ne pas insérer les données exemple si possible.
 Attention, communes, zonages et MNT national ?
 
 Taxons saisissables
-===================
+-------------------
 
 GeoNature n'interroge pas directement la table ``taxonomie.taxref`` pour permettre à l'administrateur de choisir quels taxons sont disponibles à la saisie. 
 
@@ -38,7 +37,7 @@ Il faut ensuite ajouter tous ces noms à la liste ``Saisie possible`` :
         
         
 Authentification CAS INPN
-=========================
+-------------------------
 
 - Code source : https://github.com/PnX-SI/GeoNature/blob/develop/backend/geonature/core/auth/routes.py#L19-L106
 - Config backend : https://github.com/PnX-SI/GeoNature/blob/develop/backend/default_config.py#L25-L35
@@ -46,7 +45,7 @@ Authentification CAS INPN
 
 
 Connexion et droits dans GeoNature
-==================================
+----------------------------------
 
 - A chaque connexion via le CAS INPN on récupère l’ID_Utilisateur. On ajoute cet utilisateur dans la base GeoNature (``utilisateurs.t_roles`` et ``utilisateurs.bib_organisme``).
 	 
@@ -60,7 +59,7 @@ NB sur la gestion des droits dans GeoNature :
 - 3 portées de ces actions sont possibles : Mes données / Les données de mon organisme / Toutes les données.
 
 Récupération des JDD
-====================
+--------------------
 
 Grâce à la nouvelle API de MTD, il est désormais possible d’ajouter les jeux de données (et des cadres d’acquisition) créés dans MTD dans la BDD GeoNature.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,9 +1,8 @@
-=============================
 INSTALLATION DE L'APPLICATION
 =============================
 
 Prérequis
-=========
+---------
 
 - Ressources minimum serveur :
 
@@ -21,7 +20,7 @@ Le script global d'installation de GeoNature va aussi se charger d'installer les
 - Librairies CSS (Bootstrap, Material Design)
 
 Installation de l'application
-=============================
+-----------------------------
 
 /!\ A mettre à jour. Install_all en cours : https://github.com/PnX-SI/GeoNature/tree/develop/install_all
 
@@ -123,7 +122,7 @@ Editez ensuite le fichier de configuration Apache: ``/etc/apache2/sites-availabl
 
 
 Installation d'un module GeoNature
-==================================
+----------------------------------
 
 L'installation de GeoNature n'est livrée qu'avec les schémas de base de données du coeur. Pour ajouter un nouveau module, il est necessaire de l'installer:
 
@@ -135,10 +134,10 @@ L'installation de GeoNature n'est livrée qu'avec les schémas de base de donné
 
 
 Doc développeur
-==========================================
+---------------
 
-Instalation de l'environnement Python
---------------------------------------
+Installation de l'environnement Python
+""""""""""""""""""""""""""""""""""""""
 
 Installer pipenv et le virtualenv ainsi que tous les dépendances Python.
 
@@ -149,15 +148,13 @@ Installer pipenv et le virtualenv ainsi que tous les dépendances Python.
 
 Lancer ensuite l'application en mode développement
 
-Stopper d'abbord le mode production, puis lancez le mode développement du backend
+Stopper d'abord le mode production, puis lancez le mode développement du backend
 
 ::
 
     cd geonature/backend/
     make supervisor-stop
     make develop
-
-
 
 
 * Installation du sous-module en mode develop. On assume que le sous-module est installé au même niveau que GeoNature, dans le répertoire `home` de l'utilisateur
@@ -180,7 +177,7 @@ Modifier le fichier de configuration du frontend ``frontend/src/conf/app.config.
 
 ::
 
-  	URL_APPLICATION: 'http://127.0.0.1:4200',
+    URL_APPLICATION: 'http://127.0.0.1:4200',
     API_ENDPOINT: 'http://127.0.0.1:8000/',
     API_TAXHUB : 'http://127.0.0.1:5000/api/',
 
@@ -188,6 +185,6 @@ Depuis le répertoire ``frontend`` lancer la commande:
 
 ::
 
-	  npm run start
+    npm run start
 
 Lancer son navigateur à l'adresse ``127.0.0.1:4200``

--- a/docs/installation_developer.rst
+++ b/docs/installation_developer.rst
@@ -1,14 +1,13 @@
-================================
 GUIDE D'INSTALLATION DEVELOPPEUR
 ================================
 
 Prérequis
-=========
+---------
 
 Un machine Linux (testé sur Ubuntu 16.04 et Debian 8)
 
 Dépendances
-===========
+-----------
 
 L'application GeoNature utilise les dépendances suivantes :
 
@@ -32,7 +31,7 @@ Les deux sous-modules sont fournis directement avec GeoNature. Il faut en revanc
 pour assuer le bon fonctionnement de l'application GeoNature.
 
 Installation des dépendances
-============================
+----------------------------
 
 * Mettre à jour de la liste des dépôts Linux :
 
@@ -60,7 +59,7 @@ Se placer dans le répertoire de GeoNature.
     sudo apt-get install -y supervisor
 
 Installation de la base de données
-==================================
+----------------------------------
 
 Créer un utilisateur PostgreSQL si vous n'en n'avez pas un :
 
@@ -92,7 +91,7 @@ Pour installer le module 'Occurrence de taxons' lancer le script :
     sudo ./data/modules/contact/install_schema.sh
 
 Installation de l'application
-=============================
+-----------------------------
 
 Lancer le script d'installation de l'application :
 
@@ -125,7 +124,7 @@ Exemple de configuration du fichier ``app.config.ts`` :
 
 
 Lancement de l'application
-==========================
+--------------------------
 
 'nvm' (node version manager) est utilisé pour installer les dernières versions de node et npm.
 
@@ -175,7 +174,7 @@ TODO interroger l'API via Postman
 
 
 Installation de TaxHub
-======================
+----------------------
 
 Sortez du répertoire de GeoNature pour installer TaxHub de manière indépendante dans son propre répertoire.
 


### PR DESCRIPTION
- Use same titles formats in all RST files
- Fix some minor typos
- Fix some DEV DOC problems after MERGE
- Add user manual to DOC index