### PR TITLE
ajout DISPLAY_EMAIL_INFO_OBS dans la config par defaut

### DIFF
--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -168,6 +168,9 @@ MAIL_ON_ERROR = false
 
     # Passe le frontend en mode multilingue (non implémenté pour l'instant)
     MULTILINGUAL = false
+    
+    #Affiche les emails des observateurs dans les modules Synthese et Validation
+    DISPLAY_EMAIL_INFO_OBS = true
 
 # Configuration de l'affichage des cartes dans GeoNature
 [MAPCONFIG]


### PR DESCRIPTION
Ajout du paramètre DISPLAY_EMAIL_INFO_OBS manquant dans config default
https://github.com/PnX-SI/GeoNature/issues/1066#issuecomment-773969956
