### PR TITLE
Feat inscription: send email to user after confirmation

### DIFF
--- a/backend/geonature/core/users/register_post_actions.py
+++ b/backend/geonature/core/users/register_post_actions.py
@@ -21,9 +21,11 @@ from geonature.utils.env import DB
 
 def validate_temp_user(data):
     """
-       Send an email after the action of account creation
+       Send an email after the action of account creation.
 
-       :param admin_validation_required: if True an admin will receive an email to validate the account creation else the user himself receive the email
+       :param admin_validation_required: if True an admin will receive an
+       email to validate the account creation else the user himself 
+       receive the email.
        :type admin_validation_required: bool
     """
     token = data.get("token", None)
@@ -61,9 +63,20 @@ def validate_temp_user(data):
     return {"msg": "ok"}
 
 
+def execute_actions_after_validation(data):
+    try:
+        if current_app.config["ACCOUNT_MANAGEMENT"]["AUTO_DATASET_CREATION"]:
+            create_dataset_user(data)
+        inform_user(data)
+    except Exception as error:
+        return {"msg": ". ".join(error.args)}
+    return {"msg": "ok"}
+
+
 def create_dataset_user(user):
     """
-        After dataset validation, add a personnal AF and JDD so the user can add new user
+        After dataset validation, add a personnal AF and JDD so the user 
+        can add new user.
     """
     af_desc_and_name = "Cadre d'acquisition personnel de {name} {surname}".format(
         name=user["nom_role"], surname=user["prenom_role"]
@@ -123,12 +136,31 @@ def create_dataset_user(user):
     new_dataset.cor_dataset_actor = [ds_productor, ds_contact]
     DB.session.add(new_dataset)
     DB.session.commit()
-    return {"msg": "ok"}
+
+
+def inform_user(user):
+    """
+    Send an email to inform the user that his account was validate.
+    """
+    app_name = current_app.config["appName"]
+    app_url = current_app.config["URL_APPLICATION"]
+
+    msg_html = render_template(
+        "email_confirm_user_validation.html",
+        user_firstname=user["prenom_role"],
+        user_lastname=user["nom_role"],
+        app_name=app_name,
+        app_url=app_url,
+        user_login=user["identifiant"],
+    )
+    subject = f"Confirmation inscription {app_name}"
+    send_mail([user["email"]], subject, msg_html)
 
 
 def send_email_for_recovery(data):
     """
-    Send an email with the login of the role and the possibility to reset its password
+    Send an email with the login of the role and the possibility to reset
+    its password
     """
     user = data["role"]
     recipients = current_app.config["MAIL_CONFIG"]["MAIL_USERNAME"]
@@ -146,15 +178,9 @@ def send_email_for_recovery(data):
     return {"msg": "ok"}
 
 
-if current_app.config["ACCOUNT_MANAGEMENT"]["AUTO_DATASET_CREATION"]:
-    function_dict = {
-        "create_temp_user": validate_temp_user,
-        "valid_temp_user": create_dataset_user,
-        "create_cor_role_token": send_email_for_recovery,
-    }
-else:
-    function_dict = {
-        "create_temp_user": validate_temp_user,
-        "create_cor_role_token": send_email_for_recovery,
-    }
+function_dict = {
+    "create_temp_user": validate_temp_user,
+    "valid_temp_user": execute_actions_after_validation,
+    "create_cor_role_token": send_email_for_recovery,
+}
 

--- a/backend/geonature/core/users/templates/email_confirm_user_validation.html
+++ b/backend/geonature/core/users/templates/email_confirm_user_validation.html
@@ -1,0 +1,14 @@
+<p>*** Ceci est un message généré automatiquement ***</p>
+
+<p>Bonjour {{ user_firstname }} {{ user_lastname }},</p>
+
+<p>Votre inscription à "{{ app_name }}" a été acceptée.</p>
+<p>
+    Vous pouvez dès à présent vous connecter sur 
+    <a href="{{ app_url }}">{{ app_url }}</a>
+</p>
+
+<p>Pour rappel, votre identifiant de connexion est : {{ user_login }}</p>
+
+<p>Bien cordialement,</p>
+<p>L'administrateur.</p>

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -373,6 +373,9 @@ MAIL_ON_ERROR = false
         required = false
 
 [SERVER]
+    # Nivau de log du serveur.
+    # Indiquer la valeur numérique correspondant au niveau suivant;
+    # CRITICAL: 50 ; ERROR: 40 ; WARNING: 30 ; INFO: 20 ; DEBUG: 10 ; NOTSET: 0
     LOG_LEVEL = 20
 
 

--- a/frontend/src/app/components/sign-up/sign-up.component.ts
+++ b/frontend/src/app/components/sign-up/sign-up.component.ts
@@ -42,7 +42,7 @@ export class SignUpComponent implements OnInit {
       identifiant: ['', Validators.required],
       email: [
         '',
-        [Validators.pattern('^[a-z0-9._-]+@[a-z0-9._-]{2,}.[a-z]{2,4}$'), Validators.required]
+        [Validators.pattern('^[+a-z0-9._-]+@[a-z0-9._-]{2,}.[a-z]{2,4}$'), Validators.required]
       ],
       password: ['', [Validators.required]],
       password_confirmation: ['', [Validators.required]],


### PR DESCRIPTION
Major changes:
- Send an email to GeoNature user after the confirmation of his inscription.
- Add a web service to call from UsersHub in order to execute only GeoNature post inscription confirmation actions (see PnX-SI/UsersHub#115).
- Add post confirmation web service URL to data sended to UsersHub when we create a temporary user.

Minor changes:
- add '+' to authorized characters in email regex of the inscription form
- add in default_config.toml.example the log levels values infos

Close #1035