### PR TITLE
EventEmitter sur genericForm + affichage champ JDD sur occtax

### DIFF
--- a/contrib/occtax/frontend/app/occtax-map-form/form/releve/releve.component.html
+++ b/contrib/occtax/frontend/app/occtax-map-form/form/releve/releve.component.html
@@ -41,7 +41,7 @@
   <div class="row row-0">
     <div class="col-xs-5 col-sm-5 col-md-5 col-lg-5 padding-sm">
       <div 
-        *ngIf="fs.currentReleve?.releve?.properties?.dataset.active == false; else elseblocDataset"
+        *ngIf=" fs.currentReleve?.releve?.properties?.dataset.active === false || !isDatasetUser(fs.currentReleve?.releve?.properties?.dataset.id_dataset); else elseblocDataset"
         class="dataset-inactive">
         <small> {{ 'MetaData.Datasets' | translate }}:  </small>
         <small>
@@ -53,6 +53,7 @@
           label="{{ 'MetaData.Datasets' | translate }}" 
           [parentFormControl]="releveForm.controls.properties.controls.id_dataset"
           [disabled]="fs.disabled"
+          (valueLoaded)="userDatasets = $event.value"
           moduleCode="OCCTAX">
         </pnx-datasets>
       </ng-template>

--- a/contrib/occtax/frontend/app/occtax-map-form/form/releve/releve.component.ts
+++ b/contrib/occtax/frontend/app/occtax-map-form/form/releve/releve.component.ts
@@ -29,6 +29,7 @@ export class ReleveComponent implements OnInit, OnDestroy {
   public occtaxConfig: any;
   private geojsonSubscription$: Subscription;
   public isEditionSub$: Subscription;
+  public userDatasets: Array<any> = [];
 
   constructor(
     private _ms: MapService,
@@ -110,6 +111,18 @@ export class ReleveComponent implements OnInit, OnDestroy {
             .properties as FormGroup).controls.hour_max.reset();
       });
   } // END INIT
+
+  isDatasetUser(id_dataset: number = null): boolean {
+    if (id_dataset === null) {
+      return true;
+    }
+    for (let i = 0; i < this.userDatasets.length; i++) {
+      if ( this.userDatasets[i].id_dataset == id_dataset )
+        return true;
+    }
+    
+    return false;
+  }
 
   toggleTime() {
     this.showTime = !this.showTime;

--- a/frontend/src/app/GN2CommonModule/form/datasets/datasets.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/datasets/datasets.component.ts
@@ -82,6 +82,7 @@ export class DatasetsComponent extends GenericFormComponent implements OnInit, O
       res => {
         this.dataSets = res.data;
         this.savedDatasets = res.data;
+        this.valueLoaded.emit({ value: this.savedDatasets })
         if (res['with_mtd_errors']) {
           this._commonService.translateToaster('error', 'MetaData.JddErrorMTD');
         }

--- a/frontend/src/app/GN2CommonModule/form/genericForm.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/genericForm.component.ts
@@ -24,6 +24,7 @@ export class GenericFormComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() displayAll: false; // param to display the field 'all' in the list, default at false
   @Output() onChange = new EventEmitter<any>();
   @Output() onDelete = new EventEmitter<any>();
+  @Output() valueLoaded = new EventEmitter<any>();
   public sub: Subscription;
 
   constructor() {}


### PR DESCRIPTION
Ajoute un EventEmitter au genericFormComponent pour permettre la récupération des données chargées ailleurs.
+ Fix le cas où lors d'une modification de donnée par un observateur de cette données, alors que le JDD de cette données n'est pas associé à l'observateur effectuant la modification, la valeur du select du jdd était vide. Le fix affiche le JDD au format texte, sans permettre sa modification. 