### PR TITLE
Style/home responsive

### DIFF
--- a/frontend/src/app/components/home-content/home-content.component.html
+++ b/frontend/src/app/components/home-content/home-content.component.html
@@ -9,17 +9,21 @@
       *ngIf="showLastObsMap"
     >
       <div class="panel panel-default">
-        <div class="panel-heading">
-          Les 100 dernières observations
-          <button 
-            routerLink="/synthese"
-            mat-stroked-button
-            color="primary"
-            class="uppercase ml-1 mt-1 float-right"
-    
-          >
-            Explorer les données
-          </button>
+        <!-- mr-0 and ml-0 since row puts margin-left and right at -15px... -->
+        <div class="panel-heading row mr-0 ml-0">
+          <div class="col-12 col-lg-5 col-xl-7">
+            <span>Les 100 dernières observations</span>
+          </div>
+          <div class="col-12 col-lg-7 col-xl-5">
+            <button
+              routerLink="/synthese"
+              mat-stroked-button
+              color="primary"
+              class="uppercase ml-1 mt-1 float-right"
+            >
+              Explorer les données
+            </button>
+          </div>
        </div>
       
         <div id="map-title">


### PR DESCRIPTION
## Objectif
Rendre le bloc de droite et plus précisément le bloc (X dernières observations et Explorer les données) plus responsive.

Closes #1682

## Captures
![image](https://user-images.githubusercontent.com/85738261/153462334-07d289f4-27b0-4560-bf0c-ec20ca2380dc.png)
![image](https://user-images.githubusercontent.com/85738261/153462370-1539d02d-543d-488b-ac7f-65b3a2a07085.png)
![image](https://user-images.githubusercontent.com/85738261/153462400-bfd9ec3d-d91a-465e-98fb-85cec141fcf7.png)
![image](https://user-images.githubusercontent.com/85738261/153462418-ffa4a77d-fd47-4c29-958d-1d253d44b8c0.png)
![image](https://user-images.githubusercontent.com/85738261/153462451-eaeda6e4-c469-4ffa-b667-70dad8d2dd92.png)

