### PR TITLE
feat/fix-install-module

### DIFF
--- a/backend/geonature/utils/gn_module_import.py
+++ b/backend/geonature/utils/gn_module_import.py
@@ -298,11 +298,8 @@ def install_frontend_dependencies(module_path):
     if (frontend_module_path / "package.json").is_file():
         try:
             # To avoid Maximum call stack size exceeded on npm install - clear cache...
-            assert (
-                subprocess.call(
-                    ["/bin/bash", "-i", "-c", "nvm use"], cwd=str(ROOT_DIR / "frontend")
-                )
-                == 0
+            subprocess.call(
+                ["/bin/bash", "-i", "-c", "nvm use"], cwd=str(ROOT_DIR / "frontend")
             )
             assert (
                 subprocess.call(

--- a/backend/geonature/utils/module.py
+++ b/backend/geonature/utils/module.py
@@ -17,14 +17,14 @@ class NoManifestFound(Exception):
 def import_legacy_module(module_object):
     sys.path.insert(0, str(GN_EXTERNAL_MODULE))  # to be able to import non-packaged modules
     try:
-        module_dir = GN_EXTERNAL_MODULE / module_object.module_path
+        # module dist is module_code.lower() because the symlink is created like this
+        # in utils.gn_module_import.copy_in_external_mods
+        module_dist = module_object.module_code.lower()
+        module_dir = GN_EXTERNAL_MODULE / module_dist
         manifest_path = module_dir / 'manifest.toml'
         if not manifest_path.is_file():
             raise NoManifestFound()
         module_manifest = load_and_validate_toml(manifest_path, ManifestSchemaProdConf)
-        # module dist is module_code.lower() because the symlink is created like this
-        # in utils.gn_module_import.copy_in_external_mods
-        module_dist = module_object.module_code.lower()
         module_blueprint = import_module(f'{module_dist}.backend.blueprint').blueprint
         module_config = {
             'ID_MODULE': module_object.id_module,


### PR DESCRIPTION
Change deux choses

pour l'installation des dependance js plus de assert sur la commande nvm use (je ne sais pas si ça vient de mon installation)

changement de module_path en module_dist (=module_code.lower()) pour l'installation des modules legacy 