### PR TITLE
[Métadonnées] Inversion domaines terrestre/marin dans JDD

### DIFF
--- a/frontend/src/app/metadataModule/datasets/dataset-form.component.html
+++ b/frontend/src/app/metadataModule/datasets/dataset-form.component.html
@@ -51,14 +51,14 @@
       
               <small>Domaine</small>
               <div class="form-check" padding-lg>
-                <input [formControl]="datasetForm.controls.marine_domain" class="" type="checkbox" name="domaine" id="terrestre"
+                <input [formControl]="datasetForm.controls.terrestrial_domain" class="" type="checkbox" name="domaine" id="terrestre"
                   value="true">
                 <small class="" for="terrestre">
                   Domaine terrestre
                 </small>
               </div>
               <div class="form-check">
-                <input [formControl]="datasetForm.controls.terrestrial_domain" type="checkbox" name="domaine" id="marin">
+                <input [formControl]="datasetForm.controls.marine_domain" type="checkbox" name="domaine" id="marin">
                 <small class="" for="marin">
                   Domaine marin
                 </small>

--- a/frontend/src/app/metadataModule/datasets/dataset-form.component.ts
+++ b/frontend/src/app/metadataModule/datasets/dataset-form.component.ts
@@ -53,8 +53,8 @@ export class DatasetFormComponent implements OnInit {
       dataset_desc: [null, Validators.required],
       id_nomenclature_data_type: [null, Validators.required],
       keywords: null,
-      marine_domain: true,
-      terrestrial_domain: false,
+      terrestrial_domain: true,
+      marine_domain: false,
       id_nomenclature_dataset_objectif: [null, Validators.required],
       //TODO bouding-box
       id_nomenclature_collecting_method: [null, Validators.required],


### PR DESCRIPTION
Correction d'une inversion dans les checkboxes des domaines terrestre et marin du formulaire des JDD. Edition inversée dans les champs booléen concernés côté BDD.