### PR TITLE
Modif zoomlevel après pointage relevé

### DIFF
--- a/frontend/src/app/GN2CommonModule/map/leaflet-draw/leaflet-draw.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/leaflet-draw/leaflet-draw.component.ts
@@ -30,7 +30,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
   @Input() geojson: GeoJSON;
   /* Boolean qui controle le zoom au point*/
   @Input() bZoomOnPoint = true;
-  @Input() zoomLevelOnPoint = 8;
+  @Input() zoomLevelOnPoint = 18;
   /**
    *  Objet permettant de paramettrer le plugin et les différentes formes dessinables (point, ligne, cercle etc...)
    *


### PR DESCRIPTION
Le niveau de zoom était fixé à 8, ce qui engendrait un zoom arrière (dé-zoom) lorsque le niveau 8 était dépassé, ce qui est généralement le cas lors d'un pointage carto précis.
Fixé à 18, cela engendre un zoom qui permet de contrôler que le point saisi est bien placé.