### PR TITLE
filtre avancé "type d'information géographique"

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/synthese-form/dynamycFormConfig.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/dynamycFormConfig.ts
@@ -194,7 +194,7 @@ export const DYNAMIC_FORM_DEF = [
   {
     type_widget: 'nomenclature',
     attribut_label: "Type d'information géographique",
-    attribut_name: 'id_nomenclature_sensitivity',
+    attribut_name: 'id_nomenclature_info_geo_type',
     code_nomenclature_type: 'TYP_INF_GEO',
     required: false,
     multi_select: true


### PR DESCRIPTION
Le filtre avancé "Type d'information géographique" ne fonctionnait pas avec la web app.
Quid de renommer ce fichier  dynamyc -> dynamic  par la même occasion ?