### PR TITLE
fix : affichage boutons d'actions occtax

### DIFF
--- a/contrib/occtax/frontend/app/occtax-form/taxa-list/taxa-list.component.html
+++ b/contrib/occtax/frontend/app/occtax-form/taxa-list/taxa-list.component.html
@@ -42,18 +42,9 @@
           selector=".btn-actions"
         >
           <mat-expansion-panel-header class="right-aligned-header">
+            
             <mat-panel-title>
-
-              <span
-                [innerHTML]="taxonTitle(occurrence)"
-                [matTooltip]="occurrence.taxref?.nom_valide || removeHtml(occurrence.nom_cite)"
-                class="header-title"
-              >
-              </span>
-
-            </mat-panel-title>
-            <mat-panel-description>
-              <span class="btn-actions d-none">
+             <span class="btn-actions d-none">
                 <button
                   mat-icon-button
                   class="btn-edit"
@@ -76,7 +67,17 @@
                   >clear</mat-icon>
                 </button>
               </span>
+            </mat-panel-title>
+            
+            <mat-panel-description>
+              <span
+                [innerHTML]="taxonTitle(occurrence)"
+                [matTooltip]="occurrence.taxref?.nom_valide || removeHtml(occurrence.nom_cite)"
+                class="header-title"
+              >
+              </span> 
             </mat-panel-description>
+            
           </mat-expansion-panel-header>
 
 


### PR DESCRIPTION
Inversion _title_ et _description_ dans la taxa-list pour s'assurer que les boutons d'actions sont toujours visibles (bug d'affichage sur les petits écran et/ou nom trop long).
Le nom du taxon est tronqué si nécessaire (visible en déroulant)

![image](https://user-images.githubusercontent.com/6163107/114849627-39a0b280-9de0-11eb-8c6f-2903853267a8.png)
#1299 #1337 