### PR TITLE
feat/config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ backend/run.py
 *.pem
 *.ipynb
 
-tsconfig.json
 .angulardoc.json
 Pipfile.lock
 

--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,8 @@ install_all/install_all.log
 .idea/
 
 backend/static/images/taxa.png
+backend/static/assets/custom/*
+!backend/static/assets/custom/.gitkeep
 
 *.swp
 *.swo

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 settings.ini
 config/geonature_config.toml
 
+frontend/src/assets/config.json
+
 **/conf_gn_module.toml
 **/module.config.ts
 

--- a/backend/geonature/core/command/main.py
+++ b/backend/geonature/core/command/main.py
@@ -89,8 +89,9 @@ def generate_frontend_config(build):
 @main.command()
 @click.option("--host", default="0.0.0.0")
 @click.option("--port", default=8000)
+@click.option("--extra-files", default="")
 @click.pass_context
-def dev_back(ctx, host, port):
+def dev_back(ctx, host, port, extra_files):
     """
         Lance l'api du backend avec flask
 
@@ -102,7 +103,7 @@ def dev_back(ctx, host, port):
     """
     if not environ.get('FLASK_ENV'):
         environ['FLASK_ENV'] = 'development'
-    ctx.invoke(run_command, host=host, port=port)
+    ctx.invoke(run_command, host=host, port=port, extra_files=extra_files.split(','))
 
 
 @main.command()

--- a/backend/geonature/core/command/main.py
+++ b/backend/geonature/core/command/main.py
@@ -3,13 +3,13 @@
 """
 
 import logging
-from os import environ
+from os import environ, path
 from collections import ChainMap, deque
 from io import StringIO
 
 import toml
 import click
-from flask.cli import run_command
+from flask.cli import run_command, SeparatedPathType
 import flask_migrate
 import alembic
 from alembic.migration import MigrationContext
@@ -89,7 +89,14 @@ def generate_frontend_config(build):
 @main.command()
 @click.option("--host", default="0.0.0.0")
 @click.option("--port", default=8000)
-@click.option("--extra-files", default="")
+@click.option("--extra-files",
+    default=None,
+    type=SeparatedPathType(),
+    help=(
+        "Extra files that trigger a reload on change. Multiple paths"
+        " are separated by '{}'.".format(path.pathsep)
+    )
+)
 @click.pass_context
 def dev_back(ctx, host, port, extra_files):
     """
@@ -103,7 +110,7 @@ def dev_back(ctx, host, port, extra_files):
     """
     if not environ.get('FLASK_ENV'):
         environ['FLASK_ENV'] = 'development'
-    ctx.invoke(run_command, host=host, port=port, extra_files=extra_files.split(','))
+    ctx.invoke(run_command, host=host, port=port, extra_files=extra_files)
 
 
 @main.command()

--- a/backend/geonature/core/gn_commons/routes.py
+++ b/backend/geonature/core/gn_commons/routes.py
@@ -90,7 +90,7 @@ def allowed_modules():
 
 @routes.route("/modules", methods=["GET"])
 @login_required
-def get_modules():
+def list_modules():
     return jsonify(allowed_modules())
 
 @routes.route("/modules_and_config", methods=["GET"])

--- a/backend/geonature/core/gn_commons/routes.py
+++ b/backend/geonature/core/gn_commons/routes.py
@@ -94,10 +94,9 @@ def list_modules():
     return jsonify(allowed_modules())
 
 @routes.route("/modules_and_config", methods=["GET"])
-@login_required
 def get_modules_and_config():
     return {
-        'modules': allowed_modules(),
+        'modules': g.current_user and allowed_modules(),
         'config': config_frontend
     }
 

--- a/backend/geonature/core/gn_commons/routes.py
+++ b/backend/geonature/core/gn_commons/routes.py
@@ -32,11 +32,19 @@ routes = Blueprint("gn_commons", __name__)
 # import routes sub folder
 from .validation.routes import *
 from .medias.routes import *
+from geonature.utils.config import config_frontend
+
+@routes.route("/config", methods=["GET"])
+# @login_required
+def config():
+    """
+    Returns geonature configuration
+    """
+
+    return config_frontend
 
 
-@routes.route("/modules", methods=["GET"])
-@login_required
-def list_modules():
+def allowed_modules():
     """
     Return the allowed modules of user from its cruved
     .. :quickref: Commons;
@@ -78,8 +86,20 @@ def list_modules():
                 )
                 module_dict["module_objects"][obj_code] = obj_dict
             allowed_modules.append(module_dict)
-    return jsonify(allowed_modules)
+    return allowed_modules
 
+@routes.route("/modules", methods=["GET"])
+@login_required
+def get_modules():
+    return jsonify(allowed_modules())
+
+@routes.route("/modules_and_config", methods=["GET"])
+@login_required
+def get_modules_and_config():
+    return {
+        'modules': allowed_modules(),
+        'config': config_frontend
+    }
 
 @routes.route("/module/<module_code>", methods=["GET"])
 def get_module(module_code):
@@ -133,7 +153,7 @@ def get_additional_fields():
         if len(params["module_code"].split(",")) > 1:
 
             ors = [
-                TAdditionalFields.modules.any(module_code=module_code) 
+                TAdditionalFields.modules.any(module_code=module_code)
                 for module_code in params["module_code"].split(",")
                 ]
 

--- a/backend/geonature/utils/command.py
+++ b/backend/geonature/utils/command.py
@@ -1,9 +1,9 @@
-"""   
+"""
     Fichier de création des commandes geonature
     Ce module ne doit en aucun cas faire appel à des models ou au coeur de geonature
     dans les imports d'entête de fichier pour garantir un bon fonctionnement des fonctions
-    d'administration de l'application GeoNature (génération des fichiers de configuration, des 
-    fichiers de routing du frontend etc...). Ces dernières doivent pouvoir fonctionner même si 
+    d'administration de l'application GeoNature (génération des fichiers de configuration, des
+    fichiers de routing du frontend etc...). Ces dernières doivent pouvoir fonctionner même si
     un paquet PIP du requirement GeoNature n'a pas été bien installé
 """
 import sys

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -4,12 +4,9 @@ npm-debug.log
 
 /dist/
 src/conf/app.config.ts
-src/tsconfig.app.json
 
 #routing
 src/app/routing/app-routing.module.ts
-#tsconfig
-tsconfig.json
 
 # custom components
 src/custom/components/**/*.component.ts

--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -6,7 +6,7 @@ import { AppConfig } from '@geonature_config/app.config';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import * as L from 'leaflet';
 import { CommonService } from '../service/common.service';
-
+import { ConfigService } from '../../services/config.service';
 import 'leaflet-draw';
 import { FormControl } from '@angular/forms';
 import { Observable, of } from 'rxjs';
@@ -68,6 +68,8 @@ export class MapComponent implements OnInit {
   /** Activer la barre de recherche */
   @Input() searchBar: boolean = true;
 
+  AppConfig = null;
+
   @ViewChild('mapDiv', { static: true }) mapContainer;
   searchLocation: string;
   public searching = false;
@@ -79,8 +81,11 @@ export class MapComponent implements OnInit {
     private _commonService: CommonService,
     private _http: HttpClient,
     private _nominatim: NominatimService,
+    private _configService: ConfigService
   ) {
     this.searchLocation = '';
+    this.AppConfig = this._configService.getConfig()
+    console.log(this.AppConfig.MAPCONFIG.CENTER)
   }
 
   ngOnInit() {
@@ -116,7 +121,8 @@ export class MapComponent implements OnInit {
     if (this.center !== undefined) {
       center = L.latLng(this.center[0], this.center[1]);
     } else {
-      center = L.latLng(AppConfig.MAPCONFIG.CENTER[0], AppConfig.MAPCONFIG.CENTER[1]);
+      center = L.latLng(
+        this.AppConfig.MAPCONFIG.CENTER[0], this.AppConfig.MAPCONFIG.CENTER[1]);
     }
 
 

--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -84,8 +84,7 @@ export class MapComponent implements OnInit {
     private _configService: ConfigService
   ) {
     this.searchLocation = '';
-    this.AppConfig = this._configService.getConfig()
-    console.log(this.AppConfig.MAPCONFIG.CENTER)
+    this.AppConfig = this._configService.config;
   }
 
   ngOnInit() {

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,6 +1,6 @@
 // Angular core
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule, APP_INITIALIZER } from '@angular/core';
+import { NgModule, APP_INITIALIZER, APP_BOOTSTRAP_LISTENER } from '@angular/core';
 
 import {
   HttpClientModule,
@@ -26,7 +26,6 @@ import { GN2CommonModule } from '@geonature_common/GN2Common.module';
 
 // Angular created component
 import { AppComponent } from './app.component';
-import { routing } from './routing/app-routing.module'; // RoutingModule
 import { HomeContentComponent } from './components/home-content/home-content.component';
 import { SidenavItemsComponent } from './components/sidenav-items/sidenav-items.component';
 import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
@@ -40,6 +39,7 @@ import { FooterComponent } from '../custom/components/footer/footer.component';
 import { IntroductionComponent } from '../custom/components/introduction/introduction.component';
 
 // Service
+import { Router, RouterModule } from "@angular/router";
 import { AuthService } from './components/auth/auth.service';
 import { CookieService } from 'ng2-cookies';
 import { ChartsModule } from 'ng2-charts';
@@ -65,6 +65,7 @@ import { UserDataService } from "./userModule/services/user-data.service";
 
 // Config
 import { APP_CONFIG_TOKEN, AppConfig } from '@geonature_config/app.config';
+import { RoutingService } from './services/routing.service';
 
 
 // Ici l'initialisation de la configuration va initialiser le service des modules
@@ -74,6 +75,11 @@ export function init_config(configService: ConfigService) {
     };
 }
 
+export function initRoutes(routingService: RoutingService) {
+  return () => {
+    routingService.init()
+  }
+}
 
 @NgModule({
   imports: [
@@ -81,7 +87,7 @@ export function init_config(configService: ConfigService) {
     HttpClientModule,
     BrowserAnimationsModule,
     FlexLayoutModule,
-    routing,
+    RouterModule.forRoot([], {useHash: true }),
     ChartModule,
     ChartsModule,
     ToastrModule.forRoot({
@@ -115,6 +121,7 @@ export function init_config(configService: ConfigService) {
     AuthGuard,
     ModuleService,
     ConfigService,
+    RoutingService,
     ToastrService,
     GlobalSubService,
     CookieService,
@@ -129,7 +136,8 @@ export function init_config(configService: ConfigService) {
     { provide: HTTP_INTERCEPTORS, useClass: MyCustomInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: UnauthorizedInterceptor, multi: true },
     // { provide: APP_INITIALIZER, useFactory: get_cruved, deps: [CruvedStoreService], multi: true},
-     { provide: APP_INITIALIZER, useFactory: init_config, deps: [ConfigService], multi: true},
+    { provide: APP_INITIALIZER, useFactory: init_config, deps: [ConfigService], multi: true},
+    { provide: APP_BOOTSTRAP_LISTENER, useFactory: initRoutes, deps: [RoutingService], multi: true },
   ],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -9,6 +9,9 @@ import {
   HTTP_INTERCEPTORS
 } from '@angular/common/http';
 
+// rxjs
+import { mergeMap } from "rxjs/operators";
+
 // For Angular Dependencies
 import 'hammerjs';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -47,6 +50,7 @@ import {
   UserManagementGuard
 } from '@geonature/routing/routes-guards.service';
 import { ModuleService } from './services/module.service';
+import { ConfigService } from './services/config.service';
 import { CruvedStoreService } from './GN2CommonModule/service/cruved-store.service';
 import { SideNavService } from './components/sidenav-items/sidenav-service';
 
@@ -63,8 +67,11 @@ import { UserDataService } from "./userModule/services/user-data.service";
 import { APP_CONFIG_TOKEN, AppConfig } from '@geonature_config/app.config';
 
 
-export function get_modules(moduleService: ModuleService) {
-    return () => {return moduleService.fetchModules().toPromise(); };
+// Ici l'initialisation de la configuration va initialiser le service des modules
+export function init_config(configService: ConfigService) {
+    return () => {
+      return configService.init().toPromise()
+    };
 }
 
 
@@ -107,6 +114,7 @@ export function get_modules(moduleService: ModuleService) {
     AuthService,
     AuthGuard,
     ModuleService,
+    ConfigService,
     ToastrService,
     GlobalSubService,
     CookieService,
@@ -121,7 +129,7 @@ export function get_modules(moduleService: ModuleService) {
     { provide: HTTP_INTERCEPTORS, useClass: MyCustomInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: UnauthorizedInterceptor, multi: true },
     // { provide: APP_INITIALIZER, useFactory: get_cruved, deps: [CruvedStoreService], multi: true},
-     { provide: APP_INITIALIZER, useFactory: get_modules, deps: [ModuleService], multi: true},
+     { provide: APP_INITIALIZER, useFactory: init_config, deps: [ConfigService], multi: true},
   ],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/app/components/home-content/home-content.component.ts
+++ b/frontend/src/app/components/home-content/home-content.component.ts
@@ -6,6 +6,7 @@ import { MapService } from '@geonature_common/map/map.service';
 import { SyntheseDataService } from '@geonature_common/form/synthese-form/synthese-data.service';
 
 import { AppConfig } from '../../../conf/app.config';
+import { ConfigService } from '../../services/config.service';
 import { SideNavService } from '../sidenav-items/sidenav-service';
 import { GlobalSubService } from '../../services/global-sub.service';
 import { ModuleService } from '../../services/module.service';
@@ -35,6 +36,7 @@ export class HomeContentComponent implements OnInit {
     private _mapService: MapService,
     private _moduleService: ModuleService,
     private translateService: TranslateService,
+    private _configService: ConfigService,
   ) {
     // this work here thanks to APP_INITIALIZER on ModuleService
     let synthese_module = this._moduleService.getModule('SYNTHESE');
@@ -52,7 +54,7 @@ export class HomeContentComponent implements OnInit {
     this.getI18nLocale();
 
     this._SideNavService.sidenav.open();
-    this.appConfig = AppConfig;
+    this.appConfig = this._configService.getConfig();
 
     if (this.showLastObsMap) {
       this._syntheseApi.getSyntheseData({ limit: 100 }).subscribe(result => {

--- a/frontend/src/app/components/home-content/home-content.component.ts
+++ b/frontend/src/app/components/home-content/home-content.component.ts
@@ -54,7 +54,7 @@ export class HomeContentComponent implements OnInit {
     this.getI18nLocale();
 
     this._SideNavService.sidenav.open();
-    this.appConfig = this._configService.getConfig();
+    this.appConfig = this._configService.config;
 
     if (this.showLastObsMap) {
       this._syntheseApi.getSyntheseData({ limit: 100 }).subscribe(result => {

--- a/frontend/src/app/components/login/login.component.html
+++ b/frontend/src/app/components/login/login.component.html
@@ -1,4 +1,15 @@
-<div id="login-body">
+<ng-container *ngIf="!configService.isInitialized">
+  <div>
+    La configuration du Frontend de cette instance contient des erreurs : <br>
+    <pre>
+{{ configService.msgError| json}}
+    </pre>
+  </div>
+</ng-container>
+
+<ng-container *ngIf="configService.isInitialized">
+
+ <div id="login-body" >
   <div
     *ngIf="!casLogin"
     class="container"
@@ -77,7 +88,7 @@
                       type="submit"
                     >Se connecter</button>
                     <br>
-                    
+
                     <div *ngIf="enable_sign_up">
                       <div class="inscription">
                         <a routerLink="/inscription">{{ 'CreateAccount' | translate }}</a>
@@ -85,7 +96,7 @@
                     </div>
                     <!-- <input type="submit" class="btn btn-success" value="Connexion"> -->
                   </form>
-                
+
                 </mat-step>
               </mat-horizontal-stepper>
             </ng-container>
@@ -164,3 +175,4 @@
 
   </div>
 </div>
+</ng-container>

--- a/frontend/src/app/components/login/login.component.html
+++ b/frontend/src/app/components/login/login.component.html
@@ -9,7 +9,10 @@
 
 <ng-container *ngIf="configService.isInitialized">
 
- <div id="login-body" >
+<div
+  id="login-body"
+  style="background: url({{appConfig.API_ENDPOINT}}/static/assets/custom/images/login_background.jpg) center 10% no-repeat;"
+>
   <div
     *ngIf="!casLogin"
     class="container"

--- a/frontend/src/app/components/login/login.component.scss
+++ b/frontend/src/app/components/login/login.component.scss
@@ -70,7 +70,6 @@
 
 #login-body {
   height: 100vh;
-  background: url(../../../custom/images/login_background.jpg) center 10% no-repeat;
   background-size: cover;
 }
 

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormBuilder } from '@angular/forms';
-import { AppConfig } from '../../../conf/app.config';
 import { AuthService } from '../auth/auth.service';
 import { ToastrService } from 'ngx-toastr';
 import { CommonService } from '@geonature_common/service/common.service';
@@ -12,16 +11,17 @@ import { ConfigService } from '../../services/config.service';
   styleUrls: ['./login.component.scss']
 })
 export class LoginComponent implements OnInit {
+  public appConfig;
   enable_sign_up: boolean = false;
   enable_user_management: boolean = false;
   public casLogin: boolean;
   public disableSubmit = false;
-  public enablePublicAccess = AppConfig.PUBLIC_ACCESS.ENABLE_PUBLIC_ACCESS;
+  public enablePublicAccess: boolean;
   identifiant: FormGroup;
   password: FormGroup;
   form: FormGroup;
   login_or_pass_recovery: boolean = false;
-  public APP_NAME = AppConfig.appName;
+  public APP_NAME:string;
 
   constructor(
     private _authService: AuthService,
@@ -30,17 +30,21 @@ export class LoginComponent implements OnInit {
     private _commonService: CommonService,
     public configService: ConfigService
   ) {
-    this.casLogin = AppConfig.CAS_PUBLIC.CAS_AUTHENTIFICATION;
-    this.enable_sign_up = AppConfig['ACCOUNT_MANAGEMENT']['ENABLE_SIGN_UP'] || false;
+    this.appConfig = this.configService.config;
+
+    this.casLogin = this.appConfig.CAS_PUBLIC.CAS_AUTHENTIFICATION;
+    this.enable_sign_up = this.appConfig['ACCOUNT_MANAGEMENT']['ENABLE_SIGN_UP'] || false;
     this.enable_user_management =
-      AppConfig['ACCOUNT_MANAGEMENT']['ENABLE_USER_MANAGEMENT'] || false;
+      this.appConfig['ACCOUNT_MANAGEMENT']['ENABLE_USER_MANAGEMENT'] || false;
+    this.enablePublicAccess = this.appConfig.PUBLIC_ACCESS.ENABLE_PUBLIC_ACCESS;
+    this.APP_NAME = this.appConfig.appName;
   }
 
   ngOnInit() {
-    if (AppConfig.CAS_PUBLIC.CAS_AUTHENTIFICATION) {
+    if (this.appConfig.CAS_PUBLIC.CAS_AUTHENTIFICATION) {
       // if token not here here, redirection to CAS login page
-      const url_redirection_cas = `${AppConfig.CAS_PUBLIC.CAS_URL_LOGIN}?service=${
-        AppConfig.API_ENDPOINT
+      const url_redirection_cas = `${this.appConfig.CAS_PUBLIC.CAS_URL_LOGIN}?service=${
+        this.appConfig.API_ENDPOINT
       }/gn_auth/login_cas`;
       document.location.href = url_redirection_cas;
     }
@@ -52,8 +56,8 @@ export class LoginComponent implements OnInit {
 
   registerPublic() {
     const userPublic = {
-      "username": AppConfig.PUBLIC_ACCESS.PUBLIC_LOGIN,
-      "password": AppConfig.PUBLIC_ACCESS.PUBLIC_PASSWORD,
+      "username": this.appConfig.PUBLIC_ACCESS.PUBLIC_LOGIN,
+      "password": this.appConfig.PUBLIC_ACCESS.PUBLIC_PASSWORD,
     }
     this._authService.signinUser(userPublic);
   }

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -4,6 +4,7 @@ import { AppConfig } from '../../../conf/app.config';
 import { AuthService } from '../auth/auth.service';
 import { ToastrService } from 'ngx-toastr';
 import { CommonService } from '@geonature_common/service/common.service';
+import { ConfigService } from '../../services/config.service';
 
 @Component({
   selector: 'pnx-login',
@@ -26,7 +27,8 @@ export class LoginComponent implements OnInit {
     private _authService: AuthService,
     private fb: FormBuilder,
     private _toasterService: ToastrService,
-    private _commonService: CommonService
+    private _commonService: CommonService,
+    public configService: ConfigService
   ) {
     this.casLogin = AppConfig.CAS_PUBLIC.CAS_AUTHENTIFICATION;
     this.enable_sign_up = AppConfig['ACCOUNT_MANAGEMENT']['ENABLE_SIGN_UP'] || false;

--- a/frontend/src/app/components/nav-home/nav-home.component.html
+++ b/frontend/src/app/components/nav-home/nav-home.component.html
@@ -38,7 +38,7 @@
       <img
         id="logo-structure"
         class="mx-2"
-        src="custom/images/{{appConfig.LOGO_STRUCTURE_FILE}}"
+        src="{{appConfig.API_ENDPOINT}}/static/assets/custom/images/{{appConfig.LOGO_STRUCTURE_FILE}}"
         alt=""
       >
 

--- a/frontend/src/app/components/nav-home/nav-home.component.html
+++ b/frontend/src/app/components/nav-home/nav-home.component.html
@@ -1,3 +1,12 @@
+<ng-container *ngIf="!configService.isInitialized">
+  <div>
+    La configuration du Frontend de cette instance contient des erreurs : <br><br>
+    <pre>
+{{ configService.msgError| json}}
+    </pre>
+  </div>
+</ng-container>
+
 <mat-sidenav-container class="sidenav-container">
 
   <mat-sidenav
@@ -10,7 +19,7 @@
   </mat-sidenav>
 
 
-  <mat-sidenav-content>
+  <mat-sidenav-content  *ngIf="configService.isInitialized">
     <mat-toolbar
       id="app-toolbar"
       class="row"

--- a/frontend/src/app/components/nav-home/nav-home.component.ts
+++ b/frontend/src/app/components/nav-home/nav-home.component.ts
@@ -10,6 +10,7 @@ import { AuthService, User } from '../../components/auth/auth.service';
 import { AppConfig } from '../../../conf/app.config';
 import { GlobalSubService } from '../../services/global-sub.service';
 import { SideNavService } from '../sidenav-items/sidenav-service';
+import { ConfigService } from '../../services/config.service';
 
 
 @Component({
@@ -34,6 +35,7 @@ export class NavHomeComponent implements OnInit, OnDestroy {
     public sideNavService: SideNavService,
     private globalSubService: GlobalSubService,
     private router: Router,
+    public configService: ConfigService
   ) {}
 
   ngOnInit() {

--- a/frontend/src/app/components/new-password/new-password.component.html
+++ b/frontend/src/app/components/new-password/new-password.component.html
@@ -1,4 +1,7 @@
-<div id="login-body">
+<div
+  id="login-body"
+  style="background: url({{appConfig.API_ENDPOINT}}/static/assets/custom/images/login_background.jpg) center 10% no-repeat;"
+>
   <div *ngIf="!casLogin"
        class="container">
     <div class="row">

--- a/frontend/src/app/components/new-password/new-password.component.scss
+++ b/frontend/src/app/components/new-password/new-password.component.scss
@@ -70,7 +70,6 @@
 
 #login-body {
   height: 100vh;
-  background: url(../../../custom/images/login_background.jpg) center 10% no-repeat;
   background-size: cover;
 }
 
@@ -94,7 +93,7 @@ small {color: red}
 }
 
 .inscription a, .forgot-password a {
-  color: inherit; 
+  color: inherit;
 }
 
 .mat-mini-fab {

--- a/frontend/src/app/components/new-password/new-password.component.ts
+++ b/frontend/src/app/components/new-password/new-password.component.ts
@@ -4,8 +4,7 @@ import { AuthService } from '../auth/auth.service';
 import { ToastrService } from 'ngx-toastr';
 import { similarValidator } from '@geonature/services/validators';
 import { Router, ActivatedRoute } from '@angular/router';
-import { AppConfig } from '../../../conf/app.config';
-
+import { ConfigService } from '@geonature/services/config.service';
 @Component({
   selector: 'pnx-new-password',
   templateUrl: 'new-password.component.html',
@@ -15,14 +14,18 @@ export class NewPasswordComponent implements OnInit {
   token: string;
   form: FormGroup;
   public casLogin
+  public appConfig;
 
   constructor(
     private _authService: AuthService,
     private fb: FormBuilder,
     private router: Router,
     private activatedRoute: ActivatedRoute,
-    private _toasterService: ToastrService
+    private _toasterService: ToastrService,
+    public configService: ConfigService,
+
   ) {
+    this.appConfig = this.configService.config;
     this.activatedRoute.queryParams.subscribe(params => {
       let token = params['token'];
       if (!RegExp('^[0-9]+$').test(token)) {
@@ -30,7 +33,7 @@ export class NewPasswordComponent implements OnInit {
       }
       this.token = token;
     });
-    this.casLogin = AppConfig.PUBLIC_ACCESS.ENABLE_PUBLIC_ACCESS;
+    this.casLogin = this.appConfig.PUBLIC_ACCESS.ENABLE_PUBLIC_ACCESS;
   }
 
   ngOnInit() {

--- a/frontend/src/app/components/sidenav-items/sidenav-items.component.html
+++ b/frontend/src/app/components/sidenav-items/sidenav-items.component.html
@@ -5,7 +5,7 @@
   >
     <img
       mat-card-image
-      src="custom/images/logo_sidebar.jpg"
+      src="{{appConfig.API_ENDPOINT}}/static/assets/custom/images/logo_sidebar.jpg"
     />
   </a>
 </mat-card>

--- a/frontend/src/app/components/sidenav-items/sidenav-items.component.ts
+++ b/frontend/src/app/components/sidenav-items/sidenav-items.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { AppConfig } from '@geonature_config/app.config';
 import { GlobalSubService } from '../../services/global-sub.service';
 import { ModuleService } from '../../services/module.service';
 import { SideNavService } from './sidenav-service';
-
+import { ConfigService } from '@geonature/services/config.service';
 @Component({
   selector: 'pnx-sidenav-items',
   templateUrl: './sidenav-items.component.html',
@@ -12,15 +11,19 @@ import { SideNavService } from './sidenav-service';
 export class SidenavItemsComponent implements OnInit {
   public nav = [{}];
   public appConfig: any;
-  public version = AppConfig.GEONATURE_VERSION;
+  public version;
   public home_page: any;
   public exportModule: any;
 
   constructor(
     public globalSub: GlobalSubService,
     public moduleService: ModuleService,
-    public _sidenavService: SideNavService
-  ) {}
+    public _sidenavService: SideNavService,
+    public configService: ConfigService
+  ) {
+    this.appConfig = this.configService.config;
+    this.version = this.appConfig.GEONATURE_VERSION
+  }
 
   ngOnInit() {
     this.home_page = { module_url: '/', module_label: 'Accueil', module_picto: 'fa-home', id: '1' };

--- a/frontend/src/app/components/sign-up/sign-up.component.html
+++ b/frontend/src/app/components/sign-up/sign-up.component.html
@@ -1,4 +1,7 @@
-<div id="login-body">
+<div
+  id="login-body"
+  style="background: url({{appConfig.API_ENDPOINT}}/static/assets/custom/images/login_background.jpg) center 10% no-repeat;"
+>
   <div class="container">
     <div class="row">
       <div class="col-md-12 col-lg-8 mx-auto">

--- a/frontend/src/app/components/sign-up/sign-up.component.ts
+++ b/frontend/src/app/components/sign-up/sign-up.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormBuilder, Validators, FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
-import { AppConfig } from '@geonature_config/app.config';
 import { ToastrService } from 'ngx-toastr';
 import { AuthService } from '../auth/auth.service';
 import { similarValidator } from '@geonature/services/validators/validators';
 import { CommonService } from '@geonature_common/service/common.service';
+import { ConfigService } from '@geonature/services/config.service';
 
 @Component({
   selector: 'pnx-signup',
@@ -17,16 +17,20 @@ export class SignUpComponent implements OnInit {
   dynamicFormGroup: FormGroup;
   public disableSubmit = false;
   public formControlBuilded = false;
-  public FORM_CONFIG = AppConfig.ACCOUNT_MANAGEMENT.ACCOUNT_FORM;
+  public appConfig;
+  public FORM_CONFIG;
 
   constructor(
     private fb: FormBuilder,
     private _authService: AuthService,
     private _router: Router,
     private _toasterService: ToastrService,
-    private _commonService: CommonService
+    private _commonService: CommonService,
+    public configService: ConfigService,
   ) {
-    if (!(AppConfig['ACCOUNT_MANAGEMENT']['ENABLE_SIGN_UP'] || false)) {
+    this.appConfig = this.configService.config
+    this.FORM_CONFIG = this.appConfig.ACCOUNT_MANAGEMENT.ACCOUNT_FORM
+    if (!(this.appConfig['ACCOUNT_MANAGEMENT']['ENABLE_SIGN_UP'] || false)) {
       this._router.navigate(['/login']);
     }
   }
@@ -58,14 +62,14 @@ export class SignUpComponent implements OnInit {
       this.disableSubmit = true;
       const finalForm = Object.assign({}, this.form.value);
       // concatenate two forms
-      if (AppConfig.ACCOUNT_MANAGEMENT.ACCOUNT_FORM.length > 0) {
+      if (this.appConfig.ACCOUNT_MANAGEMENT.ACCOUNT_FORM.length > 0) {
         finalForm['champs_addi'] = this.dynamicFormGroup.value;
       }
       this._authService
         .signupUser(finalForm)
         .subscribe(
           res => {
-            const callbackMessage = AppConfig.ACCOUNT_MANAGEMENT.AUTO_ACCOUNT_CREATION
+            const callbackMessage = this.appConfig.ACCOUNT_MANAGEMENT.AUTO_ACCOUNT_CREATION
               ? 'AutoAccountEmailConfirmation'
               : 'AdminAccountEmailConfirmation';
             this._commonService.translateToaster('info', callbackMessage);

--- a/frontend/src/app/services/config.service.ts
+++ b/frontend/src/app/services/config.service.ts
@@ -30,17 +30,16 @@ export class ConfigService {
 
           this.config = config;
 
-          if (!this.config.URL_APPLICATION) {
+          if (!this.config.API_ENDPOINT) {
             this.msgError = {
-              message: `Le fichier de configuration 'assets/config.json' est mal renseigné : il manque une valeur pour 'URL_APPLICATION'`,
+              message: `Le fichier de configuration 'assets/config.json' est mal renseigné : il manque une valeur pour 'API_ENDPOINT'`,
               config: config
             }
             console.error(this.msgError)
             return of(false)
           }
 
-          // const apiConfig = `${this._config.URL_APPLICATION}/gn_commons/config`;
-          const apiConfig = `${this.config.URL_APPLICATION}/gn_commons/modules_and_config`;
+          const apiConfig = `${this.config.API_ENDPOINT}/gn_commons/modules_and_config`;
 
           // on initialise ici la configuration ET les modules
           return this._hhtp.get(apiConfig);

--- a/frontend/src/app/services/config.service.ts
+++ b/frontend/src/app/services/config.service.ts
@@ -1,0 +1,78 @@
+import { HttpClient } from "@angular/common/http";
+import { catchError, concatMap, mergeMap } from "rxjs/operators";
+import { of, forkJoin } from "rxjs"
+import { Injectable } from '@angular/core';
+import { ModuleService } from './module.service'
+
+@Injectable()
+export class ConfigService {
+  constructor(
+    private _hhtp: HttpClient,
+    private _modules: ModuleService,
+  ) {}
+
+  _config: any = {};
+  isInitialized = false;
+  msgError: any;
+
+  init() {
+    return this._hhtp.get('./assets/config.json')
+      .pipe(
+        catchError((error) => {
+          console.log('assets/config.json', error);
+          this.msgError= `Le fichier de configuration 'assets/config.json' n'est pas présent.`
+          return of(false);
+        }),
+        mergeMap((config:any) => {
+          if (!config) {
+            return of(false);
+          }
+
+          this._config = config;
+
+          if (!this._config.URL_APPLICATION) {
+            this.msgError = {
+              message: `Le fichier de configuration 'assets/config.json' est mal renseigné : il manque une valeur pour 'URL_APPLICATION'`,
+              config: config
+            }
+            console.error(this.msgError)
+            return of(false)
+          }
+
+          const apiConfig = `${this._config.URL_APPLICATION}/gn_commons/config`;
+
+          // on initialise ici la configuration ET les modules
+          return forkJoin([
+            this._hhtp.get(apiConfig),
+            this._modules.fetchModules()
+          ])
+        }),
+        catchError((error) => {
+          console.error('api config modules', error);
+          this.msgError = {
+            error: error.message,
+            url: error.url,
+            config: this._config,
+            hints: `Veuillez vérifier si l'url de l'application est bien ${this._config.URL_APPLICATION} et si l'application est en bon état de marche`
+          }
+          return of(false);
+        }),
+        mergeMap((results: any) => {
+          if (!results[0]) {
+            return of(false)
+          }
+          this._config = {
+            ...this._config,
+            ...results[0]
+          };
+          this.isInitialized = true;
+          return of(this._config)
+        })
+      )
+  }
+
+  getConfig() {
+    return this._config
+  }
+
+}

--- a/frontend/src/app/services/module.service.ts
+++ b/frontend/src/app/services/module.service.ts
@@ -43,7 +43,7 @@ export class ModuleService {
    * @param module_code: name of the module
    */
   getModule(module_code: string) {
-    for (let mod of this.modules) {
+    for (let mod of (this.modules || [])) {
       if (mod.module_code.toLowerCase() === module_code.toLowerCase()) {
         return mod;
       }

--- a/frontend/src/app/services/module.service.ts
+++ b/frontend/src/app/services/module.service.ts
@@ -25,6 +25,10 @@ export class ModuleService {
     return this.modules;
   }
 
+  setModules(modules) {
+    this.modules = modules;
+  }
+
   getDisplayedModules() {
     return this.modules.filter(mod => {
       return (

--- a/frontend/src/app/services/routing.service.ts
+++ b/frontend/src/app/services/routing.service.ts
@@ -1,0 +1,155 @@
+import { Injectable } from '@angular/core';
+
+import { Routes, Router } from '@angular/router';
+import { ConfigService } from './config.service'
+import { ModuleService } from './module.service'
+
+import { LoginComponent } from '../components/login/login.component';
+import { NewPasswordComponent } from '../components/new-password/new-password.component'
+import { SignUpComponent } from '../components/sign-up/sign-up.component';
+import { UserManagementGuard } from '@geonature/routing/routes-guards.service';
+import { NavHomeComponent } from '../components/nav-home/nav-home.component';
+import { PageNotFoundComponent } from '../components/page-not-found/page-not-found.component';
+import { HomeContentComponent } from '../components/home-content/home-content.component';
+
+import { SignUpGuard } from '@geonature/routing/routes-guards.service';
+import { AuthGuard, ModuleGuardService } from '@geonature/routing/routes-guards.service';
+
+import externalModules from '../../../../external_modules'
+
+@Injectable()
+export class RoutingService {
+  constructor(
+    private _configService: ConfigService,
+    private _moduleService: ModuleService,
+    private _router: Router,
+  ) {};
+
+  init() {
+    this._router.resetConfig(this.getRoutes());
+    console.log(this.getRoutes())
+    this._router.navigateByUrl(this._router.url);
+    // reload route
+  }
+
+  getRoutes(): Routes {
+    const routes: Routes = [];
+
+    // definitions
+
+    const login = {
+      path: 'login',
+      component: LoginComponent,
+    };
+
+    const signUp = {
+      path: 'inscription',
+      component: SignUpComponent,
+      canActivate: [SignUpGuard],
+    };
+
+    const newPassword = {
+      path: 'new-password',
+      component: NewPasswordComponent,
+      canActivate: [UserManagementGuard],
+    };
+
+    const sideBar = {
+      path: '',
+      component: NavHomeComponent,
+      canActivateChild: [AuthGuard],
+      children: this.getSideBarRoutes()
+    }
+
+    const notFound = {
+      path: '**',
+      component: PageNotFoundComponent,
+    };
+
+    // set routes
+
+    routes.push(login);
+
+    if (this._configService.config?.ACCOUNT_MANAGEMENT?.ENABLE_SIGN_UP) {
+      routes.push(signUp);
+    }
+
+    if (this._configService.config?.ACCOUNT_MANAGEMENT?.ENABLE_USER_MANAGEMENT) {
+      routes.push(newPassword);
+    }
+
+    routes.push(sideBar);
+    routes.push(notFound);
+    return routes;
+  }
+
+  getSideBarRoutes(): Routes {
+    const sideBarRoutes:Routes = []
+
+    const home = {
+      path: '',
+      component: HomeContentComponent,
+    };
+
+    const synthese = {
+      path: 'synthese',
+      data: { module_code: 'synthese' },
+      canActivate: [ModuleGuardService],
+      loadChildren: () => import('@geonature/syntheseModule/synthese.module').then(m => m.SyntheseModule)
+    };
+
+    const metadata = {
+      path: 'metadata',
+      data: { module_code: 'metadata' },
+      canActivate: [ModuleGuardService],
+      loadChildren: () => import('@geonature/metadataModule/metadata.module').then(m => m.MetadataModule)
+    };
+
+    const admin = {
+      path: 'admin',
+      data: { module_code: 'admin' },
+      loadChildren: () => import('@geonature/adminModule/admin.module').then(m => m.AdminModule),
+      canActivate: [ModuleGuardService],
+    }
+
+    const user = {
+      path: 'user',
+      data: { module_code: 'user' },
+      loadChildren: () => import('@geonature/userModule/user.module').then(m => m.UserModule),
+    };
+
+    sideBarRoutes.push(home);
+    sideBarRoutes.push(synthese);
+    sideBarRoutes.push(metadata);
+    sideBarRoutes.push(admin);
+
+    if(this._configService.config?.ACCOUNT_MANAGEMENT?.ENABLE_USER_MANAGEMENT) {
+      sideBarRoutes.push(user)
+    }
+
+    for (const externalModule of this.getExternalModules()) {
+      sideBarRoutes.push(externalModule)
+    }
+
+    return sideBarRoutes;
+  }
+
+  getExternalModules():Routes {
+    const modules: Routes = [];
+    for  (const [moduleCode, moduleComponent] of Object.entries(externalModules)) {
+      const module = this._moduleService.getModule(moduleCode)
+      if (!module) {
+        continue;
+      }
+      modules.push({
+        path: module.module_path,
+        loadChildren: () => moduleComponent,
+        canActivate: [ModuleGuardService],
+        data: {
+          module_code: moduleCode
+        }
+      })
+    }
+    return modules;
+  }
+}

--- a/frontend/src/app/services/routing.service.ts
+++ b/frontend/src/app/services/routing.service.ts
@@ -27,9 +27,8 @@ export class RoutingService {
 
   init() {
     this._router.resetConfig(this.getRoutes());
-    console.log(this.getRoutes())
-    this._router.navigateByUrl(this._router.url);
     // reload route
+    this._router.navigateByUrl(this._router.url);
   }
 
   getRoutes(): Routes {

--- a/frontend/src/tsconfig.app.json
+++ b/frontend/src/tsconfig.app.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../out-tsc/app",
+    "module": "es2020",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "main.ts",
+    "polyfills.ts",
+    "*.d.ts",
+    "**/*"
+    ,"../../external_modules/index.ts"
+    ,"../..external_modules/**/*.ts"
+  ],
+  "exclude": [
+    "**/*.spec.ts"
+    ,"../..external_modules/**/*.spec.ts"
+  ],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "importHelpers": true,
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "module": "es2020",
+    "target": "es2015",
+    "lib": [
+      "es2018",
+      "dom"
+    ],
+    "typeRoots": [
+      "node_modules/@types",
+      "./src/typings.d.ts"
+    ],
+    "types":[
+    ],
+    "baseUrl": "node_modules",
+    "paths": {
+      "@angular/*": ["./@angular/*"],
+      "@geonature_common/*" : ["../src/app/GN2CommonModule/*"],
+      "@geonature/*" : ["../src/app/*"],
+      "@geonature_config/*" : ["../src/conf/*"],
+      "@librairies/*" : ["./*"],
+    }
+  }
+}

--- a/install/assets/geonature.service
+++ b/install/assets/geonature.service
@@ -12,8 +12,9 @@ Environment=GUNICORN_NUM_WORKERS=4
 Environment=GUNICORN_HOST=127.0.0.1
 Environment=GUNICORN_PORT=8000
 Environment=GUNICORN_TIMEOUT=30
-Environment=GUNICORN_EXTRA_FILE=${BASE_DIR}/config/geonature_config.toml
+Environment=GEONATURE_CONFIG_FILE=${BASE_DIR}/config/geonature_config.toml
 EnvironmentFile=-${BASE_DIR}/environ
+Environment=GUNICORN_EXTRA_FILE=${GEONATURE_CONFIG_FILE}
 ExecStart=${BASE_DIR}/backend/venv/bin/gunicorn geonature:create_app() \
                 --name "${GUNICORN_PROC_NAME}" --workers "${GUNICORN_NUM_WORKERS}" \
                 --bind "${GUNICORN_HOST}:${GUNICORN_PORT}" --timeout="${GUNICORN_TIMEOUT}"

--- a/install/assets/geonature.service
+++ b/install/assets/geonature.service
@@ -12,10 +12,12 @@ Environment=GUNICORN_NUM_WORKERS=4
 Environment=GUNICORN_HOST=127.0.0.1
 Environment=GUNICORN_PORT=8000
 Environment=GUNICORN_TIMEOUT=30
+Environment=GUNICORN_EXTRA_FILE=${BASE_DIR}/config/geonature_config.toml
 EnvironmentFile=-${BASE_DIR}/environ
 ExecStart=${BASE_DIR}/backend/venv/bin/gunicorn geonature:create_app() \
                 --name "${GUNICORN_PROC_NAME}" --workers "${GUNICORN_NUM_WORKERS}" \
                 --bind "${GUNICORN_HOST}:${GUNICORN_PORT}" --timeout="${GUNICORN_TIMEOUT}"
+                --reload --reload-extra-file="${GUNICORN_EXTRA_FILE}"
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutStartSec=10
 TimeoutStopSec=5

--- a/install/frontend.sh
+++ b/install/frontend.sh
@@ -1,0 +1,43 @@
+# frontend.sh
+
+#
+# fonction qui crée le fichier external_modules/index.ts
+# TODO trouver un moyen de retrouver module_code depuis le frontend
+# le mettre dans les package.json ??
+#
+function create_external_modules_index() {
+
+    GN_DIR=$1
+    if [ -z "${GN_DIR}" ]; then
+        echo veuillez spécifier le repertoire de geonature
+        exit 1
+    fi
+
+    cur=$(pwd)
+
+    module_codes=""
+
+    cd ${GN_DIR}/external_modules
+
+    index_file=./index.ts
+    echo "// Liste des modules de geonature" > ${index_file}
+
+    for path in $(ls */frontend/app/gnModule.module.ts); do
+        module_code_lower=${path%%/*}
+        module_code_upper=$(echo ${module_code_lower} | awk '{print toupper($1);}')
+        module_codes="${module_codes} ${module_code_upper}"
+        echo "import { GeonatureModule as ${module_code_upper} } from './${path%%.ts}';" >> ${index_file}
+    done
+
+    echo "" >> ${index_file}
+    echo "export default {" >> ${index_file}
+    for module_code in $(echo ${module_codes}); do
+        echo "  ${module_code}," >> ${index_file}
+    done
+    echo "};" >> ${index_file}
+
+    cat "${index_file}"
+    cd "$cur"
+
+}
+


### PR DESCRIPTION
## BUT

Ce travail a pour but de rendre plus indépendant le frontend de geonature et de simplifier sa conguration. Cela peut aussi contribuer à faciliter la dockerisation du frontend.

Le but est de rendre possible la configuration du frontend après un build et de la limiter à une action:

- créer un fichier `assets/config.json` (dans les repertoires frontend/dist/assets et `frontend/src/assets` qui contient les information suivantes:
```
{
"API_ENDPOINT": "localhost:8000"
}
``` 

Dans le cadre d'une installation par docker, on aurait juste à récupérer le docker avec le frontend déjà buildé et à créé un volume pour le fichier assets/config.json

L'accès à la configuration passe désormais par le service `ConfigService`
A son initialisation, ce service
- récupère le fichier `config.json` et de la valeur de `API_ENDPOINT`par un appel `http` 
- il peut alors faire une requête pour obtenir la configuration (on fait aussi l'initialisation des modules dans la foulée)
- gére et signale  les erreurs

Ce service est initinialisé dans app.modules (`APP_INITIALIZER`)

Au niveau du backend on souhaite que l'appli puisse être relancée en cas de changement de config pour cela on ajoute
- une option `extra-files` à la commande `geonature dev_back`: `geonature dev_back --extra-files="config/geonature_config.toml`   
- les options `--reload` et `--reload-extra-file=<chemin vers geonature_config.toml>` à la commande gunicorn qui sera appelée par le service `geonature`

Une route est crée pour récupéré la configuration (idéalement il faudrait une route unique pour récupérer la config ET les modules et dont le contenu dépend du fait que l'on est loggé ou non, à voir plus tard)

Le commit 53b172d présente ces changements avec une application sur le centrage de la carte (paramètres `[CENTER]` de `[[MAP_CONFIG]]` dans le fichier `geonature_config.toml` (pour avoir un exemple visuel pour valider le concept)

Lorsque l'on fait un changement de ce paramètre, il n'y a qu'à
- sauvegarder le fichier, l'application backend détecte un changement et se relance
- recharger la page du navigateur

Les étapes suivantes:
- [ ] passer des composant custom (introduction, footer) à du texte html stocké en configuration
- [x] mettre les images personalisables, logo, accueil dans le dossier static
- [ ] gérer les modules et les routes de la manière la plus automatique possible
  - gros morceau 
- [x] voir comment on peut se passer des commandes geonature qui gère le frontend
  - [x] `generate_frontend_modules_route`
  - [x] `generate_frontend_tsconfig`
  - [x] `generate_frontend_tsconfig_app`
  - etc..  
- [ ] appliquer l'utilisation de config service partout (GN et modules)
