### PR TITLE
add NOT NULL constraint on unique_id_sinp in synthese table

### DIFF
--- a/data/core/synthese.sql
+++ b/data/core/synthese.sql
@@ -136,7 +136,7 @@ CREATE TABLE t_sources (
 
 CREATE TABLE synthese (
     id_synthese integer NOT NULL,
-    unique_id_sinp uuid,
+    unique_id_sinp uuid NOT NULL,
     unique_id_sinp_grp uuid,
     id_source integer,
     id_module integer,

--- a/data/migrations/2.5.5to2.6.0.sql
+++ b/data/migrations/2.5.5to2.6.0.sql
@@ -393,3 +393,7 @@ SELECT  s.id_synthese,
   WHERE d.validable = true AND NOT s.unique_id_sinp IS NULL;
 
 COMMENT ON VIEW gn_commons.v_synthese_validation_forwebapp  IS 'Vue utilisée pour le module validation. Prend l''id_nomenclature dans la table synthese ainsi que toutes les colonnes de la synthese pour les filtres. On JOIN sur la vue latest_validation pour voir si la validation est auto';
+
+-- Ajoute une contrainte NON NULL sur le champ unique_id_sinp de la synthese
+
+ALTER TABLE gn_synthese.synthese ALTER COLUMN unique_id_sinp SET NOT NULL;


### PR DESCRIPTION
Ajout d'une contrainte `NOT NULL` sur le champs unique_id_sinp de la table de synthèse.
Fixes #1204