### PR TITLE
synthese reference biblio type text

### DIFF
--- a/data/core/synthese.sql
+++ b/data/core/synthese.sql
@@ -163,7 +163,7 @@ CREATE TABLE synthese (
     id_nomenclature_info_geo_type integer DEFAULT get_default_nomenclature_value('TYP_INF_GEO'),
     id_nomenclature_behaviour integer DEFAULT get_default_nomenclature_value('OCC_COMPORTEMENT'),
     id_nomenclature_biogeo_status integer DEFAULT get_default_nomenclature_value('STAT_BIOGEO'),
-    reference_biblio character varying(255),
+    reference_biblio text,
     count_min integer,
     count_max integer,
     cd_nom integer,

--- a/data/migrations/2.5.5to2.5.6.sql
+++ b/data/migrations/2.5.5to2.5.6.sql
@@ -4,6 +4,7 @@ ALTER TABLE gn_synthese.synthese
 ALTER TABLE ONLY gn_synthese.synthese
     ADD CONSTRAINT fk_synthese_id_nomenclature_biogeo_status FOREIGN KEY (id_nomenclature_biogeo_status) REFERENCES ref_nomenclatures.t_nomenclatures(id_nomenclature) ON UPDATE CASCADE;
 
+ALTER TABLE gn_synthese.synthese ALTER COLUMN reference_biblio TYPE TEXT; 
 
 CREATE OR REPLACE FUNCTION gn_synthese.fct_tri_calculate_sensitivity() RETURNS TRIGGER
   LANGUAGE plpgsql

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -21,6 +21,7 @@ CHANGELOG
 **⚠️ Notes de version**
 
 * Si vous aviez fait des customisations (logo, PDF export...) alors XXXXXX
+* Si des vues utilisent la colonne ``gn_synthese.synthese.refence_biblio`` (par exemple ``v_synthese_for_web_app`` et ``gn_commons.v_synthese_validation_forwebapp``), celles-ci doivent être supprimées (DROP) et recrées
 * Revoir http://docs.geonature.fr/admin-manual.html#integrer-son-logo ?
 
 2.5.5 (2020-11-19)

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,7 @@ CHANGELOG
 **🐛 Corrections**
 
 * Synthèse : fonction ``import_row_from_table``: test sur LOWER(tbl_name) 
+* Synthèse : changement de type pour ``refence_biblio`` (varchar(255) -> text)
 
 **⚠️ Notes de version**
 


### PR DESCRIPTION
Aucune raison de limiter ce champs à 255 charactère dans le standard occTax