### PR TITLE
fix virtualenv version as new 20.x breaks app installation

### DIFF
--- a/install/install_all/install_all.sh
+++ b/install/install_all/install_all.sh
@@ -100,7 +100,7 @@ sudo apt-get install -y libgdal-dev
 sudo apt-get install -y python-gdal 
 sudo apt-get install -y python3-virtualenv virtualenv 
 sudo apt-get install -y build-essential 
-sudo pip install --upgrade pip virtualenv virtualenvwrapper 
+sudo pip install --upgrade pip virtualenv==16.7.9 virtualenvwrapper 
 
 if [ "$OS_VERSION" == "9" ]
 then


### PR DESCRIPTION
La nouvelle version de virtualenv tirée par pip dans le script d'install casse complètement l'installation en empêchant la commande "geonature" d'être crée (et donc le renommage des fichiers .sample etc..).
Fixer la version de virtualenv a une version précédente (que j'ai utilisée avec succès dans mon cas), résous le problème.