### PR TITLE
fix 1095 - Leaflet draw: Don't create additional circlemarker for poi…

### DIFF
--- a/frontend/src/app/GN2CommonModule/map/leaflet-draw/leaflet-draw.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/leaflet-draw/leaflet-draw.component.ts
@@ -184,11 +184,6 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
         this.map.setView(layer.getLatLng(), 15);
       }
     }
-    if (geojson.type === 'Point') {
-      const latLng = L.GeoJSON.coordsToLatLng(geojson.coordinates);
-      layer = L.circleMarker(latLng);
-      this.mapservice.leafletDrawFeatureGroup.addLayer(layer);
-    }
 
     if (layer.getBounds) {
       this.mapservice.map.fitBounds(layer.getBounds());


### PR DESCRIPTION
Fix issue #1095 

Suppression de la création d'un circle marker en utilisant le composant leaflet draw pour un point.
On n'utilise que le marker déjà créé.