### PR TITLE
remove CRUVED_SEARCH_WITH_OBSERVER_AS_TXT

### DIFF
--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -138,11 +138,6 @@ class SyntheseQuery:
                 self.model_id_syn_col.in_(subquery_observers),
                 self.model_id_digitiser_column == user.id_role,
             ]
-            if current_app.config["SYNTHESE"]["CRUVED_SEARCH_WITH_OBSERVER_AS_TXT"]:
-                user_fullname1 = user.nom_role + " " + user.prenom_role + "%"
-                user_fullname2 = user.prenom_role + " " + user.nom_role + "%"
-                ors_filters.append(self.model_observers_column.ilike(user_fullname1))
-                ors_filters.append(self.model_observers_column.ilike(user_fullname2))
 
             allowed_datasets = [d.id_dataset for d in TDatasets.query.filter_by_scope(scope).all()]
             ors_filters.append(self.model_id_dataset_column.in_(allowed_datasets))

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -270,8 +270,6 @@ class Synthese(Schema):
     EXCLUDED_COLUMNS = fields.List(fields.String(), load_default=[])
     # Afficher ou non l'arbre taxonomique
     DISPLAY_TAXON_TREE = fields.Boolean(load_default=True)
-    # rajoute le filtre sur l'observers_txt en ILIKE sur les portée 1 et 2 du CRUVED
-    CRUVED_SEARCH_WITH_OBSERVER_AS_TXT = fields.Boolean(load_default=False)
     # Switch the observer form input in free text input (true) or in select input (false)
     SEARCH_OBSERVER_WITH_LIST = fields.Boolean(load_default=False)
     # id of the observer list -- utilisateurs.t_menus

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -265,10 +265,6 @@ MAIL_ON_ERROR = false
     # Passer à 'false' si le temps de chargement est trop long.
     DISPLAY_TAXON_TREE = true
 
-    # Active (=true) ou pas (=false) le fait de rechercher sur le nom d'observateur
-    # en 'ILIKE' sur les portées 1 et 2 du CRUVED
-    CRUVED_SEARCH_WITH_OBSERVER_AS_TXT = false
-
     # Switch the observer form input in free text input (false by default) or in select input (true)
     SEARCH_OBSERVER_WITH_LIST = false
     # id of the observer list -- utilisateurs.t_menus


### PR DESCRIPTION
Si on veut garder cette option, il faudrait l’implémenter également dans has_instance_permission du modèle Synthese.

Mais je propose plutôt de virer cette option qui est à priori inutile.
Les observateurs textuels permettent de saisir des observateurs n’ayant pas de compte, mais comme ces derniers n’ont pas de compte, ils ne se connectent pas pour voir leur observation, et donc ce filtre est inutile.