### PR TITLE
Fix frontend/synthese: improve design for advanced-form

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form.component.html
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form.component.html
@@ -9,152 +9,159 @@
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
+
 <div class="modal-body">
-  <pnx-autocomplete
-    [apiEndPoint]="URL_AUTOCOMPLETE"
-    [searchAsParameter]="'true'"
-    [parentFormControl]="formService.searchForm.controls.taxon_rank"
-    [formatter]="formatter"
-    [othersGetParams]="queryString"
-    [mapFunc]="mapFunc"
-    [formatter]="formatter"
-    keyValue="displayed_name"
-    label="Rechercher un rang taxonomique (nom latin - au dessus du genre)"
-    (onChange)="onTaxonSelected($event)"
-  >
-  </pnx-autocomplete>
-
-  <div
-    class="alert alert-warning taxon-alert"
-    *ngIf="formService.selectedTaxonFromRankInput.length > 0"
-  >
-    <p class="taxon-list">
-      <b> Taxon(s) recherché(s):</b>
-    </p>
-    <li
-      class="taxon-list"
-      *ngFor="let taxon of formService.selectedTaxonFromRankInput; let i = index"
+  <div class="form-group">
+    <pnx-autocomplete
+      [apiEndPoint]="URL_AUTOCOMPLETE"
+      [searchAsParameter]="'true'"
+      [parentFormControl]="formService.searchForm.controls.taxon_rank"
+      [formatter]="formatter"
+      [othersGetParams]="queryString"
+      [mapFunc]="mapFunc"
+      [formatter]="formatter"
+      keyValue="displayed_name"
+      label="Rechercher un rang taxonomique (nom latin - au dessus du genre)"
+      (onChange)="onTaxonSelected($event)"
     >
-      {{taxon.lb_nom}}
-      <i
-        (click)="formService.removeTaxon(i, formService.selectedTaxonFromRankInput)"
-        class="fa fa-times clickable"
-      ></i>
-    </li>
+    </pnx-autocomplete>
 
+    <div
+      class="searched-taxa-list alert alert-warning taxon-alert"
+      *ngIf="formService.selectedTaxonFromRankInput.length > 0"
+    >
+      <h5><small>Taxon(s) recherché(s):</small></h5>
+      <ul class="list-group d-flex flex-row flex-wrap" >
+        <li
+          class="list-group-item d-flex justify-content-between w-50"
+          *ngFor="let taxon of formService.selectedTaxonFromRankInput; let i = index"
+        >
+          {{taxon.lb_nom}}
+          <i
+            (click)="formService.removeTaxon(i, formService.selectedTaxonFromRankInput)"
+            class="fa fa-times clickable"
+          ></i>
+        </li>
+      </ul>
+    </div>
   </div>
-  <button
-    (click)="toggleTree()"
-    id="btn-tree"
-    class="btn btn-sm btn-outline-primary"
-    data-toggle="collapse"
-    data-target="#collapseTree"
-  >
-    Arbre taxonomique
-    <i
-      *ngIf="showTree"
-      class="fa fa-chevron-down"
-      aria-expanded="false"
-    > </i>
-    <i
-      *ngIf="!showTree"
-      class="fa fa-chevron-right"
-      aria-expanded="false"
-    > </i>
-  </button>
 
   <div
     [hidden]="!AppConfig.SYNTHESE.DISPLAY_TAXON_TREE"
-    class="collapse"
-    id="collapseTree"
+    class="form-group"
   >
-    <small> Selectionner un ou plusieurs taxons à partir de la hierarchie taxonomique </small> <br>
-    <span *ngIf="isLoading"> Chargement... <img
-        src="assets/images/Spinner.gif"
-        alt="Chargement..."
-        height="40"
-        width="40"
-      > </span>
-    <div class="card">
-      <div class="card-body tree-wrapper">
-        <tree-root
-          #tree
-          (event)="catchEvent($event)"
-          [state]="storeService.taxonTreeState"
-          [nodes]="storeService.taxonTree"
-          [options]="treeOptions"
-        >
-          <ng-template
-            #treeNodeTemplate
-            let-node
-            let-index="index"
-          >
-
-            <i
-              *ngIf="!node.data.leaf"
-              class="fa fa-folder-o"
-              aria-hidden="true"
-            ></i>
-            <i
-              *ngIf="node.data.leaf"
-              class="fa fa-hand-o-right"
-              aria-hidden="true"
-            ></i>
-
-            <span [ngClass]="node.data.classes">{{ node.data.name }}</span>
-          </ng-template>
-        </tree-root>
-
-
-
-      </div>
-
-    </div>
     <button
-      type="button"
-      id="button-refresh"
-      class="btn btn-sm btn-outline-danger"
-      (click)="resetTree()"
+      (click)="toggleTree()"
+      id="btn-tree"
+      class="btn btn-sm btn-outline-primary"
+      data-toggle="collapse"
+      data-target="#collapseTree"
     >
-      <small> Réinitialiser la sélection </small>
+      Arbre taxonomique
+      <i
+        *ngIf="showTree"
+        class="fa fa-chevron-down"
+        aria-expanded="false"
+      > </i>
+      <i
+        *ngIf="!showTree"
+        class="fa fa-chevron-right"
+        aria-expanded="false"
+      > </i>
     </button>
+
+    <div
+      class="collapse"
+      id="collapseTree"
+    >
+      <small>
+        Selectionner un ou plusieurs taxons à partir de la hierarchie taxonomique
+      </small>
+      <br>
+      <span *ngIf="isLoading">
+        Chargement...
+        <img
+          src="assets/images/Spinner.gif"
+          alt="Chargement..."
+          height="40"
+          width="40"
+        >
+      </span>
+      <div class="card">
+        <div class="card-body tree-wrapper">
+          <tree-root
+            #tree
+            (event)="catchEvent($event)"
+            [state]="storeService.taxonTreeState"
+            [nodes]="storeService.taxonTree"
+            [options]="treeOptions"
+          >
+            <ng-template
+              #treeNodeTemplate
+              let-node
+              let-index="index"
+            >
+              <i
+                *ngIf="!node.data.leaf"
+                class="fa fa-folder-o"
+                aria-hidden="true"
+              ></i>
+              <i
+                *ngIf="node.data.leaf"
+                class="fa fa-hand-o-right"
+                aria-hidden="true"
+              ></i>
+              <span [ngClass]="node.data.classes">{{ node.data.name }}</span>
+            </ng-template>
+          </tree-root>
+        </div>
+      </div>
+      <button
+        type="button"
+        id="button-refresh"
+        class="btn btn-sm btn-outline-danger"
+        (click)="resetTree()"
+      >
+        <small> Réinitialiser la sélection </small>
+      </button>
+    </div>
   </div>
-  <br>
 
+  <div class="form-group">
+    <pnx-multiselect
+      [values]="storeService.taxonomyLR"
+      [parentFormControl]="formService.searchForm.controls.taxonomy_lr"
+      keyLabel="nom_categorie_lr"
+      keyValue="id_categorie_france"
+      label="Liste rouge UICN"
+    >
+    </pnx-multiselect>
+  </div>
 
+  <div class="form-group">
+    <pnx-multiselect
+      [values]="storeService.taxonomyHab"
+      [parentFormControl]="formService.searchForm.controls.taxonomy_id_hab"
+      keyLabel="nom_habitat"
+      keyValue="id_habitat"
+      label="Habitat"
+    >
+    </pnx-multiselect>
+  </div>
 
-
-
-  <pnx-multiselect
-    [values]="storeService.taxonomyLR"
-    [parentFormControl]="formService.searchForm.controls.taxonomy_lr"
-    keyLabel="nom_categorie_lr"
-    keyValue="id_categorie_france"
-    label="Liste rouge UICN"
-  >
-  </pnx-multiselect>
-  <pnx-multiselect
-    [values]="storeService.taxonomyHab"
-    [parentFormControl]="formService.searchForm.controls.taxonomy_id_hab"
-    keyLabel="nom_habitat"
-    keyValue="id_habitat"
-    label="Habitat"
-  >
-  </pnx-multiselect>
-
-  <pnx-multiselect
-    [values]="storeService.taxonomyGroup2Inpn"
-    [parentFormControl]="formService.searchForm.controls.taxonomy_group2_inpn"
-    keyLabel="value"
-    keyValue="value"
-    label="Groupe 2 INPN"
-  >
-  </pnx-multiselect>
-
-
+  <div class="form-group">
+    <pnx-multiselect
+      [values]="storeService.taxonomyGroup2Inpn"
+      [parentFormControl]="formService.searchForm.controls.taxonomy_group2_inpn"
+      keyLabel="value"
+      keyValue="value"
+      label="Groupe 2 INPN"
+    >
+    </pnx-multiselect>
+  </div>
 
   <div *ngIf="storeService.formBuilded && storeService.taxhubAttributes.length > 0">
-    <h5> Attributs taxhub</h5>
+    <h5>Attributs taxhub</h5>
     <div
       class="dynamic-form padding-sm"
       *ngFor="let formDef of storeService.taxhubAttributes; let i = index"
@@ -166,12 +173,15 @@
       </pnx-dynamic-form>
     </div>
 
+  </div>
+</div>
 
-  </div>
-  <div class="modal-footer">
-    <button
-      type="button"
-      class="btn btn-success"
-      (click)="onCloseModal()"
-    >Valider et fermer</button>
-  </div>
+<div class="modal-footer">
+  <button
+    type="button"
+    class="btn btn-success"
+    (click)="onCloseModal()"
+  >
+    Valider et fermer
+  </button>
+</div>

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form.component.scss
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form.component.scss
@@ -1,13 +1,22 @@
 .leaf {
   font-weight: bold;
 }
-
 .tree-wrapper {
   padding: 15px;
   max-height: 300px;
   overflow: auto;
 }
-
 #btn-tree {
   margin-top: 5px;
+}
+.searched-taxa-list {
+  padding: 0.5rem;
+}
+.searched-taxa-list ul {
+  margin-bottom: 0;
+  padding-left: 0;
+}
+.searched-taxa-list li {
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.25rem;
 }


### PR DESCRIPTION
Hide taxo tree button when SYNTHESE.DISPLAY_TAXON_TREE is false. Isolate
Synthese advanced form inputs in DIV tags with "group-form" CSS class. 
Improve searched taxa display style.

Close #1057.