### PR TITLE
Paramétrage de la nav-home

### DIFF
--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -255,6 +255,7 @@ class MapConfig(Schema):
 # class a utiliser pour les paramètres que l'on veut passer au frontend
 class GnGeneralSchemaConf(Schema):
     appName = fields.String(missing="GeoNature2")
+    LOGO_STRUCTURE_FILE = fields.String(missing="logo_structure.png")
     GEONATURE_VERSION = fields.String(missing=GEONATURE_VERSION.strip())
     DEFAULT_LANGUAGE = fields.String(missing="fr")
     PASS_METHOD = fields.String(

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -25,6 +25,9 @@ SQLALCHEMY_TRACK_MODIFICATIONS = false
 # Nom de l'application dans la page d'accueil.
 appName = "GeoNature 2"
 
+# Nom du fichier du logo present dans le dossier custom/images
+LOGO_STRUCTURE_FILE = 'logo_structure.png'
+
 # Langue par défaut utilisée par l'application.
 # Utilisée pour l'instant seulement avec les nomenclatures.
 DEFAULT_LANGUAGE = "fr"

--- a/frontend/src/app/components/nav-home/nav-home.component.html
+++ b/frontend/src/app/components/nav-home/nav-home.component.html
@@ -10,7 +10,7 @@
 
       <mat-icon (click)="closeSideBar()" class="icon-toolbar clickable">apps</mat-icon>
       <span id="module-name"> {{moduleName}}</span>
-      <img id="logo-structure" src="custom/images/logo_structure.png" alt="">
+      <img id="logo-structure" src="custom/images/{{appConfig.LOGO_STRUCTURE_FILE}}" alt="">
       <span class="toolbar-spacer"></span>
       <div>
 

--- a/frontend/src/app/components/nav-home/nav-home.component.html
+++ b/frontend/src/app/components/nav-home/nav-home.component.html
@@ -8,7 +8,9 @@
   <mat-sidenav-content>
     <mat-toolbar id="app-toolbar" class="row">
 
-      <mat-icon (click)="closeSideBar()" class="icon-toolbar clickable">apps</mat-icon>
+      <button class="menu-button toolbar-button" mat-fab (click)="closeSideBar()">
+        <mat-icon class="menu-icon" aria-label="Ouvrir le menu">menu</mat-icon>
+      </button>
       <span id="module-name"> {{moduleName}}</span>
       <img id="logo-structure" src="custom/images/{{appConfig.LOGO_STRUCTURE_FILE}}" alt="">
       <span class="toolbar-spacer"></span>
@@ -21,8 +23,8 @@
       <span class="toolbar-spacer"></span>
       <ng-container *ngIf="!appConfig.CAS_PUBLIC.CAS_AUTHENTIFICATION && appConfig.ACCOUNT_MANAGEMENT.ENABLE_USER_MANAGEMENT ; else noUserManagement">
         <button 
-          mat-button 
-          class="toolbar-rigth"
+          mat-raised-button 
+          class="toolbar-button toolbar-rigth"
           matTooltip="Ouvrir le menu" 
           data-toggle="dropdown" 
           aria-haspopup="true" 

--- a/frontend/src/app/components/nav-home/nav-home.component.scss
+++ b/frontend/src/app/components/nav-home/nav-home.component.scss
@@ -1,9 +1,16 @@
+@import '../../../conf/names_variables.scss';
+@import '../../../custom/custom.scss';
+
 #documentation_link {
   color: black !important;
 }
 
 .toolbar-icon {
   padding: 0 15px;
+}
+
+#app-toolbar {
+  background-color: $navbar-color;
 }
 
 .appnav {

--- a/frontend/src/app/components/nav-home/nav-home.component.scss
+++ b/frontend/src/app/components/nav-home/nav-home.component.scss
@@ -50,6 +50,7 @@ mat-icon {
 .toolbar-button {
   background-color: $navbar-color !important;
   color: $navbar-text-button-color !important;
+  outline: none;
 }
 
 .menu-button {

--- a/frontend/src/app/components/nav-home/nav-home.component.scss
+++ b/frontend/src/app/components/nav-home/nav-home.component.scss
@@ -46,3 +46,16 @@ mat-icon {
 .dropdown-item .fa {
   margin-right: 12px;
 }
+
+.toolbar-button {
+  background-color: $navbar-color !important;
+  color: $navbar-text-button-color !important;
+}
+
+.menu-button {
+  margin-right: 10px;
+}
+
+.menu-button mat-icon.menu-icon {
+  margin: 0;
+}

--- a/frontend/src/conf/names_variables.scss
+++ b/frontend/src/conf/names_variables.scss
@@ -17,3 +17,5 @@ $background: #eeeeee;
 
 $main-color: #000000;
 $second-color: #c5c7cc;
+
+$navbar-color: #f5f5f5;

--- a/frontend/src/conf/names_variables.scss
+++ b/frontend/src/conf/names_variables.scss
@@ -19,3 +19,4 @@ $main-color: #000000;
 $second-color: #c5c7cc;
 
 $navbar-color: #f5f5f5;
+$navbar-text-button-color: rgba(0,0,0,.87);

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -18,6 +18,7 @@ mat-sidenav-content {
 .mat-toolbar {
   //min-height: 5vh !important;
   min-height: 40px !important;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12), 0 3px 1px -2px rgba(0,0,0,.2);
 }
 .mat-toolbar-row {
   //height: 5vh !important;


### PR DESCRIPTION
Proposition d'une petite PR permettant de :
- modifier la couleur du menu haut de l'app via les variables `$navbar-color` et `$navbar-text-button-color` à spécifier dans le fichier custom/custom.scss.
- rendre paramétrable (geonature_config.toml) le nom du fichier de l'image de la structure déposé dans le dossier custom/images

+ Modification des icons servant de bouton d'action en buton.
