### PR TITLE
Correction translate

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-
+import { TranslateService } from '@ngx-translate/core';
 import { AuthService } from '@geonature/components/auth/auth.service';
+import { AppConfig } from '../conf/app.config';
 
 @Component({
   selector: 'pnx-root',
@@ -8,7 +9,14 @@ import { AuthService } from '@geonature/components/auth/auth.service';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
-  constructor(private _authService: AuthService) {}
+  constructor(
+  	private _authService: AuthService, 
+  	private translate: TranslateService
+  ) {
+  	translate.addLangs(['en', 'fr', 'cn']);
+    translate.setDefaultLang(AppConfig.DEFAULT_LANGUAGE);
+    translate.use(AppConfig.DEFAULT_LANGUAGE);
+  }
 
   ngOnInit() {}
 }

--- a/frontend/src/app/components/nav-home/nav-home.component.ts
+++ b/frontend/src/app/components/nav-home/nav-home.component.ts
@@ -30,11 +30,7 @@ export class NavHomeComponent implements OnInit, OnDestroy {
     private _sideNavService: SideNavService,
     private _location: Location,
     private _globalSub: GlobalSubService
-  ) {
-    translate.addLangs(['en', 'fr', 'cn']);
-    translate.setDefaultLang(AppConfig.DEFAULT_LANGUAGE);
-    translate.use(AppConfig.DEFAULT_LANGUAGE);
-  }
+  ) {}
 
   ngOnInit() {
     this.appConfig = AppConfig;


### PR DESCRIPTION
Toute p'tite PR pour intégrer translate dans le app.component. Ca permet de l'avoir (le translate) sur la page de log et de corriger le message "LoginError" pas beau.