### PR TITLE
corrige le nombre de ligne affichée sur releve map-list apres recherche

### DIFF
--- a/contrib/occtax/frontend/app/occtax-map-list/filter/occtax-map-list-filter.component.ts
+++ b/contrib/occtax/frontend/app/occtax-map-list/filter/occtax-map-list-filter.component.ts
@@ -39,7 +39,7 @@ export class OcctaxMapListFilterComponent implements OnInit {
 
   searchData() {
     this.mapListService.zoomOnLayer = true;
-    this.mapListService.refreshUrlQuery(12);
+    this.mapListService.refreshUrlQuery(this.mapListService.rowPerPage);
     const params = [];
     for (let key in this.occtaxMapListService.dynamicFormGroup.value) {
       let value = this.occtaxMapListService.dynamicFormGroup.value[key];

--- a/contrib/occtax/frontend/app/occtax-map-list/filter/occtax-map-list-filter.component.ts
+++ b/contrib/occtax/frontend/app/occtax-map-list/filter/occtax-map-list-filter.component.ts
@@ -39,7 +39,7 @@ export class OcctaxMapListFilterComponent implements OnInit {
 
   searchData() {
     this.mapListService.zoomOnLayer = true;
-    this.mapListService.refreshUrlQuery(this.mapListService.rowPerPage);
+    this.mapListService.refreshUrlQuery(this.occtaxMapListService.rowPerPage);
     const params = [];
     for (let key in this.occtaxMapListService.dynamicFormGroup.value) {
       let value = this.occtaxMapListService.dynamicFormGroup.value[key];

--- a/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.html
+++ b/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.html
@@ -72,7 +72,7 @@
           [externalSorting]="true"
           [footerHeight]="40"
           [headerHeight]="35"
-          [limit]="mapListService.rowPerPage"
+          [limit]="occtaxMapListS.rowPerPage"
           [loadingIndicator]="mapListService.isLoading"
           [messages]="occtaxConfig.list_messages"
           [offset]="mapListService.page.pageNumber"

--- a/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.html
+++ b/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.html
@@ -50,7 +50,7 @@
       >
         <!-- MAP -->
         <pnx-map-list
-          [idName]="idName"
+          [idName]="mapListService.idName"
           height="100%"
         >
         </pnx-map-list>
@@ -72,7 +72,7 @@
           [externalSorting]="true"
           [footerHeight]="40"
           [headerHeight]="35"
-          [limit]="rowPerPage"
+          [limit]="mapListService.rowPerPage"
           [loadingIndicator]="mapListService.isLoading"
           [messages]="occtaxConfig.list_messages"
           [offset]="mapListService.page.pageNumber"

--- a/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.ts
+++ b/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.ts
@@ -26,6 +26,7 @@ import { MediaService } from '@geonature_common/service/media.service';
 import { OcctaxFormReleveService } from "../occtax-form/releve/releve.service";
 import { OcctaxFormOccurrenceService } from "../occtax-form/occurrence/occurrence.service";
 import { OcctaxFormService } from "../occtax-form/occtax-form.service";
+import { OcctaxMapListService } from "./occtax-map-list.service";
 
 // /occurrence/occurrence.service";
 
@@ -71,7 +72,8 @@ export class OcctaxMapListComponent
     public mediaService: MediaService,
     private _releveFormService: OcctaxFormReleveService,
     private _occurrenceFormService: OcctaxFormOccurrenceService,
-    private _occtaxFormService: OcctaxFormService
+    private _occtaxFormService: OcctaxFormService,
+    private occtaxMapListS: OcctaxMapListService
 
   ) { }
 
@@ -104,7 +106,7 @@ export class OcctaxMapListComponent
     this.calculateNbRow();
     this.mapListService.getData(
       this.apiEndPoint,
-      [{ param: "limit", value: this.mapListService.rowPerPage }],
+      [{ param: "limit", value: this.occtaxMapListS.rowPerPage }],
       this.displayLeafletPopupCallback.bind(this) //afin que le this présent dans displayLeafletPopupCallback soit ce component.
     );
     // end OnInit
@@ -133,7 +135,7 @@ export class OcctaxMapListComponent
   calculateNbRow() {
     let wH = window.innerHeight;
     let listHeight = wH - 64 - 150;
-    this.mapListService.rowPerPage = Math.round(listHeight / 40);
+    this.occtaxMapListS.rowPerPage = Math.round(listHeight / 40);
   }
 
   refreshForms() {

--- a/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.ts
+++ b/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.ts
@@ -42,7 +42,6 @@ export class OcctaxMapListComponent
   public availableColumns: Array<any>;
   public pathEdit: string;
   public pathInfo: string;
-  public idName: string;
   public apiEndPoint: string;
   public occtaxConfig: any;
   // public formsDefinition = FILTERSLIST;
@@ -50,7 +49,6 @@ export class OcctaxMapListComponent
   public formsSelected = [];
   public moduleSub: Subscription;
   public cardContentHeight: number;
-  public rowPerPage: number;
 
   advandedFilterOpen = false;
   @ViewChild(NgbModal)
@@ -83,7 +81,7 @@ export class OcctaxMapListComponent
     this.mapListService.zoomOnLayer = true;
     //config
     this.occtaxConfig = ModuleConfig;
-    this.idName = "id_releve_occtax";
+    this.mapListService.idName = "id_releve_occtax";
     this.apiEndPoint = "occtax/releves";
     // refresh forms
     this.refreshForms();
@@ -101,13 +99,12 @@ export class OcctaxMapListComponent
     // columns available for display
     this.mapListService.availableColumns = this.occtaxConfig.available_maplist_column;
 
-    this.mapListService.idName = this.idName;
     // FETCH THE DATA
     this.mapListService.refreshUrlQuery();
     this.calculateNbRow();
     this.mapListService.getData(
       this.apiEndPoint,
-      [{ param: "limit", value: this.rowPerPage }],
+      [{ param: "limit", value: this.mapListService.rowPerPage }],
       this.displayLeafletPopupCallback.bind(this) //afin que le this présent dans displayLeafletPopupCallback soit ce component.
     );
     // end OnInit
@@ -136,7 +133,7 @@ export class OcctaxMapListComponent
   calculateNbRow() {
     let wH = window.innerHeight;
     let listHeight = wH - 64 - 150;
-    this.rowPerPage = Math.round(listHeight / 40);
+    this.mapListService.rowPerPage = Math.round(listHeight / 40);
   }
 
   refreshForms() {

--- a/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.service.ts
+++ b/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.service.ts
@@ -4,6 +4,7 @@ import { FormGroup, FormBuilder } from "@angular/forms";
 @Injectable({ providedIn: 'root' })
 export class OcctaxMapListService {
     public dynamicFormGroup: FormGroup;
+    public rowPerPage: number;
 
     constructor(private _fb: FormBuilder) {
         this.dynamicFormGroup = this._fb.group({


### PR DESCRIPTION
Il y avait un problème d'affichage sur le MapList d'occtax. Le nombre de ligne du tableau est déterminé par la taille de l'écran, mais lors d'une recherche 12 résultats étaient imposé. Si l'écran ne pouvait afficher que 10 lignes il y avait des données qui ne pouvaient être visualisés.