### PR TITLE
fix: unique constraints on ref_geo #1270

### DIFF
--- a/data/core/ref_geo.sql
+++ b/data/core/ref_geo.sql
@@ -215,6 +215,7 @@ COMMENT ON COLUMN bib_areas_types.ref_name IS 'Indique le nom du référentiel g
 COMMENT ON COLUMN bib_areas_types.ref_version IS 'Indique l''année du référentiel utilisé';
 ALTER SEQUENCE bib_areas_types_id_type_seq OWNED BY bib_areas_types.id_type;
 ALTER TABLE ONLY bib_areas_types ALTER COLUMN id_type SET DEFAULT nextval('bib_areas_types_id_type_seq'::regclass);
+ALTER TABLE ONLY bib_areas_types ADD CONSTRAINT unique_bib_areas_types_type_code UNIQUE (type_code);
 
 CREATE SEQUENCE l_areas_id_area_seq
     START WITH 1
@@ -343,7 +344,8 @@ ALTER TABLE ref_geo.li_grids
 CREATE INDEX index_l_areas_geom ON l_areas USING gist (geom);
 CREATE INDEX index_l_areas_centroid ON l_areas USING gist (centroid);
 CREATE INDEX index_dem_vector_geom ON dem_vector USING gist (geom);
-CREATE UNIQUE INDEX IF NOT EXISTS i_unique_l_areas_id_type_area_code ON ref_geo.l_areas (id_type, area_code);
+CREATE UNIQUE INDEX i_unique_l_areas_id_type_area_code ON l_areas (id_type, area_code);
+CREATE UNIQUE INDEX i_unique_bib_areas_types_type_code ON bib_areas_types(type_code);
 
 ------------
 --TRIGGERS--

--- a/data/migrations/2.6.2to2.6.3.sql
+++ b/data/migrations/2.6.2to2.6.3.sql
@@ -1,0 +1,22 @@
+-- Update script from GeoNature 2.6.2 to 2.6.3
+
+BEGIN;
+   ------------------------------------
+   -- ADD MISSING UNIQUE CONSTRAINTS --
+   ------------------------------------
+
+   CREATE UNIQUE INDEX IF NOT EXISTS i_unique_l_areas_id_type_area_code ON ref_geo.l_areas (id_type, area_code);
+   ALTER TABLE ONLY ref_geo.l_areas DROP CONSTRAINT IF EXISTS unique_l_areas_id_type_area_code;
+   ALTER TABLE ONLY ref_geo.l_areas
+        ADD CONSTRAINT  unique_l_areas_id_type_area_code UNIQUE (id_type, area_code);
+   CREATE UNIQUE INDEX IF NOT EXISTS  i_unique_bib_areas_types_type_code ON ref_geo.bib_areas_types(type_code);
+   ALTER TABLE ONLY ref_geo.bib_areas_types DROP CONSTRAINT IF EXISTS unique_bib_areas_types_type_code;
+   ALTER TABLE ONLY ref_geo.bib_areas_types
+        ADD CONSTRAINT unique_bib_areas_types_type_code UNIQUE (type_code);
+    
+
+COMMIT;
+
+
+
+


### PR DESCRIPTION
* As mentionnend in #1271, migration queries are now in 2.6.2-2.6.3 migration file.
* Add a unique constraint to `type_code` in `bib_areas_types`
* refactor create unique index in ref_geo.sql (removing if not exists, removing schema already defined in search path) 