### PR TITLE
Fix install_gn_module: use Nvm when installing JS dependencies

### DIFF
--- a/backend/geonature/utils/gn_module_import.py
+++ b/backend/geonature/utils/gn_module_import.py
@@ -326,6 +326,10 @@ def install_frontend_dependencies(module_path):
         try:
             # To avoid Maximum call stack size exceeded on npm install - clear cache...
             assert subprocess.call(
+                ['/bin/bash', '-i', '-c', 'nvm use'],
+                cwd=str(ROOT_DIR / "frontend")
+            ) == 0
+            assert subprocess.call(
                 ['npm', 'install', str(frontend_module_path), '--no-save'],
                 cwd=str(ROOT_DIR / "frontend")
             ) == 0


### PR DESCRIPTION
Add use of Nvm to load correct Node version for GeoNature before installing JS dependencies with Npm.
Fix #926.