### PR TITLE
Trigger meta_data synthese

### DIFF
--- a/data/core/public.sql
+++ b/data/core/public.sql
@@ -15,13 +15,8 @@ CREATE OR REPLACE FUNCTION public.fct_trg_meta_dates_change()
   RETURNS trigger AS
 $BODY$
 begin
-        if(TG_OP = 'INSERT') THEN
-                NEW.meta_create_date = NOW();
-        ELSIF(TG_OP = 'UPDATE') THEN
+        IF(TG_OP = 'UPDATE') THEN
                 NEW.meta_update_date = NOW();
-                if(NEW.meta_create_date IS NULL) THEN
-                        NEW.meta_create_date = NOW();
-                END IF;
         end IF;
         return NEW;
 end;

--- a/data/core/synthese.sql
+++ b/data/core/synthese.sql
@@ -993,7 +993,7 @@ JOIN taxonomie.taxref ref ON t.cd_ref = ref.cd_nom;
 --TRIGGERS--
 ------------
 CREATE TRIGGER tri_meta_dates_change_synthese
-  BEFORE INSERT OR UPDATE
+  BEFORE UPDATE
   ON synthese
   FOR EACH ROW
   EXECUTE PROCEDURE public.fct_trg_meta_dates_change();

--- a/data/migrations/2.4.1to2.4.2.sql
+++ b/data/migrations/2.4.1to2.4.2.sql
@@ -1,0 +1,21 @@
+--Ne plus modifier meta_date_create lors d'un UPDATE
+CREATE OR REPLACE FUNCTION public.fct_trg_meta_dates_change()
+  RETURNS trigger AS
+$BODY$
+begin
+        IF(TG_OP = 'UPDATE') THEN
+                NEW.meta_update_date = NOW();
+        end IF;
+        return NEW;
+end;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+
+--Ne plus exectuer le trigger à l'INSERT
+DROP TRIGGER tri_meta_dates_change_synthese ON gn_synthese.synthese;
+CREATE TRIGGER tri_meta_dates_change_synthese
+  BEFORE UPDATE
+  ON gn_synthese.synthese
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.fct_trg_meta_dates_change();


### PR DESCRIPTION
#986 et #895 
La PR désactive la modification du champs _meta_create_date_ (si NULL) lors d'un update.
La PR permet aussi de spécifier un valeur à _meta_create_date_ lors d'un INSERT (auparavant, la valeur indiqué à l'INSERT était écrasée par le trigger)