### PR TITLE
backend: réponse 401 ou redirection vers login

### DIFF
--- a/backend/geonature/core/errors/routes.py
+++ b/backend/geonature/core/errors/routes.py
@@ -1,6 +1,9 @@
 import logging
+from urllib.parse import urlparse
 
-from flask import current_app, jsonify, Response
+from flask import current_app, jsonify, Response, request, json, redirect
+from werkzeug.exceptions import Unauthorized, HTTPException
+from werkzeug import url_encode
 
 from pypnusershub.db.tools import InsufficientRightsError
 from sqlalchemy.exc import SQLAlchemyError
@@ -56,4 +59,41 @@ def geonature_insuffisant_rights_error(error):
     DB.session.rollback()
     response = jsonify(str(error))
     response.status_code = 403
+    return response
+
+
+@current_app.errorhandler(Unauthorized)
+def handle_unauthenticated_request(e):
+    if request.headers.get('Content-Type') == 'application/json':
+        response = e.get_response()
+        response.data = json.dumps({
+            'code': e.code,
+            'name': e.name,
+            'description': e.description,
+        })
+        response.content_type = 'application/json'
+        return response
+    else:
+        base_url = current_app.config['URL_APPLICATION']
+        login_path = '/#/login'  # FIXME: move in config
+        api_endpoint = current_app.config['API_ENDPOINT']
+        url_application = current_app.config['URL_APPLICATION']
+        if urlparse(api_endpoint).netloc == urlparse(url_application).netloc:
+            next_url = request.full_path
+        else:
+            next_url = request.url
+        query_string = url_encode({'next': next_url})
+        return redirect(f'{base_url}{login_path}?{query_string}')
+
+
+@current_app.errorhandler(HTTPException)
+def handle_exception(e):
+    response = e.get_response()
+    if request.headers.get('Content-Type') == 'application/json':
+        response.data = json.dumps({
+            'code': e.code,
+            'name': e.name,
+            'description': e.description,
+        })
+        response.content_type = 'application/json'
     return response

--- a/backend/geonature/core/gn_permissions/tools.py
+++ b/backend/geonature/core/gn_permissions/tools.py
@@ -1,6 +1,7 @@
 import logging, json
 
 from flask import current_app, redirect, Response
+from werkzeug.exceptions import Unauthorized
 
 from itsdangerous import (
     TimedJSONWebSignatureSerializer as Serializer,
@@ -44,48 +45,29 @@ def get_user_from_token_and_raise(
 ):
     """
     Deserialize the token
-    catch excetpion and return appropriate Response(403, 302 ...)
+    Catch specific exceptions and return common exceptions (Unauthorized, Forbidden) with
+    appropriate message
     """
     try:
         token = request.cookies["token"]
         return user_from_token(token, secret_key)
 
+    except KeyError:
+        raise Unauthorized(description='No token.')
     except AccessRightsExpiredError:
-        if redirect_on_expiration:
-            res = redirect(redirect_on_expiration, code=302)
-        else:
-            res = Response("Token Expired", 403)
-        res.set_cookie("token", expires=0)
-        return res
-    except InsufficientRightsError as e:
-        log.info(e)
-        if redirect_on_expiration:
-            res = redirect(redirect_on_expiration, code=302)
-        else:
-            res = Response("Forbidden", 403)
-        return res
-    except KeyError as e:
-        if redirect_on_expiration:
-            return redirect(redirect_on_expiration, code=302)
-        return Response("No token", 403)
-
+        raise Unauthorized(description='Token expired.')
     except UnreadableAccessRightsError:
-        log.info("Invalid Token : BadSignature")
-        # invalid token
-        if redirect_on_invalid_token:
-            res = redirect(redirect_on_invalid_token, code=302)
-        else:
-            res = Response("Token BadSignature", 403)
-        res.set_cookie("token", expires=0)
-        return res
-
+        response = Unauthorized(description='Token corrupted.').get_response()
+        response.set_cookie("token", expires=0)
+        raise Unauthorized(response=response)
+    except InsufficientRightsError as e:
+        raise Forbidden
     except Exception as e:
         trap_all_exceptions = current_app.config.get("TRAP_ALL_EXCEPTIONS", True)
         if not trap_all_exceptions:
             raise
         log.critical(e)
-        msg = json.dumps({"type": "Exception", "msg": repr(e)})
-        return Response(msg, 403)
+        raise Forbidden(description=repr(e))
 
 
 class UserCruved:

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -50,7 +50,7 @@ import { ModuleService } from './services/module.service';
 import { CruvedStoreService } from './GN2CommonModule/service/cruved-store.service';
 import { SideNavService } from './components/sidenav-items/sidenav-service';
 
-import { MyCustomInterceptor } from './services/http.interceptor';
+import { MyCustomInterceptor, ContentTypeInterceptor } from './services/http.interceptor';
 import { GlobalSubService } from './services/global-sub.service';
 
 export function createTranslateLoader(http: HttpClient) {
@@ -107,7 +107,8 @@ import { UserDataService } from "./userModule/services/user-data.service";
     SideNavService,
     CruvedStoreService,
     UserDataService,
-    { provide: HTTP_INTERCEPTORS, useClass: MyCustomInterceptor, multi: true }
+    { provide: HTTP_INTERCEPTORS, useClass: MyCustomInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: ContentTypeInterceptor, multi: true }
   ],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/app/components/auth/auth.service.ts
+++ b/frontend/src/app/components/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Router } from '@angular/router';
+import { Router, ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
@@ -22,7 +22,7 @@ export class AuthService {
   token: string;
   loginError: boolean;
   public isLoading = false;
-  constructor(private router: Router, private _http: HttpClient, private _cookie: CookieService) { }
+  constructor(private router: Router, private route: ActivatedRoute, private _http: HttpClient, private _cookie: CookieService) { }
 
   setCurrentUser(user) {
     localStorage.setItem('current_user', JSON.stringify(user));
@@ -89,7 +89,15 @@ export class AuthService {
           };
           this.setCurrentUser(userForFront);
           this.loginError = false;
-          this.router.navigate(['']);
+          let next_url = '';
+          this.route.queryParams.subscribe(params => {
+              next_url = params['next'];
+          });
+          if (next_url) {
+              window.location.href = next_url;
+          } else {
+              this.router.navigate(['']);
+          }
         },
         // error callback
         () => {

--- a/frontend/src/app/services/http.interceptor.ts
+++ b/frontend/src/app/services/http.interceptor.ts
@@ -61,3 +61,17 @@ export class MyCustomInterceptor implements HttpInterceptor {
     return hostname;
   }
 }
+
+
+/* Cet intercepteur a pour rôle d’ajouter un header Content-Type: application/json.
+ * Ceci permet à l’API d’ajuster sa réponse (réponse 403 vs redirection login par exemple).
+ */
+@Injectable()
+export class ContentTypeInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const modifiedReq = req.clone({
+      headers: req.headers.set('Content-Type', 'application/json')
+    })
+    return next.handle(modifiedReq);
+  }
+}


### PR DESCRIPTION
Le frontend définie un header Content-Type: application/json
dont le backend se sert pour choisir entre répondre par une 401
(appelle de l’API par le frontend) ou rediriger vers une page de
login (accès directe à l’URI depuis le navigateur - par exemple
vues d’exports).
Close #1193