### PR TITLE
Update af-form.component.html

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,7 +2,7 @@
 CHANGELOG
 =========
 
-2.1.0 (2019-05-29)
+2.1.0 (2019-05-31)
 ------------------
 
 **🚀 Nouveautés**
@@ -30,6 +30,7 @@ CHANGELOG
 * Correction lors d'import de fichier GPX ayant une altitude (#631)
 * Occtax - Correction du filtre Observateur texte libre (#598)
 * Métadonnées - Inversion des domaines terrestre/marin (par @xavyeah39)
+* Métadonnées - Correction de l'édition des cadres d'acquisition (#654, par @DonovanMaillard)
 * Mise à jour de sécurité de Jinja2 et SQLAlchemy
 
 **⚠️ Notes de version**

--- a/frontend/src/app/metadataModule/af/af-form.component.html
+++ b/frontend/src/app/metadataModule/af/af-form.component.html
@@ -75,7 +75,7 @@
       
               <small>Description de la cible </small>
               <div class="input-group">
-                <input class="form-control form-control-sm" type="text" name="" id="" [formControl]="afForm.controls.keywords">
+                <input class="form-control form-control-sm" type="text" name="" id="" [formControl]="afForm.controls.target_description">
               </div>
       
               <pnx-date label="Date début" [parentFormControl]="afForm.controls.acquisition_framework_start_date">


### PR DESCRIPTION
Une coquille qui renvoyait la mauvaise info dans l'interface des cadres d'acquisition. Le champs "description cible" renvoyait les mots clés (déjà renvoyés dans le bon champs)

testé et fonctionnel sur mon instance :)