### PR TITLE
fix: Add some missing unique constraints

### DIFF
--- a/data/core/meta.sql
+++ b/data/core/meta.sql
@@ -420,6 +420,10 @@ CREATE TRIGGER tri_meta_dates_change_t_acquisition_frameworks
 --------------
 --CONSTRAINS--
 --------------
+
+ALTER TABLE t_datasets
+  ADD CONSTRAINT unique_dataset_uuid UNIQUE (unique_dataset_id);
+
 ALTER TABLE t_datasets
   ADD CONSTRAINT check_t_datasets_resource_type CHECK (ref_nomenclatures.check_nomenclature_type_by_mnemonique(id_nomenclature_resource_type,'RESOURCE_TYP')) NOT VALID;
 
@@ -438,6 +442,9 @@ ALTER TABLE t_datasets
 ALTER TABLE t_datasets
   ADD CONSTRAINT check_t_datasets_source_status CHECK (ref_nomenclatures.check_nomenclature_type_by_mnemonique(id_nomenclature_source_status,'STATUT_SOURCE')) NOT VALID;
 
+
+ALTER TABLE t_acquisition_frameworks
+  ADD CONSTRAINT unique_acquisition_frameworks_uuid UNIQUE (unique_acquisition_framework_id);
 
 ALTER TABLE t_acquisition_frameworks
   ADD CONSTRAINT check_t_acquisition_frameworks_territorial_level CHECK (ref_nomenclatures.check_nomenclature_type_by_mnemonique(id_nomenclature_territorial_level,'NIVEAU_TERRITORIAL')) NOT VALID;
@@ -468,8 +475,14 @@ ALTER TABLE cor_acquisition_framework_actor
 
 
 ALTER TABLE sinp_datatype_protocols
+  ADD CONSTRAINT unique_sinp_datatype_protocols_uuid UNIQUE (unique_protocol_id);
+
+ALTER TABLE sinp_datatype_protocols
   ADD CONSTRAINT check_sinp_datatype_protocol_type CHECK (ref_nomenclatures.check_nomenclature_type_by_mnemonique(id_nomenclature_protocol_type,'TYPE_PROTOCOLE')) NOT VALID;
 
+
+ALTER TABLE sinp_datatype_publications
+  ADD CONSTRAINT unique_sinp_datatype_publications_uuid UNIQUE (unique_publication_id);
 
 ALTER TABLE cor_dataset_actor
   ADD CONSTRAINT check_cor_dataset_actor CHECK (ref_nomenclatures.check_nomenclature_type_by_mnemonique(id_nomenclature_actor_role,'ROLE_ACTEUR')) NOT VALID;
@@ -496,6 +509,17 @@ CREATE INDEX i_t_datasets_id_acquisition_framework
   ON gn_meta.t_datasets
   USING btree
   (id_acquisition_framework);
+
+CREATE UNIQUE INDEX i_unique_t_acquisition_framework_unique_id 
+  ON gn_meta.t_acquisition_frameworks 
+  USING btree 
+  (unique_acquisition_framework_id);
+
+CREATE UNIQUE INDEX i_unique_t_datasets_unique_id 
+  ON gn_meta.t_datasets 
+  USING btree 
+  (unique_dataset_id);
+
 
 --------
 --VIEW--

--- a/data/core/synthese.sql
+++ b/data/core/synthese.sql
@@ -332,6 +332,9 @@ ALTER TABLE ONLY cor_observer_synthese
 --CONSTRAINTS--
 ---------------
 
+ALTER TABLE ONLY t_sources
+    ADD CONSTRAINT unique_name_source UNIQUE (name_source);
+
 ALTER TABLE ONLY synthese
     ADD CONSTRAINT unique_id_sinp_unique UNIQUE (unique_id_sinp);
 
@@ -458,6 +461,8 @@ ORDER BY loc.cd_ref;
 -----------
 --INDEXES--
 -----------
+
+CREATE UNIQUE INDEX i_unique_t_sources_name_source ON t_sources USING btree (name_source);
 
 CREATE INDEX i_synthese_t_sources ON synthese USING btree (id_source);
 

--- a/data/migrations/2.5.5to2.6.0.sql
+++ b/data/migrations/2.5.5to2.6.0.sql
@@ -1,5 +1,14 @@
 -- Update script from GeoNature 2.5.5 to 2.6.0
 
+------------------------------------
+-- ADD MISSING UNIQUE CONSTRAINTS --
+------------------------------------
+
+-- gn_synthese.t_sources.name_source UNIQUE
+ALTER TABLE ONLY t_sources
+    ADD CONSTRAINT unique_name_source UNIQUE (name_source);
+CREATE UNIQUE INDEX i_unique_t_sources_name_source ON t_sources USING btree (name_source);
+
 ----------------------------
 -- SENSITIVITY schema update
 ----------------------------

--- a/data/migrations/2.5.5to2.6.0.sql
+++ b/data/migrations/2.5.5to2.6.0.sql
@@ -5,9 +5,24 @@
 ------------------------------------
 
 -- gn_synthese.t_sources.name_source UNIQUE
-ALTER TABLE ONLY t_sources
+ALTER TABLE ONLY gn_synthese.t_sources
     ADD CONSTRAINT unique_name_source UNIQUE (name_source);
-CREATE UNIQUE INDEX i_unique_t_sources_name_source ON t_sources USING btree (name_source);
+CREATE UNIQUE INDEX i_unique_t_sources_name_source ON gn_synthese.t_sources USING btree (name_source);
+
+ALTER TABLE gn_meta.t_datasets
+  ADD CONSTRAINT unique_dataset_uuid UNIQUE (unique_dataset_id);
+CREATE UNIQUE INDEX i_unique_t_datasets_unique_id ON gn_meta.t_datasets USING btree (unique_dataset_id);
+
+ALTER TABLE gn_meta.t_acquisition_frameworks
+  ADD CONSTRAINT unique_acquisition_frameworks_uuid UNIQUE (unique_acquisition_framework_id);
+CREATE UNIQUE INDEX i_unique_t_acquisition_framework_unique_id ON gn_meta.t_acquisition_frameworks USING btree (unique_acquisition_framework_id);
+
+ALTER TABLE gn_meta.sinp_datatype_protocols
+  ADD CONSTRAINT unique_sinp_datatype_protocols_uuid UNIQUE (unique_protocol_id);
+
+ALTER TABLE gn_meta.sinp_datatype_publications
+  ADD CONSTRAINT unique_sinp_datatype_publications_uuid UNIQUE (unique_publication_id);
+
 
 ----------------------------
 -- SENSITIVITY schema update


### PR DESCRIPTION
* Ajout d'une contrainte d'unicité sur `name_source` dans `gn_synthese.t_sources` > fix: #1215 
* Ajout de contraintes d'unicité sur tous les champs UUID du module `gn_meta` et création d'index unique sur les UUID des cadres d'acquisition et des jeux de données > 
fix: #1239