### PR TITLE
Controle des routes différentié en fonction des paramètres de ACCOUNT_MANAGEMENT

### DIFF
--- a/backend/geonature/core/users/routes.py
+++ b/backend/geonature/core/users/routes.py
@@ -217,7 +217,8 @@ def get_organismes():
     q = DB.session.query(BibOrganismes)
     if "orderby" in params:
         try:
-            order_col = getattr(BibOrganismes.__table__.columns, params.pop("orderby"))
+            order_col = getattr(
+                BibOrganismes.__table__.columns, params.pop("orderby"))
             q = q.order_by(order_col)
         except AttributeError:
             log.error("the attribute to order on does not exist")
@@ -236,7 +237,8 @@ def get_organismes_jdd(info_role):
     """
     params = request.args.to_dict()
 
-    datasets = [dataset["id_dataset"] for dataset in get_datasets_cruved(info_role)]
+    datasets = [dataset["id_dataset"]
+                for dataset in get_datasets_cruved(info_role)]
     q = (
         DB.session.query(BibOrganismes)
         .join(
@@ -247,7 +249,8 @@ def get_organismes_jdd(info_role):
     )
     if "orderby" in params:
         try:
-            order_col = getattr(BibOrganismes.__table__.columns, params.pop("orderby"))
+            order_col = getattr(
+                BibOrganismes.__table__.columns, params.pop("orderby"))
             q = q.order_by(order_col)
         except AttributeError:
             log.error("the attribute to order on does not exist")
@@ -277,14 +280,16 @@ def inscription():
     data["url_confirmation"] = config["API_ENDPOINT"] + "/users/confirmation"
 
     r = s.post(
-        url=config["API_ENDPOINT"] + "/pypn/register/post_usershub/create_temp_user",
+        url=config["API_ENDPOINT"] +
+        "/pypn/register/post_usershub/create_temp_user",
         json=data,
     )
 
     return Response(r), r.status_code
 
 
-@routes.route("/login/recovery", methods=["POST"])  # TODO supprimer si non utilisé
+# TODO supprimer si non utilisé
+@routes.route("/login/recovery", methods=["POST"])
 def login_recovery():
     """
         Call UsersHub API to create a TOKEN for a user	
@@ -323,10 +328,12 @@ def confirmation():
     if token is None:
         return {"message": "Token introuvable"}, 404
 
-    data = {"token": token, "id_application": config["ID_APPLICATION_GEONATURE"]}
+    data = {"token": token,
+            "id_application": config["ID_APPLICATION_GEONATURE"]}
 
     r = s.post(
-        url=config["API_ENDPOINT"] + "/pypn/register/post_usershub/valid_temp_user",
+        url=config["API_ENDPOINT"] +
+        "/pypn/register/post_usershub/valid_temp_user",
         json=data,
     )
 
@@ -389,7 +396,7 @@ def change_password(id_role):
         Modifie le mot de passe de l'utilisateur connecté et de son ancien mdp 
         Fait appel à l'API UsersHub
     """
-    if not current_app.config["ACCOUNT_MANAGEMENT"].get("ENABLE_SIGN_UP", False):
+    if not current_app.config["ACCOUNT_MANAGEMENT"].get("ENABLE_USER_MANAGEMENT", False):
         return {"message": "Page introuvable"}, 404
 
     user = DB.session.query(User).get(id_role)
@@ -426,7 +433,8 @@ def change_password(id_role):
     ):
         return {"msg": "Erreur serveur"}, 500
     r = s.post(
-        url=config["API_ENDPOINT"] + "/pypn/register/post_usershub/change_password",
+        url=config["API_ENDPOINT"] +
+        "/pypn/register/post_usershub/change_password",
         json=data,
     )
 
@@ -453,7 +461,8 @@ def new_password():
         return {"msg": "Erreur serveur"}, 500
 
     r = s.post(
-        url=config["API_ENDPOINT"] + "/pypn/register/post_usershub/change_password",
+        url=config["API_ENDPOINT"] +
+        "/pypn/register/post_usershub/change_password",
         json=data,
     )
 

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -39,7 +39,8 @@ import { CookieService } from 'ng2-cookies';
 import {
   AuthGuard,
   ModuleGuardService,
-  SignUpGuard
+  SignUpGuard,
+  UserManagementGuard
 } from '@geonature/routing/routes-guards.service';
 import { ModuleService } from './services/module.service';
 import { CruvedStoreService } from './services/cruved-store.service';
@@ -92,6 +93,7 @@ export function HttpLoaderFactory(http: Http) {
     HttpClient,
     ModuleGuardService,
     SignUpGuard,
+    UserManagementGuard,
     SideNavService,
     CruvedStoreService,
     { provide: HTTP_INTERCEPTORS, useClass: MyCustomInterceptor, multi: true }

--- a/frontend/src/app/routing/app-routing.module.ts.sample
+++ b/frontend/src/app/routing/app-routing.module.ts.sample
@@ -1,24 +1,31 @@
+import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+
 import { HomeContentComponent } from '../components/home-content/home-content.component';
 import { PageNotFoundComponent } from '../components/page-not-found/page-not-found.component';
 import { AuthGuard, ModuleGuardService } from '@geonature/routing/routes-guards.service';
+
 {% if enable_sign_up %}
+import { SignUpGuard } from '@geonature/routing/routes-guards.service';
 import { SignUpComponent } from '../components/sign-up/sign-up.component';
 {% endif %}
+
 {% if enable_user_management %}
+import { UserManagementGuard } from '@geonature/routing/routes-guards.service';
 import { NewPasswordComponent } from '../components/new-password/new-password.component';
 {% endif %}
+
 import { LoginComponent } from '../components/login/login.component';
 import { NavHomeComponent } from '../components/nav-home/nav-home.component';
 
 
 const defaultRoutes: Routes = [
   { path: 'login',  component: LoginComponent},
-  {% if enable_user_management %}
-    { path: 'new-password',  component: NewPasswordComponent},
-  {% endif %}
   {% if enable_sign_up %}
-  { path: 'inscription',  component: SignUpComponent},
+  { path: 'inscription',  component: SignUpComponent, canActivate: [SignUpGuard]},
+  {% endif %}
+  {% if enable_user_management %}
+  { path: 'new-password',  component: NewPasswordComponent, canActivate: [UserManagementGuard]},
   {% endif %}
    { path: '', component: NavHomeComponent, canActivateChild: [AuthGuard],
      children: [
@@ -47,4 +54,3 @@ const defaultRoutes: Routes = [
 
 
 export const routing = RouterModule.forRoot(defaultRoutes, {useHash: true });
-

--- a/frontend/src/app/routing/routes-guards.service.ts
+++ b/frontend/src/app/routing/routes-guards.service.ts
@@ -79,3 +79,17 @@ export class SignUpGuard implements CanActivate {
     }
   }
 }
+
+@Injectable()
+export class UserManagementGuard implements CanActivate {
+  constructor(private _router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    if (AppConfig['ACCOUNT_MANAGEMENT']['ENABLE_USER_MANAGEMENT'] || false) {
+      return true;
+    } else {
+      this._router.navigate(['/login']);
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Le controle des routes du frontend mélangeait les paramètres ENABLE_SIGN_UP et ENABLE_USER_MANAGEMENT. Ce qui faisait qu'il était impossible d'avoir les fonctionnalité quand ENABLE_SIGN_UP seul était activé