### PR TITLE
Fix gn_commons.v_meta_actions_on_object

### DIFF
--- a/data/core/commons.sql
+++ b/data/core/commons.sql
@@ -563,7 +563,7 @@ INSERT INTO gn_commons.t_modules(module_code, module_label, module_picto, module
 CREATE VIEW gn_commons.v_meta_actions_on_object AS
 WITH insert_a AS (
 	SELECT
-		id_history_action, id_table_location, uuid_attached_row, operation_type, operation_date, (table_content -> 'id_digitiser')::text::int as id_creator
+		id_history_action, id_table_location, uuid_attached_row, operation_type, operation_date, (table_content ->> 'id_digitiser')::int as id_creator
 	FROM gn_commons.t_history_actions
 	WHERE operation_type = 'I'
 ),

--- a/data/migrations/2.2.1to2.3.0.sql
+++ b/data/migrations/2.2.1to2.3.0.sql
@@ -412,3 +412,33 @@ CREATE OR REPLACE VIEW gn_synthese.v_synthese_taxon_for_export_view AS
     FROM gn_synthese.synthese  s
    JOIN taxonomie.taxref t ON s.cd_nom = t.cd_ref;
 
+-- ##########################################################
+-- Mise à jour de la vue gn_commons.v_meta_actions_on_object
+-- ##########################################################
+
+CREATE OR REPLACE VIEW gn_commons.v_meta_actions_on_object AS
+WITH insert_a AS (
+	SELECT
+		id_history_action, id_table_location, uuid_attached_row, operation_type, operation_date, (table_content ->> 'id_digitiser')::int as id_creator
+	FROM gn_commons.t_history_actions
+	WHERE operation_type = 'I'
+),
+delete_a AS (
+	SELECT
+		id_history_action, id_table_location, uuid_attached_row, operation_type, operation_date
+	FROM gn_commons.t_history_actions
+	WHERE operation_type = 'D'
+),
+last_update_a AS (
+	SELECT DISTINCT ON (uuid_attached_row)
+		id_history_action, id_table_location, uuid_attached_row, operation_type, operation_date
+	FROM gn_commons.t_history_actions
+	WHERE operation_type = 'U'
+	ORDER BY uuid_attached_row, operation_date DESC
+)
+SELECT
+	i.id_table_location, i.uuid_attached_row, i.operation_date as meta_create_date, i.id_creator, u.operation_date as meta_update_date,
+	d.operation_date as meta_delete_date
+FROM insert_a i
+LEFT OUTER JOIN last_update_a u ON i.uuid_attached_row = u.uuid_attached_row
+LEFT OUTER JOIN delete_a d ON i.uuid_attached_row = d.uuid_attached_row;


### PR DESCRIPTION
gn_commons.v_meta_actions_on_object was causing a problem : ERREUR: syntaxe en entrée invalide pour l'entier : « null ».
This fix this error by getting directly integer from json object, instead of converting integer from text.