### PR TITLE
Add WMS support

### DIFF
--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -127,7 +127,11 @@ export class MapComponent implements OnInit {
       const configObj = (basemap as any).subdomains
         ? { attribution: basemap.attribution, subdomains: (basemap as any).subdomains }
         : { attribution: basemap.attribution };
-      baseControl[basemap.name] = L.tileLayer(basemap.layer, configObj);
+      if( basemap.hasOwnProperty('url') ){
+        baseControl[basemap.name] = L.tileLayer.wms(basemap.url, {'layers':basemap.layers,'attribution':basemap.attribution});
+      }else{
+        baseControl[basemap.name] = L.tileLayer(basemap.layer, configObj);
+      }
       if (index === 0) {
         map.addLayer(baseControl[basemap.name]);
       }


### PR DESCRIPTION
Ajout de la possibilité d'afficher une couche WMS dans le composent map.component.
```
Exemple de config
BASEMAP = [
    {"name" = "OpenStreetMap", "layer" = "//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png", "attribution" = "&copy OpenStreetMap"},
    {"name"= "OpenTopoMap", "layer" = "//a.tile.opentopomap.org/{z}/{x}/{y}.png", "attribution" = "© OpenTopoMap"},
    {"name" = "OSM Naturaliste","url"="https://osm.geo2france.fr/mapproxy/service?SERVICE=WMS","layers" = "naturaliste", attribution="© Geo2France et Picardie Nature. Données OpenStreetMap"},
]
```
Ca peut être amélioré en permettant la définition d'autres paramètres WMS (seul _layers_ peut être défini ici), mais je ne suis pas assez à l'aise sur TypeScript pour ça ;-)