### PR TITLE
Feat tpl/emails: custom text in user sign-up email

### DIFF
--- a/backend/geonature/core/users/register_post_actions.py
+++ b/backend/geonature/core/users/register_post_actions.py
@@ -3,7 +3,7 @@ Action triggered after register action (create temp user, change password etc...
 """
 import datetime
 
-from flask import render_template, current_app, url_for
+from flask import Markup, render_template, current_app, url_for
 from pypnusershub.db.models import Application, User
 from pypnusershub.db.models_register import TempUser
 from sqlalchemy.sql import func
@@ -144,6 +144,8 @@ def inform_user(user):
     """
     app_name = current_app.config["appName"]
     app_url = current_app.config["URL_APPLICATION"]
+    text_addon = current_app.config["ACCOUNT_MANAGEMENT"]["ADDON_USER_EMAIL"]
+    html_text_addon = Markup(text_addon)
 
     msg_html = render_template(
         "email_confirm_user_validation.html",
@@ -152,6 +154,7 @@ def inform_user(user):
         app_name=app_name,
         app_url=app_url,
         user_login=user["identifiant"],
+        text_addon=html_text_addon,
     )
     subject = f"Confirmation inscription {app_name}"
     send_mail([user["email"]], subject, msg_html)

--- a/backend/geonature/core/users/templates/email_admin_validate_account.html
+++ b/backend/geonature/core/users/templates/email_admin_validate_account.html
@@ -1,27 +1,28 @@
+<p>*** Ceci est un message généré automatiquement ***</p>
 <p>Bonjour,</p>
-
-<p>Un utilisateur vient d'effectuer une demande de création de compte sur GeoNature</p>
-
-Voici les informations de l'utilisateur :
-
+<p>
+  Un utilisateur vient d'effectuer une demande de création de compte 
+  sur GeoNature.
+</p>
+<p>Voici les informations de l'utilisateur :</p>
 <ul>
-  <li> <b>Nom : </b>  {{user.nom_role}}</li>
-  <li> <b>Prénom : </b>  {{user.prenom_role}}</li>
-  <li> <b>Identifiant : </b>  {{user.identifiant}}</li>
-  <li> <b>Email : </b> {{user.email}}</li>
-
+  <li><b>Nom :</b> {{user.nom_role}}</li>
+  <li><b>Prénom :</b> {{user.prenom_role}}</li>
+  <li><b>Identifiant :</b> {{user.identifiant}}</li>
+  <li><b>Email :</b> {{user.email}}</li>
 </ul>
 
 {% if additional_fields | length > 0 %}
-<h5>Informations complémentaires :</h5>
-  <ul>
-  {% for item in additional_fields %}
-    <li><b> {{item.key}}: </b>  {{item.value}}  </li> 
-  {% endfor %}
-</ul>
-
+  <h5>Informations complémentaires :</h5>
+    <ul>
+    {% for item in additional_fields %}
+      <li><b> {{item.key}}: </b>  {{item.value}}  </li> 
+    {% endfor %}
+  </ul>
 {% endif%}
-
-<p>Pour valider cette demande,  <a href="{{ url_validation }}">cliquer sur ce lien</a>.</p>
-
-<p>Cordialement,</p>
+<p>
+  Pour valider cette demande, 
+  <a href="{{ url_validation }}">cliquer sur ce lien</a>.
+</p>
+<p>Bien cordialement,</p>
+<p>l'administrateur.</p>

--- a/backend/geonature/core/users/templates/email_confirm_user_validation.html
+++ b/backend/geonature/core/users/templates/email_confirm_user_validation.html
@@ -6,6 +6,8 @@
     <a href="{{ app_url }}">{{ app_url }}</a>
 </p>
 <p>Pour rappel, votre identifiant de connexion est : {{ user_login }}</p>
-
+{% if text_addon != '' %}
+    {{ text_addon }}
+{% endif%}
 <p>Bien cordialement,</p>
 <p>l'administrateur.</p>

--- a/backend/geonature/core/users/templates/email_confirm_user_validation.html
+++ b/backend/geonature/core/users/templates/email_confirm_user_validation.html
@@ -1,14 +1,11 @@
 <p>*** Ceci est un message généré automatiquement ***</p>
-
 <p>Bonjour {{ user_firstname }} {{ user_lastname }},</p>
-
 <p>Votre inscription à "{{ app_name }}" a été acceptée.</p>
 <p>
     Vous pouvez dès à présent vous connecter sur 
     <a href="{{ app_url }}">{{ app_url }}</a>
 </p>
-
 <p>Pour rappel, votre identifiant de connexion est : {{ user_login }}</p>
 
 <p>Bien cordialement,</p>
-<p>L'administrateur.</p>
+<p>l'administrateur.</p>

--- a/backend/geonature/core/users/templates/email_login_and_new_pass.html
+++ b/backend/geonature/core/users/templates/email_login_and_new_pass.html
@@ -1,11 +1,11 @@
-
-<p> Vous avez oublié votre identifiant / mot de passe.</p> 
-
+<p>*** Ceci est un message généré automatiquement ***</p>
+<p>Bonjour,</p>
+<p>Vous avez oublié votre identifiant / mot de passe.</p> 
+<p>Voici vos informations pour vous connecter :</p>
+<p><b> Identifiant :</b>  {{identifiant}}</p>
 <p>
-  Voici vos informations pour vous connecter :
+  Pour réinitialiser votre mot de passe,
+  <a href="{{url_password}}">cliquez sur ce lien</a>.
 </p>
-
-<b> Identifiant :</b>  {{identifiant}}
-<br>
-<br>
-Pour réinitialiser votre mot de passe <a href="{{url_password}}">cliquez ici</a>  
+<p>Bien cordialement,</p>
+<p>l'administrateur.</p>

--- a/backend/geonature/core/users/templates/email_self_validate_account.html
+++ b/backend/geonature/core/users/templates/email_self_validate_account.html
@@ -1,7 +1,10 @@
+<p>*** Ceci est un message généré automatiquement ***</p>
 <p>Bonjour,</p>
-
 <p>Vous venez de demander la création d'un compte utilisateur sur GeoNature.</p>
-
-<p>Avant toute chose, et par mesure de sécurité, nous vous remercions de bien vouloir <a href="{{ url_validation }}">valider votre adresse e-mail</a> pour confirmer la création de votre compte.</p>
-
-<p>Cordialement,</p>
+<p>
+    Avant toute chose, et par mesure de sécurité, nous vous remercions de 
+    bien vouloir <a href="{{ url_validation }}">valider votre adresse e-mail</a>
+    pour confirmer la création de votre compte.
+</p>
+<p>Bien cordialement,</p>
+<p>l'administrateur.</p>

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -71,13 +71,14 @@ class MailConfig(Schema):
 
 
 class AccountManagement(Schema):
-    # config liée à l'incription
+    # Config for sign-up
     ENABLE_SIGN_UP = fields.Boolean(missing=False)
     ENABLE_USER_MANAGEMENT = fields.Boolean(missing=False)
     AUTO_ACCOUNT_CREATION = fields.Boolean(missing=True)
     AUTO_DATASET_CREATION = fields.Boolean(missing=True)
     VALIDATOR_EMAIL = fields.Email()
     ACCOUNT_FORM = fields.List(fields.Dict(), missing=[])
+    ADDON_USER_EMAIL = fields.String(missing="")
 
 
 class UsersHubConfig(Schema):

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -105,7 +105,9 @@ MAIL_ON_ERROR = false
     MAIL_USERNAME = "my_user_name - email address of the sender"
     MAIL_PASSWORD = "my_pass"
     MAIL_DEFAULT_SENDER = "my_email@email.com"
-    MAIL_MAX_EMAILS = <int>
+    # Nombre max d'email que le serveur peut envoyer aucours d'une seule connection
+    # Laisser en commentaire si le serveur n'a pas de limite.
+    # MAIL_MAX_EMAILS = 100
     MAIL_ASCII_ATTACHMENTS = false
     # Email(s) où envoyer les erreurs générées par le backend de GeoNature
     ERROR_MAIL_TO = ["email@email.com", "email2@email.com"]
@@ -323,23 +325,38 @@ MAIL_ON_ERROR = false
     # Activer l'affichage du lien vers le formulaire d'inscription
     ENABLE_SIGN_UP = true
 
-    # Activer l'affichage de l'onglet de gestion des demandes de compte utilisateur
+    # Activer l'affichage de l'onglet de gestion des demandes de compte 
+    # utilisateur
     ENABLE_USER_MANAGEMENT = false
 
-    # Valider automatiquement la demande de création de compte (=true), sinon nécessite une validation (=false)
+    # Valider automatiquement la demande de création de compte (=true), 
+    # sinon nécessite une validation (=false)
     AUTO_ACCOUNT_CREATION = false
 
-    # Créer automatiquement (=true) un nouveau jeu de données pour chaque compte utilisateur
+    # Créer automatiquement (=true) un nouveau jeu de données pour chaque
+    # compte utilisateur
     AUTO_DATASET_CREATION = true
 
     # Email du validateur si auto_account_creation = false
     VALIDATOR_EMAIL = "theo.lechemia@ecrins-parcnational.fr"
 
+    # Texte complémentaire ajouté à la fin des emails envoyés à l'utilisateur.
+    # Utiliser du HTML simple (compatible avec les email) ou du texte.
+    # Mettre une chaine vide pour ne rien ajouter.
+    # Par défaut, chaine vide.
+    ADDON_USER_EMAIL = """<p>
+            Toute l'équipe de GeoNature vous remercie pour votre inscription.
+        </p>"""
+
     # Configuration de la customisation du formulaire d'inscription
-    # Chaque section [[ACCOUNT_MANAGEMENT.ACCOUNT_FORM]] correspond à un champ (de type checkbox, select etc...)
+    # Chaque section [[ACCOUNT_MANAGEMENT.ACCOUNT_FORM]] correspond à un 
+    # champ (de type checkbox, select etc...)
     [[ACCOUNT_MANAGEMENT.ACCOUNT_FORM]]
         type_widget = "checkbox"
-        attribut_label = "<a target=\"_blank\" href=\"http://docs.geonature.fr\">J'ai lu et j'accepte la charte</a>"
+        attribut_label = """
+            <a target="_blank" href="http://docs.geonature.fr">
+                J'ai lu et j'accepte la charte
+            </a>"""
         attribut_name = "validate_charte"
         values = [true] 
         required = true

--- a/docs/admin-manual.rst
+++ b/docs/admin-manual.rst
@@ -904,7 +904,7 @@ Renseigner les paramètres suivants dans le fichier de configuration (``geonatur
         ADMIN_APPLICATION_LOGIN = "login_admin_usershub"
         ADMIN_APPLICATION_PASSWORD = "password_admin_usershub
 
-Les fonctionnalités de création de compte nécessitent l'envoi d'emails pour vérifier l'identité des demandeurs de compte. Il est donc nécessaire d'avoir un serveur SMTP capable d'envoyer des emails. Renseigner la rubrique ``MAIL_CONFIG`` de la configuration :
+Les fonctionnalités de création de compte nécessitent l'envoi d'emails pour vérifier l'identité des demandeurs de compte. Il est donc nécessaire d'avoir un serveur SMTP capable d'envoyer des emails. Renseigner la rubrique ``MAIL_CONFIG`` de la configuration. La description détaillées des paramètres de configuration d'envoie des emails est disponible dans `la documentation de Flask-Mail <https://flask-mail.readthedocs.io/en/latest/#configuring-flask-mail>`_. Exemple :
 
 ::
 
@@ -944,6 +944,18 @@ Deux modes sont alors disponibles. Soit l'utilisateur est automatiquement accept
 
 L'utilisateur qui demande la création de compte est automatiquement mis dans un "groupe" UsersHub (par défaut, il s'agit du groupe "En poste"). Ce groupe est paramétrable depuis la table ``utilisateurs.cor_role_app_profil``. (La ligne où ``is_default_group_for_app = true`` sera utilisée comme groupe par défaut pour GeoNature). Il n'est pas en paramètre de GeoNature pusqu'il serait falsifiable via l'API. ⚠️ **Attention**, si vous effectuez une migration depuis une version de GeoNature < 2.2.0, aucun groupe par défaut n'est défini, vous devez définir à la main le groupe par défaut pour l'application GeoNature dans la table ``utilisateurs.cor_role_app_profil``.
 
+Dans le mode "création de compte validé par administrateur", lorsque l'inscription est validée par un administrateur, un email est envoyé à l'utilisateur pour lui indiquer la confirmation de son inscription.
+Il est possible de personnaliser le texte de la partie finale de cet email située juste avant la signature à l'aide du paramètre ``ADDON_USER_EMAIL`` (toujours à ajouter à la rubrique ``[ACCOUNT_MANAGEMENT]``).
+Vous pouvez utiliser des balises HTML compatibles avec les emails pour ce texte.
+
+::
+
+    [ACCOUNT_MANAGEMENT]
+        ADDON_USER_EMAIL = """<p>
+            Toute l'équipe de GeoNature vous remercie pour votre inscription.
+          </p>"""
+
+
 Il est également possible de créer automatiquement un jeu de données et un cadre d'acquisition "personnel" à l'utilisateur afin qu'il puisse saisir des données dès sa création de compte via le paramètre ``AUTO_DATASET_CREATION``. Par la suite l'administrateur pourra rattacher l'utilisateur à des JDD et CA via son organisme.
 
 ::
@@ -963,14 +975,17 @@ Le formulaire de création de compte est par défaut assez minimaliste (nom, pr�
 
 Il est possible d'ajouter des champs au formulaire grâce à un générateur controlé par la configuration. Plusieurs type de champs peuvent être ajoutés (text, textarea, number, select, checkbox mais aussi taxonomy, nomenclature etc...).
 
-L'exemple ci-dessous permet de créer un champs de type "checkbox" obligatoire, avec un lien vers un document (une charte par exemple) et un champ de type "select", non obligatoire. (voir le fichier ``geonature_config.toml.example`` pour un exemple plus exhaustif).
+L'exemple ci-dessous permet de créer un champs de type "checkbox" obligatoire, avec un lien vers un document (une charte par exemple) et un champ de type "select", non obligatoire. (voir le fichier ``config/geonature_config.toml.example`` pour un exemple plus exhaustif).
 
 ::
 
         [ACCOUNT_MANAGEMENT]
         [[ACCOUNT_MANAGEMENT.ACCOUNT_FORM]]
             type_widget = "checkbox"
-            attribut_label = "<a target='_blank' href='http://docs.geonature.fr'>J'ai lu et j'accepte la charte</a>"
+            attribut_label = """
+              <a target="_blank" href="http://docs.geonature.fr">
+                J'ai lu et j'accepte la charte
+              </a>"""
             attribut_name = "validate_charte"
             values = [true] 
             required = true


### PR DESCRIPTION
Add a custom text to email send to user after his sign-up confirmation.
Use a new parameter in config file to define this text.
Normalize all emails template text (add same signature, header...).
Improve "default_config.toml.example" documentation. 

Close #1050.