### PR TITLE
Modif de l'attribution du height du map container

### DIFF
--- a/frontend/src/app/GN2CommonModule/map/map.component.html
+++ b/frontend/src/app/GN2CommonModule/map/map.component.html
@@ -1,4 +1,4 @@
-<div class="map-container">
+<div class="map-container" [ngStyle]="{'height': height}">
 
     <div class="form-row" *ngIf="searchBar">
         <div class="form-group col-md-12">
@@ -18,7 +18,7 @@
             </ng-template>
         </div>
     </div>
-    <div id="map" [ngStyle]="{'height': height}" ></div>
+    <div id="map"></div>
 </div>
 
 

--- a/frontend/src/app/GN2CommonModule/map/map.component.scss
+++ b/frontend/src/app/GN2CommonModule/map/map.component.scss
@@ -3,6 +3,10 @@
   margin: -25px -15px -15px -15px;
 }
 
+#map {
+  height: 100%;
+}
+
 .editable {
   cursor: crosshair;
 }


### PR DESCRIPTION
Pour permettre d'adapter le height de la carte si le height d'un contenant parent est modifié. Plus simplement faire que `<pnx-map height="100%">` fonctionne.