### PR TITLE
[Metadata] - Petites corrections au niveau des forms acteurs

### DIFF
--- a/frontend/src/app/metadataModule/af/af-form.component.html
+++ b/frontend/src/app/metadataModule/af/af-form.component.html
@@ -265,17 +265,17 @@
               (actorFormRemove)="afFormS.removeActor(afFormS.actors, idx)"
               [defaultTab]="afFormS.acquisition_framework?.value?.id_acquisition_framework ? 'all': 'organism'"            >
             </pnx-metadata-actor>
-            <button
-              class="mt-2 float-right"
-              type="button"
-              mat-mini-fab
-              color="primary"
-              matTooltip="Ajouter un autre contact principal"
-              (click)="addContact(afFormS.actors, true)"
-            >
-              <mat-icon>add</mat-icon>
-            </button>
           </ng-container>
+          <button
+            class="mt-2 float-right"
+            type="button"
+            mat-mini-fab
+            color="primary"
+            matTooltip="Ajouter un autre contact principal"
+            (click)="addContact(afFormS.actors, true)"
+          >
+            <mat-icon>add</mat-icon>
+          </button>
           <ng-container *ngIf="form.get('cor_af_actor').invalid && form.get('cor_af_actor').errors?.mainContactRequired">
             <small
               class="mat-error">
@@ -290,12 +290,13 @@
           <h3 class="main-color"> Autre(s) acteur(s) </h3>
         </div>
         <div class="card-body">
-          <ng-container *ngFor="let actorForm of afFormS.genericActorsForm.controls; let idx = index"> 
+          <ng-container *ngFor="let actorForm of afFormS.actors.controls; let idx = index"> 
 
           <pnx-metadata-actor
-            [actorForm]="genericActorForm"
+            *ngIf="!afFormS.isMainContact(actorForm)"
+            [actorForm]="actorForm"
             metadataType="af"
-            (actorFormRemove)="afFormS.removeActor(afFormS.genericActorsForm, idx)"
+            (actorFormRemove)="afFormS.removeActor(afFormS.actors, idx)"
             [defaultTab]="afFormS.acquisition_framework?.value?.id_acquisition_framework ? 'all': 'organism'"
           >
           </pnx-metadata-actor>
@@ -308,7 +309,7 @@
           mat-mini-fab
           color="primary"
           matTooltip="Ajouter un autre acteur"
-          (click)="addContact(afFormS.genericActorsForm, false)"
+          (click)="addContact(afFormS.actors, false)"
         >
           <mat-icon>add</mat-icon>
         </button>

--- a/frontend/src/app/metadataModule/af/af-form.component.html
+++ b/frontend/src/app/metadataModule/af/af-form.component.html
@@ -263,7 +263,8 @@
               [isRemovable]="idx != 0"
               metadataType="af"
               (actorFormRemove)="afFormS.removeActor(afFormS.actors, idx)"
-              [defaultTab]="afFormS.acquisition_framework?.value?.id_acquisition_framework ? 'all': 'organism'"            >
+              [defaultTab]="(afFormS.acquisition_framework | async)?.id_acquisition_framework ? 'all': 'organism'"
+            >
             </pnx-metadata-actor>
           </ng-container>
           <button
@@ -297,7 +298,7 @@
             [actorForm]="actorForm"
             metadataType="af"
             (actorFormRemove)="afFormS.removeActor(afFormS.actors, idx)"
-            [defaultTab]="afFormS.acquisition_framework?.value?.id_acquisition_framework ? 'all': 'organism'"
+            [defaultTab]="(afFormS.acquisition_framework | async)?.id_acquisition_framework ? 'all': 'organism'"
           >
           </pnx-metadata-actor>
 

--- a/frontend/src/app/metadataModule/af/af-form.component.ts
+++ b/frontend/src/app/metadataModule/af/af-form.component.ts
@@ -24,7 +24,6 @@ import { MetadataDataService } from '../services/metadata-data.service';
 export class AfFormComponent implements OnInit {
 
   public form: FormGroup;
-  public genericActorForm: FormGroup = this.actorFormS.createForm();
   //observable pour la liste déroulantes HTML des AF parents
   public acquisitionFrameworkParents: Observable<any>;
 

--- a/frontend/src/app/metadataModule/af/af-form.component.ts
+++ b/frontend/src/app/metadataModule/af/af-form.component.ts
@@ -87,7 +87,6 @@ export class AfFormComponent implements OnInit {
     )
   }
 
-
   postAf() {
     if (!this.form.valid)
       return;

--- a/frontend/src/app/metadataModule/datasets/dataset-form.component.html
+++ b/frontend/src/app/metadataModule/datasets/dataset-form.component.html
@@ -248,7 +248,7 @@
               [isRemovable]="idx != 0"
               metadataType="dataset"
               (actorFormRemove)="datasetFormS.removeActor(datasetFormS.actors, idx)"
-              [defaultTab]="datasetFormS.dataset?.value?.id_dataset ? 'all': 'organism'"
+              [defaultTab]="(datasetFormS.dataset | async)?.id_dataset ? 'all': 'organism'"
             >
             </pnx-metadata-actor>
           </ng-container>
@@ -276,7 +276,7 @@
             [actorForm]="actorForm"
             metadataType="dataset"
             (actorFormRemove)="datasetFormS.removeActor(datasetFormS.genericActorForm, idx)"
-            [defaultTab]="datasetFormS.dataset?.value?.id_dataset ? 'all': 'organism'"
+            [defaultTab]="(datasetFormS.dataset | async)?.id_dataset ? 'all': 'organism'"
             >
             </pnx-metadata-actor>
           </ng-container>

--- a/frontend/src/app/metadataModule/services/af-form.service.ts
+++ b/frontend/src/app/metadataModule/services/af-form.service.ts
@@ -11,7 +11,6 @@ export class AcquisitionFrameworkFormService {
  
   public form: FormGroup;
   public acquisition_framework: BehaviorSubject<any> = new BehaviorSubject(null);
-  public genericActorsForm: FormArray; 
  
   constructor(
     private fb: FormBuilder, 
@@ -69,7 +68,6 @@ export class AcquisitionFrameworkFormService {
       ]),
       bibliographical_references: this.fb.array([]),
     });
-    this.genericActorsForm = this.fb.array([]);
  
     this.form.setValidators([
       this.formS.dateValidator(
@@ -113,10 +111,6 @@ export class AcquisitionFrameworkFormService {
           this.form.get('acquisition_framework_parent_id').disable();
         }
       });
- 
-    //gère la separation des acteurs selon le type de role de chacun d'eux
-    this.actors.valueChanges
-      .subscribe(form => this.setOtherActorGroupForms());
   }
  
   get actors(): FormArray {
@@ -157,18 +151,6 @@ export class AcquisitionFrameworkFormService {
   //retourne true sur l'acteur est contact principal
   isMainContact(actorForm) {
     return actorForm.get('id_nomenclature_actor_role').value == this.actorFormS.getIDRoleTypeByCdNomenclature("1")
-  }
- 
-  setOtherActorGroupForms(): void {
-    for (let i = 0; i < this.actors.controls.length; i++) {
-      const actorControl = this.actors.controls[i]
-      const role_type = this.actorFormS.getRoleTypeByID(actorControl.get('id_nomenclature_actor_role').value);
- 
-      if (role_type !== undefined && !this.isMainContact(actorControl)) {
-        this.actors.removeAt(i);
-        this.genericActorsForm.push(actorControl);
-      }
-    }
   }
  
   reset() {


### PR DESCRIPTION
Pour corriger l'affichage des autres acteurs qui ne s'affichaient pas pour le cadre d'acquisition.
Reprend aussi la gestion des onglets des acteurs selon si c'est une création ou une modification.

Remarque au passage, il est actuellement possible de saisir plusieurs contacts principaux au niveau du cadre d'acquisition. Hors sur le format 1.3.10 ce n'est pas la lecture que j'en fait où la multiplicité n'est pas indiquée en 0..*. En fait la multiplicité n'est pas renseignée...