### PR TITLE
feat(synthese): id_source in taxa_distribution

### DIFF
--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -905,6 +905,7 @@ def get_taxa_distribution():
 
     id_dataset = request.args.get("id_dataset")
     id_af = request.args.get("id_af")
+    id_source = request.args.get("id_source")
 
     rank = request.args.get("taxa_rank")
     if not rank:
@@ -927,6 +928,8 @@ def get_taxa_distribution():
         query = query.outerjoin(TDatasets, TDatasets.id_dataset == Synthese.id_dataset).filter(
             TDatasets.id_acquisition_framework == id_af
         )
+    elif id_source is not None:
+        query = query.filter(Synthese.id_source == id_source)
 
     data = query.group_by(rank).all()
     return [{"count": d[0], "group": d[1]} for d in data]

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -928,7 +928,8 @@ def get_taxa_distribution():
         query = query.outerjoin(TDatasets, TDatasets.id_dataset == Synthese.id_dataset).filter(
             TDatasets.id_acquisition_framework == id_af
         )
-    elif id_source is not None:
+    # User can add id_source filter along with id_dataset or id_af
+    if id_source is not None:
         query = query.filter(Synthese.id_source == id_source)
 
     data = query.group_by(rank).all()


### PR DESCRIPTION
## Objectif
Permettre l'utilisation de l'`id_source` sur la route `taxa_distribution` de la synthèse.
Pour le moment il ne peut être utilisé avec `id_dataset` et `id_af`. A discuter dans #1446

Permet aussi de répondre à https://github.com/PnX-SI/gn_module_import/issues/221

Closes #1446