### PR TITLE
Fix frontend

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.html
+++ b/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.html
@@ -8,6 +8,7 @@
 	[placeholder]="placeholder||label"
 	[virtualScroll]="true"
 	[formControl]="parentFormControl"
+  appendTo="body"
 >
 	<ng-template 
     ng-option-tmp 

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.ts
@@ -31,7 +31,7 @@ export class TaxonSheetComponent implements OnInit {
                             taxonAttrAndMedias => {
                                 const media = taxonAttrAndMedias.medias.find(m => m.id_type == AppConfig.TAXHUB.ID_TYPE_MAIN_PHOTO);
                                 if(media) {
-                                    this.mediaUrl = `${AppConfig.API_TAXHUB}tmedias/thumbnail/${media.id_media}?h=300&w300`;
+                                    this.mediaUrl = `${AppConfig.API_TAXHUB}/tmedias/thumbnail/${media.id_media}?h=300&w300`;
                                 }
 
                             }


### PR DESCRIPTION
FIx deux bug de la 2.9 : 
- mauvaise URL de Taxhub (slash final manquant) sur le fiche profil
- masquage des liste déroulante des ng-select dans un bloc à longueur/largeur fixe (fix en utilisant `appendTo="body"`)