### PR TITLE
#1701 fix taxhub habitat list display

### DIFF
--- a/contrib/occtax/frontend/app/occtax-form/releve/releve.component.scss
+++ b/contrib/occtax/frontend/app/occtax-form/releve/releve.component.scss
@@ -51,3 +51,13 @@ button .mat-spinner {
   background-color: #ddd;
   cursor: not-allowed;
 }
+
+:host ::ng-deep ngb-typeahead-window  {
+  width: 100%;
+  overflow: auto;
+  max-height: 300px;
+}
+
+::ng-deep .dropdown-item {
+  white-space: inherit;
+}


### PR DESCRIPTION
Link #1701 
Change le CSS de l'auto-complétions à la saisie de l'habitat d'une observation pour afficher la liste de valeurs avec l'intégralité des informations.

Testé sur écrans > = 15''.

![issue1701](https://user-images.githubusercontent.com/16317988/153602624-3bf3db35-2eb3-466d-aca1-8bfa26fd2928.gif)
