### PR TITLE
Feat/pdftaxa master

### DIFF
--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -321,21 +321,6 @@ def get_dataset_details(info_role, id_dataset):
     return get_dataset_details_dict(id_dataset, info_role)
 
 
-@routes.route("/upload_canvas", methods=["POST"])
-@json_resp
-def upload_canvas():
-    """Upload the canvas as a temporary image used while generating the pdf file
-    """
-    data = request.data[22:]
-    filepath = str(BACKEND_DIR) + "/static/images/taxa.png"
-    fm.remove_file(filepath)
-    if data:
-        binary_data = a2b_base64(data)
-        fd = open(filepath, "wb")
-        fd.write(binary_data)
-        fd.close()
-    return "OK"
-
 def create_taxa_chart(id_dataset=None, id_af=None):
     """Create a png chart of the taxonomic distribution using the matplotlib library
     """

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -850,7 +850,7 @@ def get_observation_count():
 
 @routes.route("/observations_bbox", methods=["GET"])
 @json_resp
-def get_bbox():
+def get_bbox(id_dataset=None):
     """
     Get bbbox of observations
 
@@ -868,9 +868,12 @@ def get_bbox():
     params = request.args
 
     query = DB.session.query(func.ST_AsGeoJSON(func.ST_Extent(Synthese.the_geom_4326)))
-        
-    if "id_dataset" in params:
-        query = query.filter(Synthese.id_dataset == params["id_dataset"])
+    
+    if not id_dataset and "id_dataset" in params:
+        id_dataset = params["id_dataset"]
+
+    if id_dataset:
+        query = query.filter(Synthese.id_dataset == id_dataset)
     data = query.one()
     if data and data[0]:
         return json.loads(data[0])
@@ -901,18 +904,23 @@ def observation_count_per_column(column):
 
 @routes.route("/taxa_distribution", methods=["GET"])
 @json_resp
-def get_taxa_distribution():
+def get_taxa_distribution(id_dataset=None, id_af=None, rank=None):
     """
     Get taxa distribution for a given dataset or acquisition framework
     and grouped by a certain taxa rank
     """
 
-    id_dataset = request.args.get("id_dataset")
-    id_af = request.args.get("id_af")
+    if not id_dataset:
+        id_dataset = request.args.get("id_dataset")
+    if not id_af:
+        id_af = request.args.get("id_af")
 
-    rank = request.args.get("taxa_rank")
+    if not rank:
+        rank = request.args.get("taxa_rank")
     if not rank:
         rank = "regne"
+
+    print(id_dataset, id_af, rank)
 
     rank = getattr(Taxref.__table__.columns, rank)
 

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -920,8 +920,6 @@ def get_taxa_distribution(id_dataset=None, id_af=None, rank=None):
     if not rank:
         rank = "regne"
 
-    print(id_dataset, id_af, rank)
-
     rank = getattr(Taxref.__table__.columns, rank)
 
     Taxref.group2_inpn

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -901,10 +901,8 @@ def observation_count_per_column(column):
         data.append(temp)
     return data
 
-
-@routes.route("/taxa_distribution", methods=["GET"])
 @json_resp
-def get_taxa_distribution(id_dataset=None, id_af=None, rank=None):
+def taxa_distribution(id_dataset=None, id_af=None, rank=None):
     """
     Get taxa distribution for a given dataset or acquisition framework
     and grouped by a certain taxa rank
@@ -940,6 +938,15 @@ def get_taxa_distribution(id_dataset=None, id_af=None, rank=None):
 
     data = query.group_by(rank).all()
     return [{"count": d[0], "group": d[1]} for d in data]
+
+@routes.route("/taxa_distribution", methods=["GET"])
+@json_resp
+def get_taxa_distribution():
+    """
+    Get taxa distribution for a given dataset or acquisition framework
+    and grouped by a certain taxa rank
+    """
+    return taxa_distribution()
 
 
 # @routes.route("/test", methods=["GET"])

--- a/backend/geonature/templates/acquisition_framework_template_pdf.html
+++ b/backend/geonature/templates/acquisition_framework_template_pdf.html
@@ -264,8 +264,8 @@
                     <p class="zone-geographique">Zone géographique</p>
                     <img
                         class="taxons"
-                        src="{{url_for('static', filename='images/map.svg')}}"
-                        alt="Pas d'observations à afficher."
+                        src="data:image/jpeg;base64,{{ data['map'] | safe }}"
+                        alt="Pas d'espèces à afficher."
                     >
                 </div>
                 {% endif %}
@@ -275,7 +275,7 @@
                     <p class="repartition-especes">Répartition des espèces</p>
                     <img
                         class="taxons"
-                        src="{{url_for('static', filename='images/taxa.png')}}"
+                        src="data:image/jpeg;base64,{{ data['chart'] | safe }}"
                         alt="Pas d'espèces à afficher."
                     >
                 </div>

--- a/backend/geonature/templates/acquisition_framework_template_pdf.html
+++ b/backend/geonature/templates/acquisition_framework_template_pdf.html
@@ -222,7 +222,115 @@
                     </p>
                 </div>
 
-                {% if data.cor_af_actor: %}
+                {% if not (data.cor_af_actor and data.cor_af_actor[5]) : %}
+                <div class="information">
+                    <p class="info-titre">Acteurs</p>
+                    <p class="info-contenu">
+                        {% if data.cor_af_actor: %}
+                        {% for act in data.cor_af_actor -%}
+                        {% if act.nomenclature_actor_role: %}
+                        {{ act.nomenclature_actor_role['mnemonique'] }} :
+                        {% endif %}
+                        {% if act.organism: %}
+                        {{ act.organism['nom_organisme'] }}
+                        {% endif %}
+                        {% if act.organism and act.role: %}
+                        -
+                        {% endif %}
+                        {% if act.role: %}
+                        {{ act.role['nom_complet'] }}
+                        {% endif %}
+                        <br>
+                        {%- endfor %}
+                        {% endif %}
+                    </p>
+                </div>
+
+                {% if data['keywords']: %}
+                <div class="information">
+                    <p class="info-titre">Mots-clés</p>
+                    <p class="info-contenu">
+                        {{ data['keywords'] }}
+                    </p>
+                </div>
+                {% endif %}
+                {% endif %}
+
+            </div>
+            <div class="right-block">
+
+                {% if data['map']: %}
+                <div class="zone">
+                    <p class="zone-geographique">Zone géographique</p>
+                    <img
+                        class="taxons"
+                        src="{{url_for('static', filename='images/map.svg')}}"
+                        alt="Pas d'observations à afficher."
+                    >
+                </div>
+                {% endif %}
+
+                {% if data['chart']: %}
+                <div class="repartition">
+                    <p class="repartition-especes">Répartition des espèces</p>
+                    <img
+                        class="taxons"
+                        src="{{url_for('static', filename='images/taxa.png')}}"
+                        alt="Pas d'espèces à afficher."
+                    >
+                </div>
+                {% endif %}
+
+                {% if not (data.datasets and data.datasets[3]) : %}
+                <div class="jdd">
+                    <hr
+                        class="ligne-jeux-donnees ligne"
+                        {% if data.css: %}
+                        id="ligne-jeux-donnees-{{data.css['entite']}}"
+                        {% else %}
+                        id="ligne-jeux-donnees-defaut"
+                        {% endif %}
+                    >
+                    <p class="liste-jdd">Liste des jeux de données associés au cadre</p>
+                    {% if data.datasets: %}
+                    {% for dataset in data.datasets -%}
+                    <div class="jdd-details">
+                        <img
+                            class="logo-jdd"
+                            src="{{url_for('static', filename='images/Taxon_icon_vert.svg')}}"
+                            alt="taxon-vert-icon"
+                        >
+                        <p class="jdd-info">
+                            {% if dataset['unique_dataset_id']: %}
+                            {{ dataset['unique_dataset_id'] }}
+                            {% endif %}
+                            <br>
+                            {% if dataset['dataset_name']: %}
+                            {{ dataset['dataset_name'] }}
+                            {% endif %}
+                        </p>
+                    </div>
+                    {%- endfor %}
+                    {% endif %}
+                </div>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="footer">
+            <a
+                target="_blank"
+                href="{{data.footer['url']}}"
+            >{{data.footer['url']}}</a>
+            <span>{{data.footer['date']}}</span>
+        </div>
+
+        {% if (data.cor_af_actor and data.cor_af_actor[5]) or (data.datasets and data.datasets[3]) : %}
+        <br />
+        <div class="description" style="transform: translateY(40px);">
+            {% if data.cor_af_actor and data.cor_af_actor[5] : %}
+            <div class="left-block">
+                <br>
                 <div class="information">
                     <p class="info-titre">Acteurs</p>
                     <p class="info-contenu">
@@ -243,7 +351,6 @@
                         {%- endfor %}
                     </p>
                 </div>
-                {% endif %}
 
                 {% if data['keywords']: %}
                 <div class="information">
@@ -253,37 +360,15 @@
                     </p>
                 </div>
                 {% endif %}
-
             </div>
+            {% endif %}
+
+            {% if data.datasets and data.datasets[3] : %}
+            {% if not(data.cor_af_actor and data.cor_af_actor[5]) : %}
+            <div class="left-block" style="border: none;">
+            </div>
+            {% endif %}
             <div class="right-block">
-
-                {% if data['chart']: %}
-                <div class="zone">
-                    <p class="zone-geographique">Zone géographique</p>
-                    <img
-                        class="taxons"
-                        src="{{url_for('static', filename='images/map.svg')}}"
-                        alt="Pas d'observations à afficher."
-                    >
-                </div>
-                {% endif %}
-                <!-- <div class="zone">
-                <p class="zone-geographique">Zone géographique</p>
-            </div> -->
-                <!-- A modifier lorsque la carte sera prete -->
-
-                {% if data['chart']: %}
-                <div class="repartition">
-                    <p class="repartition-especes">Répartition des espèces</p>
-                    <img
-                        class="taxons"
-                        src="{{url_for('static', filename='images/taxa.png')}}"
-                        alt="Pas d'espèces à afficher."
-                    >
-                </div>
-                {% endif %}
-
-                {% if data.datasets: %}
                 <div class="jdd">
                     <hr
                         class="ligne-jeux-donnees ligne"
@@ -294,6 +379,7 @@
                         {% endif %}
                     >
                     <p class="liste-jdd">Liste des jeux de données associés au cadre</p>
+                    {% if data.datasets: %}
                     {% for dataset in data.datasets -%}
                     <div class="jdd-details">
                         <img
@@ -312,17 +398,12 @@
                         </p>
                     </div>
                     {%- endfor %}
+                    {% endif %}
                 </div>
-                {% endif %}
             </div>
-
-            <div class="footer">
-                <a
-                    target="_blank"
-                    href="{{data.footer['url']}}"
-                >{{data.footer['url']}}</a>
-                <span>{{data.footer['date']}}</span>
-            </div>
+            {% endif %}
+        </div>
+        {% endif %}
     </body>
 
 </html>

--- a/backend/geonature/templates/acquisition_framework_template_pdf.html
+++ b/backend/geonature/templates/acquisition_framework_template_pdf.html
@@ -257,6 +257,16 @@
             </div>
             <div class="right-block">
 
+                {% if data['chart']: %}
+                <div class="zone">
+                    <p class="zone-geographique">Zone géographique</p>
+                    <img
+                        class="taxons"
+                        src="{{url_for('static', filename='images/map.svg')}}"
+                        alt="Pas d'observations à afficher."
+                    >
+                </div>
+                {% endif %}
                 <!-- <div class="zone">
                 <p class="zone-geographique">Zone géographique</p>
             </div> -->
@@ -267,7 +277,7 @@
                     <p class="repartition-especes">Répartition des espèces</p>
                     <img
                         class="taxons"
-                        src="{{url_for('static', filename='images/taxa.svg')}}"
+                        src="{{url_for('static', filename='images/taxa.png')}}"
                         alt="Pas d'espèces à afficher."
                     >
                 </div>

--- a/backend/geonature/templates/dataset_template_pdf.html
+++ b/backend/geonature/templates/dataset_template_pdf.html
@@ -200,6 +200,16 @@
         class="right-block"
         style="display:grid"
       >
+        {% if data['chart']: %}
+        <div class="zone">
+          <p class="zone-geographique">Zone géographique</p>
+          <img
+            class="taxons"
+            src="{{url_for('static', filename='images/map.svg')}}"
+            alt="Pas d'observations à afficher."
+          >
+        </div>
+        {% endif %}
         <!-- <div class="zone">
                     <p class="zone-geographique">Zone géographique</p>
                     <div class="map"></div>

--- a/backend/geonature/templates/dataset_template_pdf.html
+++ b/backend/geonature/templates/dataset_template_pdf.html
@@ -190,17 +190,14 @@
           </p>
         </div>
         {% endif %}
-
-      </div>
-
       {% endif %}
-
+      </div>
 
       <div
         class="right-block"
         style="display:grid"
       >
-        {% if data['chart']: %}
+        {% if data['map']: %}
         <div class="zone">
           <p class="zone-geographique">Zone géographique</p>
           <img
@@ -210,11 +207,6 @@
           >
         </div>
         {% endif %}
-        <!-- <div class="zone">
-                    <p class="zone-geographique">Zone géographique</p>
-                    <div class="map"></div>
-                </div> -->
-        <!-- A modifier lorsque la carte sera prete -->
 
         {% if data['chart']: %}
         <div class="repartition">

--- a/backend/geonature/templates/dataset_template_pdf.html
+++ b/backend/geonature/templates/dataset_template_pdf.html
@@ -202,7 +202,7 @@
           <p class="zone-geographique">Zone géographique</p>
           <img
             class="taxons"
-            src="{{url_for('static', filename='images/map.svg')}}"
+            src="data:image/jpeg;base64,{{ data['map'] | safe }}"
             alt="Pas d'observations à afficher."
           >
         </div>
@@ -213,7 +213,7 @@
           <p class="repartition-especes">Répartition des espèces</p>
           <img
             class="taxons"
-            src="{{url_for('static', filename='images/taxa.png')}}"
+            src="data:image/jpeg;base64,{{ data['chart'] | safe }}"
             alt="Pas d'espèces à afficher."
           >
         </div>

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -430,9 +430,6 @@ export class DataFormService {
     );
   }
 
-  uploadCanvas(img: any) {
-    return this._http.post<any>(`${AppConfig.API_ENDPOINT}/meta/upload_canvas`, img);
-  }
   getTaxaDistribution(taxa_rank, params?: ParamsDict) {
     let queryString = new HttpParams();
     queryString = queryString.set('taxa_rank', taxa_rank);

--- a/frontend/src/app/metadataModule/af/af-card.component.ts
+++ b/frontend/src/app/metadataModule/af/af-card.component.ts
@@ -105,9 +105,6 @@ export class AfCardComponent implements OnInit {
     const url = `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks/export_pdf/${
       this.af.id_acquisition_framework
     }`;
-    const chart_img = this.chart ? this.chart.ctx.canvas.toDataURL('image/png') : '';
-    this._dfs.uploadCanvas(chart_img).subscribe(data => {
-      window.open(url);
-    });
+    window.open(url);
   }
 }

--- a/frontend/src/app/metadataModule/datasets/dataset-card.component.ts
+++ b/frontend/src/app/metadataModule/datasets/dataset-card.component.ts
@@ -137,12 +137,7 @@ export class DatasetCardComponent implements OnInit {
 
   getPdf() {
     const url = `${AppConfig.API_ENDPOINT}/meta/dataset/export_pdf/${this.id_dataset}`;
-    const dataUrl = this.chart ? this.chart.ctx.canvas.toDataURL('image/png') : '';
-    this._dfs.uploadCanvas(dataUrl).subscribe(data => {
-      console.log(url);
-
-      window.open(url);
-    });
+    window.open(url);
   }
 
   uuidReportImport(id_import) {


### PR DESCRIPTION
Cette PR fait suite à une demande de Théo non associée à un ticket, dans laquelle la gestion du graphique de répartition taxonomique dans les PDF d'export pouvait poser problème (graphique enregistré sous un nom générique, jamais supprimé, et on vérifiait juste l'existence du fichier pour en déduire qu'il avait bien été généré), et accessoirement d'afficher la carte de répartition taxonomique sur les PDF.

Pour résoudre cela, j'ai créé les graphiques entièrement en backend (matplotlib+staticmaps), ajouté des arguments conditionnels aux routes de la synthèse pour y accéder depuis le back, sauvegardé les graphiques ainsi générés, puis les ai supprimés une fois le PDF formé. J'ai également réglé des soucis dans les PDF, notamment la pagination qui était cassée dans celui des JDD, et absente dans celui des cadres d'acquisition, ou encore le footer qui n'apparaissait pas sur le document des cadres.