### PR TITLE
Fix dead links in documentation

### DIFF
--- a/docs/admin-manual.rst
+++ b/docs/admin-manual.rst
@@ -381,7 +381,7 @@ Idem côté Frontend, où chaque module a sa configuration et ses composants : h
 
 Mais en pouvant utiliser des composants du Cœur comme expliqué dans la documentation Developpeur.
 
-Plus d'infos sur le développement d'un module : https://github.com/PnX-SI/GeoNature/blob/develop/docs/development.rst#d%C3%A9velopper-et-installer-un-gn_module
+Plus d'infos sur le développement d'un module : https://github.com/PnX-SI/GeoNature/blob/master/docs/development.rst#d%C3%A9velopper-et-installer-un-gn_module
 
 
 Configuration

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -909,18 +909,7 @@ tslint fait la même chose que pylint mais pour la partie frontend en
 typescript::
 
         cd frontend
-        ng lint
-
-
-L'intallation globale de l'interface en ligne de commande (CLI)
-d'Angular est nécessaire pour utilser la commande "ng"
-
-Si la commande "ng" n'existe pas, il faudra alors utiliser la commande suivante auparavant
-
-::
-
-        npm install -g @angular/cli
-
+        npm run lint
 
 
 Pytest

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -225,7 +225,7 @@ Développer un gn_module
 
 Avant de développer un gn_module, assurez-vous d'avoir GeoNature bien
 installé sur votre machine
-(`voir doc <https://github.com/PnX-SI/GeoNature/blob/develop/docs/installation-standalone.rst>`__).
+(`voir doc <https://github.com/PnX-SI/GeoNature/blob/master/docs/installation-standalone.rst>`__).
 
 Afin de pouvoir connecter ce module au "coeur", il est impératif de suivre
 une arborescence prédéfinie par l'équipe GeoNature.
@@ -718,7 +718,7 @@ Un ensemble de composants décrits ci-dessous sont intégrés dans le coeur de G
 Voir la `DOCUMENTATION COMPLETE <http://pnx-si.github.io/GeoNature/frontend/modules/GN2CommonModule.html>`_ sur les composants génériques. 
 
 
-NB: mes composants de type "formulaire" (balise `input` ou `select`) partagent une logique commune et ont des ``Inputs`` et des ``Outputs`` communs décrit ci dessous. (voir https://github.com/PnX-SI/GeoNature/blob/develop/frontend/src/app/GN2CommonModule/form/genericForm.component.ts).
+NB: mes composants de type "formulaire" (balise `input` ou `select`) partagent une logique commune et ont des ``Inputs`` et des ``Outputs`` communs décrit ci dessous. (voir https://github.com/PnX-SI/GeoNature/blob/master/frontend/src/app/GN2CommonModule/form/genericForm.component.ts).
 
 Une documentation complète des composants générique est
 `disponible ici <http://pnx-si.github.io/GeoNature/frontend/modules/GN2CommonModule.html>`_
@@ -726,7 +726,7 @@ Une documentation complète des composants générique est
 NB: mes composants de type "formulaire" (balise `input` ou `select`) partagent
 une logique commune et ont des ``Inputs`` et des ``Outputs`` communs décrit
 ci dessous.
-(voir https://github.com/PnX-SI/GeoNature/blob/develop/frontend/src/app/GN2CommonModule/form/genericForm.component.ts).
+(voir https://github.com/PnX-SI/GeoNature/blob/master/frontend/src/app/GN2CommonModule/form/genericForm.component.ts).
 
 - Inputs
 
@@ -788,7 +788,7 @@ service :
         [{'param': 'limit', 'value': 10'},
         {'param': 'cd_nom', 'value': 212'}])
 
-  `Exemple dans le module OccTax  <https://github.com/PnX-SI/GeoNature/blob/develop/frontend/src/modules/occtax/occtax-map-list/occtax-map-list.component.ts#L84/>`_
+  `Exemple dans le module OccTax  <https://github.com/PnX-SI/GeoNature/blob/master/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.ts#L99/>`_
 
   L'API doit nécessairement renvoyer un objet comportant un
   GeoJson. La structure du l'objet doit être la suivante :

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -912,6 +912,16 @@ typescript::
         ng lint
 
 
+L'intallation globale de l'interface en ligne de commande (CLI)
+d'Angular est nécessaire pour utilser la commande "ng"
+
+Si la commande "ng" n'existe pas, il faudra alors utiliser la commande suivante auparavant
+
+::
+
+        npm install -g @angular/cli
+
+
 
 Pytest
 ******

--- a/docs/installation-mtes.rst
+++ b/docs/installation-mtes.rst
@@ -3,7 +3,7 @@ SPECIFICITES DEPOBIO
 
 Cette documentation mentionne les spécificités et la configuration de l'installation de l'instance nationale du Ministère de la Transition Ecologique et Solidaire (MTES), dans le cadre du projet de Depôt Légal des données de biodiversité (https://depot-legal-biodiversite.naturefrance.fr/).
 
-Pour l'installation de GeoNature, voir la procédure d'installation de GeoNature et ses dépendances (https://github.com/PnX-SI/GeoNature/blob/develop/docs/installation-all.rst).
+Pour l'installation de GeoNature, voir la procédure d'installation de GeoNature et ses dépendances (https://github.com/PnX-SI/GeoNature/blob/master/docs/installation-all.rst).
 
 
 Configuration Apache
@@ -304,7 +304,7 @@ Depuis le répertoire ``backend`` de GeoNature
     deactivate
 
 
-Pour plus d'information sur la configuration du module Occtax, voir la documentation concernant le module (https://github.com/PnX-SI/GeoNature/blob/develop/docs/admin-manual.rst#module-occtax).
+Pour plus d'information sur la configuration du module Occtax, voir la documentation concernant le module (https://github.com/PnX-SI/GeoNature/blob/master/docs/admin-manual.rst#module-occtax).
 
 Référentiel géographique
 ------------------------
@@ -319,8 +319,8 @@ des altitudes pour chaque observation).
 Authentification CAS INPN
 -------------------------
 
-- Code source : https://github.com/PnX-SI/GeoNature/blob/develop/backend/geonature/core/auth/routes.py
-- Config : https://github.com/PnX-SI/GeoNature/blob/develop/config/default_config.toml.example#L29-L44
+- Code source : https://github.com/PnX-SI/GeoNature/blob/master/backend/geonature/core/auth/routes.py
+- Config : https://github.com/PnX-SI/GeoNature/blob/master/config/default_config.toml.example#L124-L135
 
 
 Connexion et droits dans GeoNature

--- a/docs/installation-standalone.rst
+++ b/docs/installation-standalone.rst
@@ -2,7 +2,7 @@ INSTALLATION AUTONOME
 =====================
 
 **Attention** : Ne suivez cette documentation que si vous souhaitez installer GeoNature de manière autonome (sans TaxHub ou UsersHub).
-Pour une installation packagée voir cette `documentation <https://github.com/PnX-SI/GeoNature/blob/install_all/docs/installation-all.rst>`_.
+Pour une installation packagée voir cette `documentation <https://github.com/PnX-SI/GeoNature/blob/master/docs/installation-all.rst>`_.
 
 Prérequis
 ---------


### PR DESCRIPTION
Hi,
I saw that some links in documentation are dead.
I notably replaced old occtax path ``frontend/src/modules/occtax`` and first link to installation-all.rst in installation-standalone.rst

I took the opportunity to replace all references to develop branch by master, but I think maybe it would be better to use github permalinks instead of references to branches (especially for references to lines)

I just clone the repository and didn't launch full installation for now, so I don't really know if e7c27637d8cc994aa9aef4be0cc8a9d9b16f2276 commit is useful (despite I searched in all project for a reference to angular/cli)

Anyway, congratulations for your work ! :)