### PR TITLE
Ajouter un signalement sur une occurrence pour la validation

### DIFF
--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -464,10 +464,6 @@ class VSyntheseForWebApp(DB.Model):
         TReport, primaryjoin=(TReport.id_synthese == foreign(id_synthese)), uselist=True
     )
 
-    def get_geofeature(self, recursif=False, fields=[]):
-        return self.as_geofeature("the_geom_4326", "id_synthese", recursif, fields=fields)
-
-
 # Non utilisé - laissé pour exemple d'une sérialisation ordonnée
 def synthese_export_serialization(cls):
     """

--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -352,6 +352,7 @@ class DefaultsNomenclaturesValue(DB.Model):
     group2_inpn = DB.Column(DB.Unicode, primary_key=True)
     id_nomenclature = DB.Column(DB.Integer)
 
+
 # Type library to list every report types
 @serializable
 class BibReportsTypes(DB.Model):
@@ -359,6 +360,7 @@ class BibReportsTypes(DB.Model):
     __table_args__ = {"schema": "gn_synthese"}
     id_type = DB.Column(DB.Integer(), primary_key=True)
     type = DB.Column(DB.Text())
+
 
 # Relation report model with User and BibReportsTypes to get every infos about a report
 @serializable
@@ -376,6 +378,7 @@ class TReport(DB.Model):
     synthese = relationship(Synthese, backref=db.backref("reports", order_by=creation_date))
     report_type = relationship(BibReportsTypes)
     user = DB.relationship(User)
+
 
 @serializable
 @geoserializable(geoCol="the_geom_4326", idCol="id_synthese")
@@ -458,9 +461,7 @@ class VSyntheseForWebApp(DB.Model):
     )
 
     reports = relationship(
-        TReport, 
-        primaryjoin=(TReport.id_synthese==foreign(id_synthese)),
-        uselist=True
+        TReport, primaryjoin=(TReport.id_synthese == foreign(id_synthese)), uselist=True
     )
 
     def get_geofeature(self, recursif=False, fields=[]):

--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -464,6 +464,7 @@ class VSyntheseForWebApp(DB.Model):
         TReport, primaryjoin=(TReport.id_synthese == foreign(id_synthese)), uselist=True
     )
 
+
 # Non utilisé - laissé pour exemple d'une sérialisation ordonnée
 def synthese_export_serialization(cls):
     """

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -304,7 +304,7 @@ def get_one_synthese(scope, id_synthese):
     if not synthese.has_instance_permission(scope=scope):
         raise Forbidden()
     geofeature = synthese.as_geofeature(
-        "the_geom_4326", "id_synthese", fields=Synthese.nomenclature_fields + fields
+        fields=Synthese.nomenclature_fields + fields
     )
     return jsonify(geofeature)
 
@@ -1109,7 +1109,7 @@ def delete_report(id_report):
     reportItem = TReport.query.get_or_404(id_report)
     # alert control to check cruved - allow validators only
     if reportItem.report_type.type in ["alert", "pin"]:
-        scope = get_scopes_by_action(module_code="VALIDATION")["R"]
+        scope = get_scopes_by_action(module_code="VALIDATION")["C"]
         if not reportItem.synthese.has_instance_permission(scope):
             raise Forbidden("Permission required to delete this report !")
     # only owner could delete a report for pin and discussion

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -303,9 +303,7 @@ def get_one_synthese(scope, id_synthese):
 
     if not synthese.has_instance_permission(scope=scope):
         raise Forbidden()
-    geofeature = synthese.as_geofeature(
-        fields=Synthese.nomenclature_fields + fields
-    )
+    geofeature = synthese.as_geofeature(fields=Synthese.nomenclature_fields + fields)
     return jsonify(geofeature)
 
 

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -6,11 +6,19 @@ import time
 from collections import OrderedDict
 from warnings import warn
 
-from flask import Blueprint, request, Response, current_app, \
-                  send_from_directory, render_template, jsonify, g
+from flask import (
+    Blueprint,
+    request,
+    Response,
+    current_app,
+    send_from_directory,
+    render_template,
+    jsonify,
+    g,
+)
 from werkzeug.exceptions import Forbidden, NotFound, BadRequest, Conflict
 from sqlalchemy import distinct, func, desc, asc, select, text, update
-from sqlalchemy.orm import joinedload, contains_eager, lazyload
+from sqlalchemy.orm import joinedload, contains_eager, lazyload, selectinload
 from geojson import FeatureCollection, Feature
 import sqlalchemy as sa
 
@@ -45,7 +53,10 @@ from geonature.core.taxonomie.models import (
 from geonature.core.gn_synthese.utils.query_select_sqla import SyntheseQuery
 
 from geonature.core.gn_permissions import decorators as permissions
-from geonature.core.gn_permissions.tools import cruved_scope_for_user_in_module
+from geonature.core.gn_permissions.tools import (
+    cruved_scope_for_user_in_module,
+    get_scopes_by_action,
+)
 
 from ref_geo.models import LAreas, BibAreasTypes
 
@@ -233,60 +244,67 @@ def get_synthese(info_role):
 @permissions.check_cruved_scope("R", get_scope=True, module_code="SYNTHESE")
 def get_one_synthese(scope, id_synthese):
     """Get one synthese record for web app with all decoded nomenclature"""
-    synthese = (
-        Synthese.query.join_nomenclatures()
-        .options(
-            joinedload("dataset").options(
-                selectinload("acquisition_framework").options(
-                    joinedload("creator"),
-                    joinedload("nomenclature_territorial_level"),
-                    joinedload("nomenclature_financing_type"),
-                ),
+    synthese = Synthese.query.join_nomenclatures().options(
+        joinedload("dataset").options(
+            selectinload("acquisition_framework").options(
+                joinedload("creator"),
+                joinedload("nomenclature_territorial_level"),
+                joinedload("nomenclature_financing_type"),
             ),
-            lazyload("areas").options(
-                joinedload("area_type"),
-            ),
-        )
-        .get_or_404(id_synthese)
+        ),
+        lazyload("areas").options(
+            joinedload("area_type"),
+        ),
     )
+    ##################
+
+    fields = [
+        "dataset",
+        "dataset.acquisition_framework",
+        "dataset.acquisition_framework.bibliographical_references",
+        "dataset.acquisition_framework.cor_af_actor",
+        "dataset.acquisition_framework.cor_objectifs",
+        "dataset.acquisition_framework.cor_territories",
+        "dataset.acquisition_framework.cor_volets_sinp",
+        "dataset.acquisition_framework.creator",
+        "dataset.acquisition_framework.nomenclature_territorial_level",
+        "dataset.acquisition_framework.nomenclature_financing_type",
+        "dataset.cor_dataset_actor",
+        "dataset.cor_dataset_actor.role",
+        "dataset.cor_dataset_actor.organism",
+        "dataset.cor_territories",
+        "dataset.nomenclature_source_status",
+        "dataset.nomenclature_resource_type",
+        "dataset.nomenclature_dataset_objectif",
+        "dataset.nomenclature_data_type",
+        "dataset.nomenclature_data_origin",
+        "dataset.nomenclature_collecting_method",
+        "dataset.creator",
+        "dataset.modules",
+        "validations",
+        "validations.validation_label",
+        "validations.validator_role",
+        "cor_observers",
+        "cor_observers.organisme",
+        "source",
+        "habitat",
+        "medias",
+        "areas",
+        "areas.area_type",
+    ]
+
+    # get reports info only if activated by admin config
+    alertModulesActivated = current_app.config["SYNTHESE"]["ALERT_MODULES"]
+    if len(alertModulesActivated) and "SYNTHESE" in alertModulesActivated:
+        fields.append("reports.report_type.type")
+        synthese = synthese.options(lazyload(Synthese.reports).joinedload(TReport.report_type))
+
+    synthese = synthese.get_or_404(id_synthese)
+
     if not synthese.has_instance_permission(scope=scope):
         raise Forbidden()
     geofeature = synthese.as_geofeature(
-        fields=Synthese.nomenclature_fields
-        + [
-            "dataset",
-            "dataset.acquisition_framework",
-            "dataset.acquisition_framework.bibliographical_references",
-            "dataset.acquisition_framework.cor_af_actor",
-            "dataset.acquisition_framework.cor_objectifs",
-            "dataset.acquisition_framework.cor_territories",
-            "dataset.acquisition_framework.cor_volets_sinp",
-            "dataset.acquisition_framework.creator",
-            "dataset.acquisition_framework.nomenclature_territorial_level",
-            "dataset.acquisition_framework.nomenclature_financing_type",
-            "dataset.cor_dataset_actor",
-            "dataset.cor_dataset_actor.role",
-            "dataset.cor_dataset_actor.organism",
-            "dataset.cor_territories",
-            "dataset.nomenclature_source_status",
-            "dataset.nomenclature_resource_type",
-            "dataset.nomenclature_dataset_objectif",
-            "dataset.nomenclature_data_type",
-            "dataset.nomenclature_data_origin",
-            "dataset.nomenclature_collecting_method",
-            "dataset.creator",
-            "dataset.modules",
-            "validations",
-            "validations.validation_label",
-            "validations.validator_role",
-            "cor_observers",
-            "cor_observers.organisme",
-            "source",
-            "habitat",
-            "medias",
-            "areas",
-            "areas.area_type",
-        ]
+        "the_geom_4326", "id_synthese", fields=Synthese.nomenclature_fields + fields
     )
     return jsonify(geofeature)
 
@@ -992,11 +1010,11 @@ def create_report(scope):
         if not synthese.has_instance_permission(scope):
             raise Forbidden
         # only allow one alert by id_synthese
-        if type_name == 'alert':
-            alert_exists = DB.session.query(TReport).join("report_type").\
-                options(contains_eager("report_type")).\
-                filter(TReport.id_synthese == id_synthese, BibReportsTypes.type==type_name).\
-                one_or_none()
+        if type_name == "alert":
+            alert_exists = TReport.query.filter(
+                TReport.id_synthese == id_synthese,
+                TReport.report_type.has(BibReportsTypes.type == type_name),
+            ).one_or_none()
             if alert_exists is not None:
                 raise Conflict("Alert already exists for this id")
     except KeyError:
@@ -1039,45 +1057,47 @@ def update_content_report(id_report):
 def list_reports(scope):
     type_name = request.args.get("type")
     id_synthese = request.args.get("idSynthese")
-    sort=request.args.get("sort")
+    sort = request.args.get("sort")
     # VERIFY ID SYNTHESE
     synthese = Synthese.query.get_or_404(id_synthese)
     if not synthese.has_instance_permission(scope):
         raise Forbidden
     # START REQUEST
-    req = DB.session.query(TReport).join("report_type").\
-            options(contains_eager("report_type")).\
-            filter(TReport.id_synthese == id_synthese)
+    req = TReport.query.filter(TReport.id_synthese == id_synthese)
+    # SORT
+    if sort == "asc":
+        req = req.order_by(asc(TReport.creation_date))
+    if sort == "desc":
+        req = req.order_by(desc(TReport.creation_date))
     # VERIFY AND SET TYPE
     type_exists = BibReportsTypes.query.filter_by(type=type_name).one_or_none()
     # type param is not required to get all
     if type_name and not type_exists:
-        raise BadRequest('This report type does not exist')
-    req = req.filter(BibReportsTypes.type==type_name)
-    # SORT
-    if sort == 'asc':
-        req = req.order_by(asc(TReport.creation_date))
-    if sort == "desc":
-        req = req.order_by(desc(TReport.creation_date))
-    # get results by type
+        raise BadRequest("This report type does not exist")
     if type_name:
-        req = req.filter(BibReportsTypes.type==type_name)
+        req = req.filter(TReport.report_type.has(BibReportsTypes.type == type_name))
     # filter by id_role for pin type only
     if type_name and type_name == "pin":
-        req = req.filter(TReport.id_role==g.current_user.id_role)
+        req = req.filter(TReport.id_role == g.current_user.id_role)
+    req = req.options(
+        joinedload("user").load_only("nom_role", "prenom_role"), joinedload("report_type")
+    )
     result = [
-        report.as_dict(fields=[
-            "id_report",
-            "id_synthese",
-            "id_role",
-            "report_type.type",
-            "report_type.id_type",
-            "content",
-            "deleted",
-            "creation_date",
-            "user.nom_role",
-            "user.prenom_role"
-        ]) for report in req.all()
+        report.as_dict(
+            fields=[
+                "id_report",
+                "id_synthese",
+                "id_role",
+                "report_type.type",
+                "report_type.id_type",
+                "content",
+                "deleted",
+                "creation_date",
+                "user.nom_role",
+                "user.prenom_role",
+            ]
+        )
+        for report in req.all()
     ]
     return jsonify(result)
 
@@ -1087,49 +1107,21 @@ def list_reports(scope):
 @json_resp
 def delete_report(id_report):
     reportItem = TReport.query.get_or_404(id_report)
-    if reportItem.report_type.type == "alert":
-        raise Forbidden("This service can't delete alert")
-    if reportItem.id_role != g.current_user.id_role:
+    # alert control to check cruved - allow validators only
+    if reportItem.report_type.type in ["alert", "pin"]:
+        scope = get_scopes_by_action(module_code="VALIDATION")["R"]
+        if not reportItem.synthese.has_instance_permission(scope):
+            raise Forbidden("Permission required to delete this report !")
+    # only owner could delete a report for pin and discussion
+    if reportItem.id_role != g.current_user.id_role and reportItem.report_type.type in [
+        "discussion",
+        "pin",
+    ]:
         raise Forbidden
+    # discussion control to don't delete but tag report as deleted only
     if reportItem.report_type.type == "discussion":
         reportItem.content = ""
         reportItem.deleted = True
     else:
         DB.session.delete(reportItem)
     DB.session.commit()
-
-
-@routes.route('/reports/alert/<int:id_report>', methods=["DELETE"])
-@permissions.check_cruved_scope("V", get_scope=True, module_code="VALIDATION")
-@json_resp
-def delete_alert_report(scope, id_report):
-    # all validator could delete an alert
-    # only owner can delete a discussion or a pin
-    reportItem = TReport.query.get_or_404(id_report)
-    if reportItem.report_type.type != "alert":
-        raise Forbidden("This service delete alert only !")
-    DB.session.delete(reportItem)
-    DB.session.commit()
-
-@routes.route('/reports/<string:type_name>', methods=["GET"])
-@permissions.check_cruved_scope("R", get_scope=True, module_code="SYNTHESE")
-def get_all_reports_by_type(scope, type_name):
-    if not type:
-        raise BadRequest("Type param is required !")
-    req = DB.session.query(TReport).join("report_type").\
-        options(contains_eager("report_type")).\
-        filter(BibReportsTypes.type==type_name)
-    result = [
-        report.as_dict(fields=[
-            "id_report",
-            "id_synthese",
-            "id_role",
-            "report_type.type",
-            "report_type.id_type",
-            "content",
-            "deleted",
-            "creation_date",
-        ]) for report in req.all()
-    ]
-    return jsonify(result)
-

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -6,19 +6,11 @@ import time
 from collections import OrderedDict
 from warnings import warn
 
-from flask import (
-    Blueprint,
-    request,
-    Response,
-    current_app,
-    send_from_directory,
-    render_template,
-    jsonify,
-    g,
-)
-from werkzeug.exceptions import Forbidden, NotFound, BadRequest
+from flask import Blueprint, request, Response, current_app, \
+                  send_from_directory, render_template, jsonify, g
+from werkzeug.exceptions import Forbidden, NotFound, BadRequest, Conflict
 from sqlalchemy import distinct, func, desc, asc, select, text, update
-from sqlalchemy.orm import joinedload, selectinload, lazyload
+from sqlalchemy.orm import joinedload, contains_eager, lazyload
 from geojson import FeatureCollection, Feature
 import sqlalchemy as sa
 
@@ -999,6 +991,14 @@ def create_report(scope):
         synthese = Synthese.query.get_or_404(id_synthese)
         if not synthese.has_instance_permission(scope):
             raise Forbidden
+        # only allow one alert by id_synthese
+        if type_name == 'alert':
+            alert_exists = DB.session.query(TReport).join("report_type").\
+                options(contains_eager("report_type")).\
+                filter(TReport.id_synthese == id_synthese, BibReportsTypes.type==type_name).\
+                one_or_none()
+            if alert_exists is not None:
+                raise Conflict("Alert already exists for this id")
     except KeyError:
         raise BadRequest("Empty request data")
     new_entry = TReport(
@@ -1039,47 +1039,45 @@ def update_content_report(id_report):
 def list_reports(scope):
     type_name = request.args.get("type")
     id_synthese = request.args.get("idSynthese")
-    sort = request.args.get("sort")
-    # READ REQUEST PARAMS
+    sort=request.args.get("sort")
+    # VERIFY ID SYNTHESE
     synthese = Synthese.query.get_or_404(id_synthese)
     if not synthese.has_instance_permission(scope):
         raise Forbidden
-    req = TReport.query.filter(TReport.id_synthese == id_synthese)
+    # START REQUEST
+    req = DB.session.query(TReport).join("report_type").\
+            options(contains_eager("report_type")).\
+            filter(TReport.id_synthese == id_synthese)
+    # VERIFY AND SET TYPE
     type_exists = BibReportsTypes.query.filter_by(type=type_name).one_or_none()
     # type param is not required to get all
     if type_name and not type_exists:
-        raise BadRequest("This report type does not exist")
-    # sort
-    if sort == "asc":
+        raise BadRequest('This report type does not exist')
+    req = req.filter(BibReportsTypes.type==type_name)
+    # SORT
+    if sort == 'asc':
         req = req.order_by(asc(TReport.creation_date))
     if sort == "desc":
         req = req.order_by(desc(TReport.creation_date))
-    # join user and bib_reports_types tables
-    result = req.options(
-        joinedload("user").load_only("nom_role", "prenom_role"), joinedload("report_type")
-    )
     # get results by type
     if type_name:
-        result = result.filter(BibReportsTypes.type == type_name)
+        req = req.filter(BibReportsTypes.type==type_name)
     # filter by id_role for pin type only
     if type_name and type_name == "pin":
-        result = result.filter(TReport.id_role == g.current_user.id_role)
+        req = req.filter(TReport.id_role==g.current_user.id_role)
     result = [
-        report.as_dict(
-            fields=[
-                "id_report",
-                "id_synthese",
-                "id_role",
-                "report_type.type",
-                "report_type.id_type",
-                "content",
-                "deleted",
-                "creation_date",
-                "user.nom_role",
-                "user.prenom_role",
-            ]
-        )
-        for report in result.all()
+        report.as_dict(fields=[
+            "id_report",
+            "id_synthese",
+            "id_role",
+            "report_type.type",
+            "report_type.id_type",
+            "content",
+            "deleted",
+            "creation_date",
+            "user.nom_role",
+            "user.prenom_role"
+        ]) for report in req.all()
     ]
     return jsonify(result)
 
@@ -1089,7 +1087,8 @@ def list_reports(scope):
 @json_resp
 def delete_report(id_report):
     reportItem = TReport.query.get_or_404(id_report)
-
+    if reportItem.report_type.type == "alert":
+        raise Forbidden("This service can't delete alert")
     if reportItem.id_role != g.current_user.id_role:
         raise Forbidden
     if reportItem.report_type.type == "discussion":
@@ -1098,3 +1097,39 @@ def delete_report(id_report):
     else:
         DB.session.delete(reportItem)
     DB.session.commit()
+
+
+@routes.route('/reports/alert/<int:id_report>', methods=["DELETE"])
+@permissions.check_cruved_scope("V", get_scope=True, module_code="VALIDATION")
+@json_resp
+def delete_alert_report(scope, id_report):
+    # all validator could delete an alert
+    # only owner can delete a discussion or a pin
+    reportItem = TReport.query.get_or_404(id_report)
+    if reportItem.report_type.type != "alert":
+        raise Forbidden("This service delete alert only !")
+    DB.session.delete(reportItem)
+    DB.session.commit()
+
+@routes.route('/reports/<string:type_name>', methods=["GET"])
+@permissions.check_cruved_scope("R", get_scope=True, module_code="SYNTHESE")
+def get_all_reports_by_type(scope, type_name):
+    if not type:
+        raise BadRequest("Type param is required !")
+    req = DB.session.query(TReport).join("report_type").\
+        options(contains_eager("report_type")).\
+        filter(BibReportsTypes.type==type_name)
+    result = [
+        report.as_dict(fields=[
+            "id_report",
+            "id_synthese",
+            "id_role",
+            "report_type.type",
+            "report_type.id_type",
+            "content",
+            "deleted",
+            "creation_date",
+        ]) for report in req.all()
+    ]
+    return jsonify(result)
+

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -26,7 +26,7 @@ from geonature.core.gn_synthese.models import (
     TSources,
     CorAreaSynthese,
     BibReportsTypes,
-    TReport
+    TReport,
 )
 from geonature.core.gn_meta.models import (
     TAcquisitionFramework,
@@ -229,10 +229,9 @@ class SyntheseQuery:
         if "has_medias" in self.filters:
             self.query = self.query.where(self.model.medias.any())
 
-
         if "has_alert" in self.filters:
             self.query = self.query.where(
-                self.model.reports.any(TReport.report_type.has(BibReportsTypes.type=="alert"))
+                self.model.reports.any(TReport.report_type.has(BibReportsTypes.type == "alert"))
             )
 
         if "id_dataset" in self.filters:

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -25,6 +25,8 @@ from geonature.core.gn_synthese.models import (
     CorObserverSynthese,
     TSources,
     CorAreaSynthese,
+    BibReportsTypes,
+    TReport
 )
 from geonature.core.gn_meta.models import (
     TAcquisitionFramework,
@@ -224,9 +226,14 @@ class SyntheseQuery:
         """
         Other filters
         """
-
         if "has_medias" in self.filters:
             self.query = self.query.where(self.model.medias.any())
+
+
+        if "has_alert" in self.filters:
+            self.query = self.query.where(
+                self.model.reports.any(TReport.report_type.has(BibReportsTypes.type=="alert"))
+            )
 
         if "id_dataset" in self.filters:
             self.query = self.query.where(

--- a/backend/geonature/tests/test_reports.py
+++ b/backend/geonature/tests/test_reports.py
@@ -74,27 +74,7 @@ class TestReports:
         assert db.session.query(
             TReport.query.filter_by(id_report=discussionReportId).exists()
         ).scalar()
-        # ERROR - NOT DELETE ALERT
-        set_logged_user_cookie(self.client, users['admin_user'])
-        response = self.client.delete(url_for(url, id_report=alertReportId))
-        assert db.session.query(
-            TReport.query.filter_by(id_report=alertReportId).exists()
-        ).scalar()
-
-    def test_delete_alert(self, reports_data, users):
-        url = "gn_synthese.delete_alert_report"
-        # ALERT - ERROR - DELETE WITH NO RIGHT
-        set_logged_user_cookie(self.client, users['noright_user'])
-        alertIdType = BibReportsTypes.query.filter(BibReportsTypes.type == "alert").first().id_type
-        alertReportId = TReport.query.filter(TReport.id_type == alertIdType).first().id_report
-        response = self.client.delete(url_for(url, id_report=alertReportId))
-        assert response.status_code == Forbidden.code
-        # ALERT - ERROR - DELETE DISCUSSION NOT ACCEPTED
-        set_logged_user_cookie(self.client, users['admin_user'])
-        otherReportId = TReport.query.filter(TReport.id_type != alertIdType).first().id_report
-        response = self.client.delete(url_for(url, id_report=otherReportId))
-        assert response.status_code == Forbidden.code
-        # ALERT - OK - DELETE ALERT
+        # SUCCESS - DELETE ALERT
         response = self.client.delete(url_for(url, id_report=alertReportId))
         assert not db.session.query(
             TReport.query.filter_by(id_report=alertReportId).exists()
@@ -116,7 +96,7 @@ class TestReports:
         assert response.status_code == 200
         assert len(response.json) == 1
         # TEST NO RESULT
-        if len(ids) > 1 :
+        if len(ids) > 1:
             # not exists because ids[1] is an alert
             response = self.client.get(url_for(url, idSynthese=ids[1], type="discussion"))
             assert response.status_code == 200

--- a/backend/geonature/tests/test_reports.py
+++ b/backend/geonature/tests/test_reports.py
@@ -58,6 +58,9 @@ class TestReports:
             .first()
             .id_report
         )
+        # get alert item
+        alertIdType = BibReportsTypes.query.filter(BibReportsTypes.type == "alert").first().id_type
+        alertReportId = TReport.query.filter(TReport.id_type == alertIdType).first().id_report
         # DELETE WITHOUT AUTH
         response = self.client.delete(url_for(url, id_report=discussionReportId))
         assert response.status_code == 401
@@ -71,11 +74,30 @@ class TestReports:
         assert db.session.query(
             TReport.query.filter_by(id_report=discussionReportId).exists()
         ).scalar()
-        # SUCCESS - DELETE IF NOT DISCUSSION
-        set_logged_user_cookie(self.client, users["admin_user"])
-        response = self.client.delete(url_for(url, id_report=notDiscussionReportId))
+        # ERROR - NOT DELETE ALERT
+        set_logged_user_cookie(self.client, users['admin_user'])
+        response = self.client.delete(url_for(url, id_report=alertReportId))
+        assert db.session.query(
+            TReport.query.filter_by(id_report=alertReportId).exists()
+        ).scalar()
+
+    def test_delete_alert(self, reports_data, users):
+        url = "gn_synthese.delete_alert_report"
+        # ALERT - ERROR - DELETE WITH NO RIGHT
+        set_logged_user_cookie(self.client, users['noright_user'])
+        alertIdType = BibReportsTypes.query.filter(BibReportsTypes.type == "alert").first().id_type
+        alertReportId = TReport.query.filter(TReport.id_type == alertIdType).first().id_report
+        response = self.client.delete(url_for(url, id_report=alertReportId))
+        assert response.status_code == Forbidden.code
+        # ALERT - ERROR - DELETE DISCUSSION NOT ACCEPTED
+        set_logged_user_cookie(self.client, users['admin_user'])
+        otherReportId = TReport.query.filter(TReport.id_type != alertIdType).first().id_report
+        response = self.client.delete(url_for(url, id_report=otherReportId))
+        assert response.status_code == Forbidden.code
+        # ALERT - OK - DELETE ALERT
+        response = self.client.delete(url_for(url, id_report=alertReportId))
         assert not db.session.query(
-            TReport.query.filter_by(id_report=notDiscussionReportId).exists()
+            TReport.query.filter_by(id_report=alertReportId).exists()
         ).scalar()
 
     def test_list_reports(self, reports_data, synthese_data, users):
@@ -94,10 +116,11 @@ class TestReports:
         assert response.status_code == 200
         assert len(response.json) == 1
         # TEST NO RESULT
-        if len(ids) > 1:
+        if len(ids) > 1 :
+            # not exists because ids[1] is an alert
             response = self.client.get(url_for(url, idSynthese=ids[1], type="discussion"))
             assert response.status_code == 200
-            assert len(response.json) == 1
+            assert len(response.json) == 0
             # TEST TYPE NOT EXISTS
             response = self.client.get(url_for(url, idSynthese=ids[1], type="foo"))
             assert response.status_code == BadRequest.code

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -303,6 +303,8 @@ class Synthese(Schema):
     DISCUSSION_MAX_LENGTH = fields.Integer(load_default=1500)
     # Allow disable discussion tab for synthese or validation
     DISCUSSION_MODULES = fields.List(fields.String(), load_default=["SYNTHESE", "VALIDATION"])
+    # Allow disable alert synthese module for synthese or validation or any
+    ALERT_MODULES = fields.List(fields.String(), load_default=["SYNTHESE", "VALIDATION"])
 
 
 # Map configuration

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -395,6 +395,7 @@ MAIL_ON_ERROR = false
     ]
     DISCUSSION_MODULES = ["SYNTHESE","VALIDATION"]
     DICUSSION_MAX_LENGTH = 1500
+    ALERT_MODULES = ["SYNTHESE","VALIDATION"]
 
 # Configuration de l'accès sans authentication
 [PUBLIC_ACCESS]

--- a/contrib/gn_module_validation/backend/gn_module_validation/blueprint.py
+++ b/contrib/gn_module_validation/backend/gn_module_validation/blueprint.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy import select, func
 from sqlalchemy.sql.expression import cast, outerjoin
 from sqlalchemy.sql.sqltypes import Integer
-from sqlalchemy.orm import aliased, joinedload, contains_eager, relation
+from sqlalchemy.orm import aliased, joinedload, contains_eager, relation, selectinload
 from marshmallow import ValidationError
 
 from utils_flask_sqla.response import json_resp
@@ -19,7 +19,7 @@ from pypnnomenclature.models import TNomenclatures, BibNomenclaturesTypes
 
 from geonature.utils.env import DB, db
 from geonature.utils.utilssqlalchemy import test_is_uuid
-from geonature.core.gn_synthese.models import Synthese
+from geonature.core.gn_synthese.models import Synthese, TReport
 from geonature.core.gn_profiles.models import VConsistancyData
 from geonature.core.gn_synthese.utils.query_select_sqla import SyntheseQuery
 from geonature.core.gn_permissions import decorators as permissions
@@ -175,15 +175,20 @@ def get_synthese_data(info_role):
     )
 
     # Step 3: Construct Synthese model from query result
-    query = (
-        Synthese.query.options(
-            *[contains_eager(rel, alias=alias) for rel, alias in zip(relationships, aliases)]
+    syntheseModelQuery = Synthese.query.options(
+        *[contains_eager(rel, alias=alias) for rel, alias in zip(relationships, aliases)]
+    ).options(*[contains_eager(rel, alias=alias) for alias, rel in lateral_join.items()])
+    if len(current_app.config["SYNTHESE"]["ALERT_MODULES"]):
+        fields |= {"reports.report_type.type"}
+        syntheseModelQuery.options(
+            *[contains_eager(rel, alias=alias) for alias, rel in lateral_join.items()]
         )
-        .options(*[contains_eager(rel, alias=alias) for alias, rel in lateral_join.items()])
-        .from_statement(query)
-    )
+
+    query = syntheseModelQuery.options(
+        selectinload(Synthese.reports).joinedload(TReport.report_type)
+    ).from_statement(query)
     # The raise option ensure that we have correctly retrived relationships data at step 3
-    return jsonify(query.as_geofeaturecollection(fields=fields, unloaded="raise"))
+    return jsonify(query.as_geofeaturecollection(fields=fields))
 
 
 @blueprint.route("/statusNames", methods=["GET"])

--- a/contrib/gn_module_validation/backend/gn_module_validation/blueprint.py
+++ b/contrib/gn_module_validation/backend/gn_module_validation/blueprint.py
@@ -178,15 +178,14 @@ def get_synthese_data(info_role):
     syntheseModelQuery = Synthese.query.options(
         *[contains_eager(rel, alias=alias) for rel, alias in zip(relationships, aliases)]
     ).options(*[contains_eager(rel, alias=alias) for alias, rel in lateral_join.items()])
+
+    # to pass alert reports infos with synthese to validation list
     if len(current_app.config["SYNTHESE"]["ALERT_MODULES"]):
         fields |= {"reports.report_type.type"}
-        syntheseModelQuery.options(
-            *[contains_eager(rel, alias=alias) for alias, rel in lateral_join.items()]
+        syntheseModelQuery = syntheseModelQuery.options(
+            selectinload(Synthese.reports).joinedload(TReport.report_type)
         )
-
-    query = syntheseModelQuery.options(
-        selectinload(Synthese.reports).joinedload(TReport.report_type)
-    ).from_statement(query)
+    query = syntheseModelQuery.from_statement(query)
     # The raise option ensure that we have correctly retrived relationships data at step 3
     return jsonify(query.as_geofeaturecollection(fields=fields))
 

--- a/contrib/gn_module_validation/frontend/app/components/validation-modal-info-obs/validation-modal-info-obs.component.ts
+++ b/contrib/gn_module_validation/frontend/app/components/validation-modal-info-obs/validation-modal-info-obs.component.ts
@@ -125,6 +125,7 @@ export class ValidationModalInfoObsComponent implements OnInit {
 
   closeModal() {
     this.activeModal.close();
+    this.onCloseModal.emit();
   }
 
   backToModule(url_source, id_pk_source) {

--- a/contrib/gn_module_validation/frontend/app/components/validation-modal-info-obs/validation-modal-info-obs.component.ts
+++ b/contrib/gn_module_validation/frontend/app/components/validation-modal-info-obs/validation-modal-info-obs.component.ts
@@ -31,6 +31,7 @@ export class ValidationModalInfoObsComponent implements OnInit {
   @Input() uuidSynthese: any;
   @Output() modifiedStatus = new EventEmitter();
   @Output() valDate = new EventEmitter();
+  @Output() onCloseModal = new EventEmitter();
 
   constructor(
     public mapListService: MapListService,
@@ -38,7 +39,7 @@ export class ValidationModalInfoObsComponent implements OnInit {
     public activeModal: NgbActiveModal,
     private _fb: FormBuilder,
     private _commonService: CommonService,
-    private _validService : ValidationService
+    private _validService: ValidationService
   ) {
     // form used for changing validation status
     this.statusForm = this._fb.group({
@@ -67,7 +68,7 @@ export class ValidationModalInfoObsComponent implements OnInit {
 
   setValidationStatus(validStatus) {
     const color = this.VALIDATION_CONFIG.STATUS_INFO[validStatus.cd_nomenclature].color;
-    this.currentValidationStatus = {...validStatus, color: color};
+    this.currentValidationStatus = { ...validStatus, color: color };
   }
 
   setCurrentCdNomenclature(item) {
@@ -115,7 +116,7 @@ export class ValidationModalInfoObsComponent implements OnInit {
     this.id_synthese = this.filteredIds[
       this.filteredIds.indexOf(this.id_synthese) + 1
     ];
-    
+
     const syntheseRow = this.mapListService.tableData[this.position];
     this.uuidSynthese = syntheseRow.unique_id_sinp;
     this.statusForm.reset();
@@ -142,7 +143,7 @@ export class ValidationModalInfoObsComponent implements OnInit {
         this.setValidationStatus(newValidationStatus);
         this.statusForm.reset();
         this.editStatus();
-      })      
+      })
   }
 
   cancel() {

--- a/contrib/gn_module_validation/frontend/app/components/validation-synthese-list/validation-synthese-list.component.html
+++ b/contrib/gn_module_validation/frontend/app/components/validation-synthese-list/validation-synthese-list.component.html
@@ -82,6 +82,12 @@
         [disabled]="row.unique_id_sinp == null"
       >
       </button>
+      <i
+        *ngIf="getAlertByRow(row)"
+        class="fa fa-flag"
+        aria-hidden="true"
+        [title]="getAlertByRow(row)?.content"
+      ></i>
     </ng-template>
   </ngx-datatable-column>
 

--- a/contrib/gn_module_validation/frontend/app/components/validation-synthese-list/validation-synthese-list.component.html
+++ b/contrib/gn_module_validation/frontend/app/components/validation-synthese-list/validation-synthese-list.component.html
@@ -83,10 +83,10 @@
       >
       </button>
       <i
-        *ngIf="getAlertByRow(row)"
+        *ngIf="findAlertInfo(row)"
         class="fa fa-flag"
         aria-hidden="true"
-        [title]="getAlertByRow(row)?.content"
+        [title]="findAlertInfo(row, 'content')"
       ></i>
     </ng-template>
   </ngx-datatable-column>

--- a/contrib/gn_module_validation/frontend/app/components/validation-synthese-list/validation-synthese-list.component.ts
+++ b/contrib/gn_module_validation/frontend/app/components/validation-synthese-list/validation-synthese-list.component.ts
@@ -51,6 +51,7 @@ export class ValidationSyntheseListComponent
   @Output() pageChange: EventEmitter<number>;
   @Output() displayAll = new EventEmitter<any>();
   @Input() idSynthese: any;
+  public alertsData: any;
   public validationStatusAsDict: any;
   public datatable_column_list: Array<any>
   public messages: any;
@@ -83,6 +84,8 @@ export class ValidationSyntheseListComponent
     this.messages = {
       emptyMessage: this.idSynthese ? this.translate.instant("Validation.noIdFound") : this.translate.instant("Validation.noData")
     };
+
+    this.getAlerts();
   }
 
   onMapClick() {
@@ -90,11 +93,11 @@ export class ValidationSyntheseListComponent
       this.mapListService.selectedRow = [];
       const integerId = parseInt(id);
       let i;
-      for (i = 0; i < this.mapListService.tableData.length; i++) {        
+      for (i = 0; i < this.mapListService.tableData.length; i++) {
         if (this.mapListService.tableData[i]["id_synthese"] === integerId) {
           this.mapListService.selectedRow.push(
             this.mapListService.tableData[i]
-          );          
+          );
           break;
         }
       }
@@ -234,10 +237,11 @@ export class ValidationSyntheseListComponent
       this.openInfoModal(this.inputSyntheseData.filter(i => i.id_synthese == this?.idSynthese)[0])
     }
     this.deselectAll();
+    this.getAlerts();
   }
 
   openInfoModal(row) {
-    if(!row) return;
+    if (!row) return;
     this.oneSyntheseObs = row;
     const modalRef = this.ngbModal.open(ValidationModalInfoObsComponent, {
       size: "lg",
@@ -267,5 +271,16 @@ export class ValidationSyntheseListComponent
       }
       this.mapListService.selectedRow = [...this.mapListService.selectedRow];
     });
+  }
+
+  getAlertByRow(row) {
+    return this.alertsData.filter(alert => alert.id_synthese == row.id_synthese)[0];
+  }
+
+  getAlerts() {
+    this.alertsData = [];
+    if (this.appConfig.SYNTHESE.ALERT_MODULES.includes("VALIDATION")) {
+      this._ds.getReportsByType("alert").subscribe(data => { this.alertsData = data });
+    }
   }
 }

--- a/contrib/gn_module_validation/frontend/app/services/data.service.ts
+++ b/contrib/gn_module_validation/frontend/app/services/data.service.ts
@@ -58,8 +58,4 @@ export class ValidationDataService {
   deleteReport(id) {
     return this._http.delete(`${AppConfig.API_ENDPOINT}/synthese/reports/${id}`)
   }
-
-  deleteAlertReport(id) {
-    return this._http.delete(`${AppConfig.API_ENDPOINT}/synthese/reports/alert/${id}`)
-  }
 }

--- a/contrib/gn_module_validation/frontend/app/services/data.service.ts
+++ b/contrib/gn_module_validation/frontend/app/services/data.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from "@angular/core";
 import { HttpClient, HttpHeaders, HttpParams } from "@angular/common/http";
 import { AppConfig } from "@geonature_config/app.config";
 import { CommonService } from "@geonature_common/service/common.service";
-import {Nomenclature} from "@geonature_common/interfaces";
+import { Nomenclature } from "@geonature_common/interfaces";
 
 @Injectable()
 export class ValidationDataService {
@@ -51,11 +51,15 @@ export class ValidationDataService {
   createReport(params) {
     return this._http.put(`${AppConfig.API_ENDPOINT}/synthese/reports`,
       params, {
-        headers: new HttpHeaders().set('Content-Type', 'application/json')
-      });
+      headers: new HttpHeaders().set('Content-Type', 'application/json')
+    });
   }
 
   deleteReport(id) {
     return this._http.delete(`${AppConfig.API_ENDPOINT}/synthese/reports/${id}`)
+  }
+
+  deleteAlertReport(id) {
+    return this._http.delete(`${AppConfig.API_ENDPOINT}/synthese/reports/alert/${id}`)
   }
 }

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/dynamicFormConfig.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/dynamicFormConfig.ts
@@ -1,5 +1,12 @@
 export const DYNAMIC_FORM_DEF = [
   {
+    attribut_name: 'has_alert',
+    type_widget: 'bool_checkbox',
+    attribut_label: "Est signalé",
+    required: false,
+    value: true
+  },
+  {
     attribut_name: 'has_medias',
     type_widget: 'bool_checkbox',
     attribut_label: 'Possède des médias',

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/dynamicFormConfig.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/dynamicFormConfig.ts
@@ -2,9 +2,9 @@ export const DYNAMIC_FORM_DEF = [
   {
     attribut_name: 'has_alert',
     type_widget: 'bool_checkbox',
-    attribut_label: "Est signalé",
+    attribut_label: 'Est signalé',
     required: false,
-    value: true
+    value: true,
   },
   {
     attribut_name: 'has_medias',

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
@@ -230,6 +230,12 @@ export class SyntheseDataService {
     return this._api.get(`${AppConfig.API_ENDPOINT}/synthese/reports?${params}`);
   }
 
+  getReportsByType(type) {
+    return this._api.get(
+      `${AppConfig.API_ENDPOINT}/synthese/reports/${type}`
+    )
+  }
+
   createReport(params) {
     return this._api.post(`${AppConfig.API_ENDPOINT}/synthese/reports`, params);
   }
@@ -240,5 +246,9 @@ export class SyntheseDataService {
 
   modifyReport(id, params) {
     return this._api.put(`${AppConfig.API_ENDPOINT}/synthese/reports/${id}`, params);
+  }
+
+  deleteAlertReport(id) {
+    return this._api.delete(`${AppConfig.API_ENDPOINT}/synthese/reports/alert/${id}`)
   }
 }

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
@@ -230,12 +230,6 @@ export class SyntheseDataService {
     return this._api.get(`${AppConfig.API_ENDPOINT}/synthese/reports?${params}`);
   }
 
-  getReportsByType(type) {
-    return this._api.get(
-      `${AppConfig.API_ENDPOINT}/synthese/reports/${type}`
-    )
-  }
-
   createReport(params) {
     return this._api.post(`${AppConfig.API_ENDPOINT}/synthese/reports`, params);
   }
@@ -246,9 +240,5 @@ export class SyntheseDataService {
 
   modifyReport(id, params) {
     return this._api.put(`${AppConfig.API_ENDPOINT}/synthese/reports/${id}`, params);
-  }
-
-  deleteAlertReport(id) {
-    return this._api.delete(`${AppConfig.API_ENDPOINT}/synthese/reports/alert/${id}`)
   }
 }

--- a/frontend/src/app/shared/alertInfoModule/alert-Info.component.html
+++ b/frontend/src/app/shared/alertInfoModule/alert-Info.component.html
@@ -1,0 +1,74 @@
+<div
+  id="createAlert"
+  class="m-4"
+>
+  <p [ngStyle]="{'font-size': '16px'}">Description du signalement :</p>
+  <form
+    class="
+    my-3"
+    *ngIf="!alert?.content"
+  >
+    <mat-form-field
+      appearance="fill"
+      style="width:100%"
+      focused
+      class="my-3 alert-field"
+    >
+      <mat-label class="gn-color">Détailler ici le signalement :</mat-label>
+      <textarea
+        matInput
+        placeholder="Votre commentaire...."
+        [formControl]="alertForm.controls.content"
+      ></textarea>
+      <mat-error *ngIf="!this.alertForm.valid">
+        Veuillez saisir un commentaire
+      </mat-error>
+    </mat-form-field>
+  </form>
+  <mat-card *ngIf="alert?.content">{{alert?.content}}</mat-card>
+  <div class="mt-4">
+    <button
+      id="cancelAlertBtn"
+      mat-raised-button
+      class="btn btn-sm mt-2 mr-2 link-infos"
+      type="submit"
+      data-dismiss="modal"
+      (click)="openCloseAlert()"
+    >
+      <mat-icon>west</mat-icon> Retour
+    </button>
+    <button
+      *ngIf="!alert || !alert?.id_report"
+      mat-raised-button
+      id="saveAlertButton"
+      (click)="createAlert()"
+      data-toggle="modal"
+      value="Signaler"
+      type="button"
+      [disabled]="!this.alertForm.valid"
+      class="btn btn-sm mt-2 mr-2 link-infos"
+      data-dismiss="modal"
+      #required
+    >
+      <mat-icon>check</mat-icon> Enregistrer
+    </button>
+    <button
+      mat-raised-button
+      *ngIf="canChangeAlert"
+      id="deleteAlertButton"
+      (click)="deleteAlert()"
+      data-toggle="modal"
+      value="delete"
+      color="success"
+      type="button"
+      class="btn btn-sm mt-2 mr-2 link-infos"
+      data-dismiss="modal"
+      ngbTooltip="Supprimer ce signalement"
+      placement="bottom"
+      color="primary"
+      #required
+    >
+      <mat-icon>verified</mat-icon> Signalement pris en compte !
+    </button>
+  </div>
+</div>

--- a/frontend/src/app/shared/alertInfoModule/alert-Info.component.scss
+++ b/frontend/src/app/shared/alertInfoModule/alert-Info.component.scss
@@ -1,0 +1,27 @@
+.link-infos {
+  border: 1px solid #673ab7;
+}
+.saveBtn {
+  background-color: #673ab7;
+  color: white;
+}
+.cancelBtn {
+  color: #673ab7;
+}
+
+::ng-deep .alert-field textarea {
+  border-left: 1px solid transparent !important;
+}
+
+::ng-deep  .alert-field {
+  border: 1px solid transparent !important;
+}
+
+.link-infos.mat-button-disabled {
+  color: white;
+  background-color: rgba(104, 58, 183, 0.226);
+}
+
+#deleteAlertButton{
+  color: gold;
+}

--- a/frontend/src/app/shared/alertInfoModule/alert-Info.component.ts
+++ b/frontend/src/app/shared/alertInfoModule/alert-Info.component.ts
@@ -1,0 +1,85 @@
+import { Component, OnInit, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { GlobalSubService } from '@geonature/services/global-sub.service';
+import { SyntheseDataService } from '@geonature_common/form/synthese-form/synthese-data.service';
+import { CommonService } from '@geonature_common/service/common.service';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { filter } from 'rxjs/operators';
+
+@Component({
+  selector: 'pnx-alert-info',
+  templateUrl: 'alert-Info.component.html',
+  styleUrls: ['alert-Info.component.scss']
+})
+
+/**
+ * Usefull (modal-body) optional component with form to create, read or delete an alert report type
+ * Only validator could delete an alert. Everybody could create one.
+ * Ref. config : ALERT_MODULES<Array>
+ */
+export class AlertInfoComponent implements OnInit, OnChanges {
+  @Input() idSynthese: number;
+  @Input() alert: any;
+  @Output() changeVisibility = new EventEmitter();
+  public moduleSub: any;
+  public userCruved: any;
+  public alertForm: FormGroup;
+  public canChangeAlert = false;
+  constructor(
+    private _formBuilder: FormBuilder,
+    private _commonService: CommonService,
+    private _syntheseDataService: SyntheseDataService,
+    public globalSub: GlobalSubService,
+  ) {
+    // a simple form
+    this.alertForm = this._formBuilder
+      .group({
+        content: ['', Validators.required]
+      });
+  }
+  ngOnInit() {
+    this.setCruved()
+  }
+  /**
+   * Display delete alert button for validator only
+   */
+  setCruved() {
+    this.moduleSub = this.globalSub.currentModuleSub
+      // filter undefined or null
+      .pipe(filter((mod) => mod))
+      .subscribe((mod) => {
+        this.userCruved = mod.cruved;
+      });
+  }
+  ngOnChanges() {
+    this.canChangeAlert = this.userCruved?.V && this.userCruved?.V > 0 && this.alert?.id_report;
+  }
+  /**
+   * Create new alert with /reports GET service
+   */
+  createAlert() {
+    this._syntheseDataService.createReport({
+      type: 'alert',
+      item: this.idSynthese,
+      content: this.alertForm.get('content').value
+    }).subscribe(
+      success => {
+        this._commonService.translateToaster('success', 'Signalement sauvegardé !');
+        this.openCloseAlert();
+      }
+    );
+  }
+  /**
+   * Manage alert form visibility
+   */
+  openCloseAlert() {
+    this.changeVisibility.emit(false);
+  }
+  /**
+   * Remove alert with /reports DELETE service
+   */
+  deleteAlert() {
+    this._syntheseDataService.deleteAlertReport(this.alert.id_report).subscribe(() => {
+      this.openCloseAlert();
+    });
+  }
+}

--- a/frontend/src/app/shared/alertInfoModule/alert-Info.component.ts
+++ b/frontend/src/app/shared/alertInfoModule/alert-Info.component.ts
@@ -4,11 +4,12 @@ import { SyntheseDataService } from '@geonature_common/form/synthese-form/synthe
 import { CommonService } from '@geonature_common/service/common.service';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { filter } from 'rxjs/operators';
+import { isEmpty } from 'lodash';
 
 @Component({
   selector: 'pnx-alert-info',
   templateUrl: 'alert-Info.component.html',
-  styleUrls: ['alert-Info.component.scss']
+  styleUrls: ['alert-Info.component.scss'],
 })
 
 /**
@@ -28,16 +29,15 @@ export class AlertInfoComponent implements OnInit, OnChanges {
     private _formBuilder: FormBuilder,
     private _commonService: CommonService,
     private _syntheseDataService: SyntheseDataService,
-    public globalSub: GlobalSubService,
+    public globalSub: GlobalSubService
   ) {
     // a simple form
-    this.alertForm = this._formBuilder
-      .group({
-        content: ['', Validators.required]
-      });
+    this.alertForm = this._formBuilder.group({
+      content: ['', Validators.required],
+    });
   }
   ngOnInit() {
-    this.setCruved()
+    this.setCruved();
   }
   /**
    * Display delete alert button for validator only
@@ -51,34 +51,35 @@ export class AlertInfoComponent implements OnInit, OnChanges {
       });
   }
   ngOnChanges() {
-    this.canChangeAlert = this.userCruved?.V && this.userCruved?.V > 0 && this.alert?.id_report;
+    this.canChangeAlert = this.userCruved?.V && this.userCruved?.V > 0 && !isEmpty(this.alert);
   }
   /**
    * Create new alert with /reports GET service
    */
   createAlert() {
-    this._syntheseDataService.createReport({
-      type: 'alert',
-      item: this.idSynthese,
-      content: this.alertForm.get('content').value
-    }).subscribe(
-      success => {
+    this._syntheseDataService
+      .createReport({
+        type: 'alert',
+        item: this.idSynthese,
+        content: this.alertForm.get('content').value,
+      })
+      .subscribe((success) => {
         this._commonService.translateToaster('success', 'Signalement sauvegardé !');
         this.openCloseAlert();
-      }
-    );
+      });
   }
   /**
    * Manage alert form visibility
    */
   openCloseAlert() {
-    this.changeVisibility.emit(false);
+    this.changeVisibility.emit();
   }
   /**
    * Remove alert with /reports DELETE service
    */
   deleteAlert() {
-    this._syntheseDataService.deleteAlertReport(this.alert.id_report).subscribe(() => {
+    this._syntheseDataService.deleteReport(this.alert.id_report).subscribe(() => {
+      this.alertForm.reset();
       this.openCloseAlert();
     });
   }

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.html
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.html
@@ -3,608 +3,599 @@
   *ngIf="isLoading"
 ></div>
 
-<<<<<<<
-  HEAD
-  <div
+<div
   *ngIf="header"
   class="modal-header padding-md-all"
 >
-  <h5 class="my-3 ml-3">{{ 'Synthese.ModalTitle' | translate }}</h5>
-  =======
-  <div
-    *ngIf="header"
-    class="modal-header padding-md-all"
-  >
-    <h5
-      *ngIf="!alertOpen"
-      class="my-3 ml-3"
-    >{{'Synthese.ModalTitle' | translate }}</h5>
-    <h5
-      *ngIf="alertOpen"
-      class="my-3 ml-3"
-    >Signalement</h5>
-    >>>>>>> 7fbe023d7 (create component alertInfoModule)
-    <button
-      type="button"
-      class="close"
-      aria-label="Close"
-      (click)="activeModal.dismiss('Cross click')"
-      [ngStyle]="{
+  <h5
+    *ngIf="!alertOpen"
+    class="my-3 ml-3"
+  >{{'Synthese.ModalTitle' | translate }}</h5>
+  <h5
+    *ngIf="alertOpen"
+    class="my-3 ml-3"
+  >Signalement</h5>
+  <button
+    type="button"
+    class="close"
+    aria-label="Close"
+    (click)="activeModal.dismiss('Cross click')"
+    [ngStyle]="{
       outlineWidth: '0px'
     }"
-    >
-      <span aria-hidden="true">&times;</span>
-    </button>
-  </div>
-
-  <mat-card
-    class="modal-body"
-    *ngIf="idSynthese && alertOpen"
   >
-    <mat-card-content *ngIf="activateAlert">
-      <span class="font-xs mb-2">
-        <pnx-alert-info
-          [idSynthese]="idSynthese"
-          [alert]="alert"
-          (changeVisibility)="openCloseAlert($event)"
-        ></pnx-alert-info>
-      </span>
-    </mat-card-content>
-  </mat-card>
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+
+<mat-card
+  class="modal-body"
+  *ngIf="idSynthese && alertOpen"
+>
+  <mat-card-content *ngIf="activateAlert">
+    <span class="font-xs mb-2">
+      <pnx-alert-info
+        [idSynthese]="idSynthese"
+        [alert]="alert"
+        (changeVisibility)="openCloseAlert($event)"
+      ></pnx-alert-info>
+    </span>
+  </mat-card-content>
+</mat-card>
 
 
-  <mat-card
-    class="modal-body"
-    *ngIf="!alertOpen"
-  >
-    <div class="d-flex w-100 justify-content-between">
-      <h4 class="mr-auto gn-color">
-        <a
-          class="no-link-style"
-          ngbTooltip="{{ 'Synthese.GnRecord' | translate }}"
+<mat-card
+  class="modal-body"
+  *ngIf="!alertOpen"
+>
+  <div class="d-flex w-100 justify-content-between">
+    <h4 class="mr-auto gn-color">
+      <a
+        class="no-link-style"
+        ngbTooltip="{{ 'Synthese.GnRecord' | translate }}"
+        placement="bottom"
+        *ngIf="selectedObsTaxonDetail && CONFIG.FRONTEND['ENABLE_PROFILES']"
+        [routerLink]="['/synthese/taxon', selectedObsTaxonDetail?.cd_ref]"
+        target="_blank"
+      >
+        <span *ngIf="selectedObsTaxonDetail?.nom_vern">
+          {{ selectedObsTaxonDetail?.nom_vern }} -
+        </span>
+        {{ selectedObsTaxonDetail?.nom_valide }}
+      </a>
+    </h4>
+    <div>
+      <mat-toolbar class="action-tbar">
+        <button
+          mat-mini-fab
+          *ngIf="selectedObs?.source?.url_source"
+          mat-raised-button
+          ngbTooltip="{{ 'Synthese.Edit' | translate }}"
           placement="bottom"
-          *ngIf="selectedObsTaxonDetail && CONFIG.FRONTEND['ENABLE_PROFILES']"
-          [routerLink]="['/synthese/taxon', selectedObsTaxonDetail?.cd_ref]"
-          target="_blank"
-        >
-          <span *ngIf="selectedObsTaxonDetail?.nom_vern">
-            {{ selectedObsTaxonDetail?.nom_vern }} -
-          </span>
-          {{ selectedObsTaxonDetail?.nom_valide }}
-        </a>
-      </h4>
-      <div>
-        <mat-toolbar class="action-tbar">
-          <button
-            mat-mini-fab
-            *ngIf="selectedObs?.source?.url_source"
-            mat-raised-button
-            ngbTooltip="{{ 'Synthese.Edit' | translate }}"
-            placement="bottom"
-            (click)="
+          (click)="
             backToModule(selectedObs?.source?.url_source, selectedObs?.entity_source_pk_value)
           "
-          >
-            <mat-icon>edit</mat-icon>
-          </button>
-          <button
-            *ngIf="selectedObs?.cor_observers?.length > 0 && CONFIG.FRONTEND.DISPLAY_EMAIL_INFO_OBS"
-            mat-mini-fab
-            ngbTooltip="{{ 'Synthese.Mailto' | translate }}"
-            placement="bottom"
-            (click)="sendMail()"
-            mat-raised-button
-          >
-            <mat-icon>mail</mat-icon>
-          </button>
-          <button
-            mat-mini-fab
-            ngbTooltip="{{ 'Synthese.copyPermalink' | translate }}"
-            placement="bottom"
-            [cdkCopyToClipboard]="
+        >
+          <mat-icon>edit</mat-icon>
+        </button>
+        <button
+          *ngIf="selectedObs?.cor_observers?.length > 0 && CONFIG.FRONTEND.DISPLAY_EMAIL_INFO_OBS"
+          mat-mini-fab
+          ngbTooltip="{{ 'Synthese.Mailto' | translate }}"
+          placement="bottom"
+          (click)="sendMail()"
+          mat-raised-button
+        >
+          <mat-icon>mail</mat-icon>
+        </button>
+        <button
+          mat-mini-fab
+          ngbTooltip="{{ 'Synthese.copyPermalink' | translate }}"
+          placement="bottom"
+          [cdkCopyToClipboard]="
             APP_CONFIG.URL_APPLICATION + '/#/validation/occurrence/' + selectedObs?.id_synthese
           "
-            (click)="displaySuccessToaster()"
-            mat-raised-button
-          >
-            <mat-icon>share</mat-icon>
-          </button>
-          <button
-            mat-mini-fab
-            *ngIf="activateAlert"
-            [ngbTooltip]="alertExists() ? 'Signalement en cours' : 'Signaler'"
-            placement="bottom"
-            mat-raised-button
-            (click)="openCloseAlert()"
-            [ngStyle]="activateAlert && alertExists() ? {'background-color': 'white', 'color': 'rgb(252,63,42)'} : ''"
-          >
-            <mat-icon>flag</mat-icon>
-          </button>
-        </mat-toolbar>
-      </div>
-    </div>
-    <mat-card-content>
-      <span class="font-xs mb-2">
-        <div>
-          <span *ngIf="selectedObs?.place_name">
-            <b>{{ 'Synthese.LocationName' | translate }} : </b> {{ selectedObs?.place_name }}
-          </span>
-          <span *ngIf="selectedObs?.precision">
-            <b>{{ 'Synthese.Accuracy' | translate }} : </b> {{ selectedObs?.precision }}
-          </span>
-        </div>
-        <b> {{ 'Synthese.Owner' | translate }} : </b>
-        <span data-qa="synthese-info-obs-observateur">
-          {{ selectedObs?.observers }}
-        </span>
-        <br />
-        <span *ngIf="selectedObs?.date_min != selectedObs?.date_max; else elseBlock">
-          <b> {{ 'Synthese.Date' | translate }} : </b><span>{{ selectedObs?.date_min }} -> {{ selectedObs?.date_max
-            }}</span>
-        </span>
-        <ng-template #elseBlock>
-          <b> {{ 'Synthese.Date' | translate }} : </b><span data-qa="synthese-info-obs-date">{{ selectedObs?.date_min
-            }}</span>
-        </ng-template>
-        <br />
-        <span *ngIf="selectedObs?.altitude_min || selectedObs?.altitude_max">
-          <b> {{ 'Synthese.Altitude' | translate }}</b> : {{ selectedObs?.altitude_min }} m -
-          {{ selectedObs?.altitude_max }} m
-          <br />
-        </span>
-        <span *ngIf="selectedObs?.depth_min || selectedObs?.depth_max">
-          <b> {{ 'Synthese.DeepMin' | translate }} </b> : {{ selectedObs?.depth_min }} m -
-          <b> {{ 'Synthese.DeepMax' | translate }} : </b> {{ selectedObs?.depth_max }} m
-          <br />
-        </span>
-        <b> {{ 'Synthese.UidObs' | translate }} : </b> {{ selectedObs?.unique_id_sinp }}
-        <br />
-        <span *ngIf="selectedObs?.habitat">
-          <b> {{ 'Synthese.Habitat' | translate }}</b>: {{ selectedObs?.habitat?.lb_hab_fr }} -
-          {{ selectedObs?.habitat?.lb_code }}
-          <br />
-        </span>
-      </span>
-      <mat-toolbar class="tbar-bottom">
-        <a
-          color="primary"
-          class="btn btn-xs align-self-start mr-2 link-infos"
-          *ngIf="selectedObsTaxonDetail && CONFIG.FRONTEND['ENABLE_PROFILES']"
-          [routerLink]="['/synthese/taxon', selectedObsTaxonDetail?.cd_ref]"
-          target="_blank"
-          mat-stroked-button
+          (click)="displaySuccessToaster()"
+          mat-raised-button
         >
-          {{ 'Synthese.GnRecord' | translate }}
-          <mat-icon aria-hidden="true">description</mat-icon>
-        </a>
-        <a
-          class="btn align-self-start mr-2 link-infos"
-          href="https://inpn.mnhn.fr/espece/cd_nom/{{ selectedObsTaxonDetail?.cd_nom }}"
-          target="_blank"
-          mat-stroked-button
-          color="primary"
+          <mat-icon>share</mat-icon>
+        </button>
+        <button
+          mat-mini-fab
+          *ngIf="activateAlert"
+          [ngbTooltip]="alertExists() ? 'Signalement en cours' : 'Signaler'"
+          placement="bottom"
+          mat-raised-button
+          (click)="openCloseAlert()"
+          [ngStyle]="activateAlert && alertExists() ? {'background-color': 'white', 'color': 'rgb(252,63,42)'} : ''"
         >
-          {{ 'Synthese.InpnTaxon' | translate }}
-          <mat-icon aria-hidden="true">launch</mat-icon>
-        </a>
-        <span class="spacer"></span>
-        <ng-content></ng-content>
+          <mat-icon>flag</mat-icon>
+        </button>
       </mat-toolbar>
-    </mat-card-content>
-  </mat-card>
+    </div>
+  </div>
+  <mat-card-content>
+    <span class="font-xs mb-2">
+      <div>
+        <span *ngIf="selectedObs?.place_name">
+          <b>{{ 'Synthese.LocationName' | translate }} : </b> {{ selectedObs?.place_name }}
+        </span>
+        <span *ngIf="selectedObs?.precision">
+          <b>{{ 'Synthese.Accuracy' | translate }} : </b> {{ selectedObs?.precision }}
+        </span>
+      </div>
+      <b> {{ 'Synthese.Owner' | translate }} : </b>
+      <span data-qa="synthese-info-obs-observateur">
+        {{ selectedObs?.observers }}
+      </span>
+      <br />
+      <span *ngIf="selectedObs?.date_min != selectedObs?.date_max; else elseBlock">
+        <b> {{ 'Synthese.Date' | translate }} : </b><span>{{ selectedObs?.date_min }} -> {{ selectedObs?.date_max
+          }}</span>
+      </span>
+      <ng-template #elseBlock>
+        <b> {{ 'Synthese.Date' | translate }} : </b><span data-qa="synthese-info-obs-date">{{ selectedObs?.date_min
+          }}</span>
+      </ng-template>
+      <br />
+      <span *ngIf="selectedObs?.altitude_min || selectedObs?.altitude_max">
+        <b> {{ 'Synthese.Altitude' | translate }}</b> : {{ selectedObs?.altitude_min }} m -
+        {{ selectedObs?.altitude_max }} m
+        <br />
+      </span>
+      <span *ngIf="selectedObs?.depth_min || selectedObs?.depth_max">
+        <b> {{ 'Synthese.DeepMin' | translate }} </b> : {{ selectedObs?.depth_min }} m -
+        <b> {{ 'Synthese.DeepMax' | translate }} : </b> {{ selectedObs?.depth_max }} m
+        <br />
+      </span>
+      <b> {{ 'Synthese.UidObs' | translate }} : </b> {{ selectedObs?.unique_id_sinp }}
+      <br />
+      <span *ngIf="selectedObs?.habitat">
+        <b> {{ 'Synthese.Habitat' | translate }}</b>: {{ selectedObs?.habitat?.lb_hab_fr }} -
+        {{ selectedObs?.habitat?.lb_code }}
+        <br />
+      </span>
+    </span>
+    <mat-toolbar class="tbar-bottom">
+      <a
+        color="primary"
+        class="btn btn-xs align-self-start mr-2 link-infos"
+        *ngIf="selectedObsTaxonDetail && CONFIG.FRONTEND['ENABLE_PROFILES']"
+        [routerLink]="['/synthese/taxon', selectedObsTaxonDetail?.cd_ref]"
+        target="_blank"
+        mat-stroked-button
+      >
+        {{ 'Synthese.GnRecord' | translate }}
+        <mat-icon aria-hidden="true">description</mat-icon>
+      </a>
+      <a
+        class="btn align-self-start mr-2 link-infos"
+        href="https://inpn.mnhn.fr/espece/cd_nom/{{ selectedObsTaxonDetail?.cd_nom }}"
+        target="_blank"
+        mat-stroked-button
+        color="primary"
+      >
+        {{ 'Synthese.InpnTaxon' | translate }}
+        <mat-icon aria-hidden="true">launch</mat-icon>
+      </a>
+      <span class="spacer"></span>
+      <ng-content></ng-content>
+    </mat-toolbar>
+  </mat-card-content>
+</mat-card>
 
-  <mat-tab-group
-    (selectedTabChange)="setValidationTab($event)"
-    #tabGroup
-    class="my-tab-grp"
-  >
-    <mat-tab label="Détail de l'occurrence">
+<mat-tab-group
+  (selectedTabChange)="setValidationTab($event)"
+  #tabGroup
+  class="my-tab-grp"
+>
+  <mat-tab label="Détail de l'occurrence">
+    <table class="font-xs table table-striped table-sm">
+      <tr>
+        <td>{{ 'Synthese.ObsState' | translate }}</td>
+        <td>{{ selectedObs?.nomenclature_observation_status?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>{{ 'Synthese.ObsTech' | translate }}</td>
+        <td>{{ selectedObs?.nomenclature_obs_technique?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>{{ 'Synthese.ObsStateBio' | translate }}</td>
+        <td>{{ selectedObs?.nomenclature_bio_condition?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>{{ 'Synthese.ObsStatusBio' | translate }}</td>
+        <td>{{ selectedObs?.nomenclature_bio_status?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>{{ 'Synthese.ObsStatBiogeo' | translate }}</td>
+        <td>{{ selectedObs?.nomenclature_occ_biogeo_status?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>{{ 'Synthese.ObsBehav' | translate }}</td>
+        <td>{{ selectedObs?.nomenclature_behaviour?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>{{ 'Synthese.ObsSex' | translate }}</td>
+        <td data-qa="synthese-info-obs-sexe-value">
+          {{ selectedObs?.nomenclature_sex?.label_default }}
+        </td>
+      </tr>
+      <tr>
+        <td>{{ 'Synthese.ObsLifeStep' | translate }}</td>
+        <td>{{ selectedObs?.nomenclature_life_stage?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Denombrement min</td>
+        <td>{{ selectedObs?.count_min }}</td>
+      </tr>
+      <tr>
+        <td>Denombrement max</td>
+        <td>{{ selectedObs?.count_max }}</td>
+      </tr>
+      <tr>
+        <td>Type de dénombrement</td>
+        <td>{{ selectedObs?.nomenclature_type_count?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Objet du dénombrement</td>
+        <td>{{ selectedObs?.nomenclature_obj_count?.label_default }}</td>
+      </tr>
+      <tr></tr>
+      <tr>
+        <td>Naturalité</td>
+        <td>{{ selectedObs?.nomenclature_naturalness?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Commentaire relevé</td>
+        <td>{{ selectedObs?.comment_context }}</td>
+      </tr>
+      <tr>
+        <td>Commentaire occurrence</td>
+        <td>{{ selectedObs?.comment_description }}</td>
+      </tr>
+      <tr>
+        <td>Determinateur</td>
+        <td>{{ selectedObs?.determiner }}</td>
+      </tr>
+      <tr>
+        <td>Preuve d'existence</td>
+        <td>{{ selectedObs?.nomenclature_exist_proof?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Preuve numérique</td>
+        <td>{{ selectedObs?.digital_proof }}</td>
+      </tr>
+      <tr>
+        <td>Preuve non numérique</td>
+        <td>{{ selectedObs?.non_digital_proof }}</td>
+      </tr>
+      <tr>
+        <td>Echantillon de preuve</td>
+        <td>{{ selectedObs?.sample_number_proof }}</td>
+      </tr>
+      <tr></tr>
+      <tr>
+        <td>Type de regroupement</td>
+        <td>{{ selectedObs?.nomenclature_grp_typ?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Méthode de regroupement</td>
+        <td>{{ selectedObs?.grp_method }}</td>
+      </tr>
+      <tr>
+        <td>Source de la donnée</td>
+        <td>{{ selectedObs?.nomenclature_source_status?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Statut de validation</td>
+        <td>{{ selectedObs?.nomenclature_valid_status?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Sensibilité</td>
+        <td>{{ selectedObs?.nomenclature_sensitivity?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Niveau de diffusion</td>
+        <td>{{ selectedObs?.nomenclature_diffusion_level?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Nature de l'objet géographique</td>
+        <td>{{ selectedObs?.nomenclature_geo_object_nature?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Floutage</td>
+        <td>{{ selectedObs?.nomenclature_blurring?.label_default }}</td>
+      </tr>
+      <tr>
+        <td>Identifiant unique SINP</td>
+        <td>{{ selectedObs?.unique_id_sinp }}</td>
+      </tr>
+      <tr>
+        <td>Champs additionnels</td>
+        <td>{{ selectedObs?.additional_data | json }}</td>
+      </tr>
+    </table>
+  </mat-tab>
+
+  <mat-tab label="Métadonnées">
+    <table class="font-xs table table-striped table-sm">
+      <tr>
+        <td>Jeu de données</td>
+        <td>{{ selectedObs?.dataset.dataset_name }}</td>
+      </tr>
+      <tr>
+        <td>Cadre d'acquisition</td>
+        <td>{{ selectedObs?.dataset.acquisition_framework.acquisition_framework_name }}</td>
+      </tr>
+      <tr>
+        <td>Acteurs</td>
+        <td>
+          <ul>
+            <li *ngFor="let actor of selectedObs?.dataset.cor_dataset_actor">
+              {{ actor.display }}
+            </li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>Module de provenance</td>
+        <td>{{ selectedObs?.source.name_source }}</td>
+      </tr>
+    </table>
+  </mat-tab>
+
+  <mat-tab label="Taxonomie">
+    <table class="font-xs table table-striped table-sm">
+      <tr>
+        <td>
+          <b>Groupe taxonomique </b>
+        </td>
+        <td>{{ selectedObsTaxonDetail?.classe }}</td>
+      </tr>
+      <tr>
+        <td>
+          <b>Ordre</b>
+        </td>
+        <td>{{ selectedObsTaxonDetail?.ordre }}</td>
+      </tr>
+      <tr>
+        <td>
+          <b> Famille</b>
+        </td>
+        <td>{{ selectedObsTaxonDetail?.famille }}</td>
+      </tr>
+    </table>
+
+    <h5 class="underlined underlined-sm main-color">Attribut(s) Taxonomique(s) locaux</h5>
+    <table class="font-xs table table-striped table-sm">
+      <tr
+        class="font-xs"
+        *ngFor="let attr of selectObsTaxonInfo?.attributs"
+      >
+        <td>
+          <b>{{ attr.label_attribut }} </b>
+        </td>
+        <td>{{ attr.valeur_attribut }}</td>
+      </tr>
+    </table>
+
+    <h5 class="underlined underlined-sm main-color">Réglementation</h5>
+    <table class="font-xs table table-striped table-sm">
+      <tr *ngFor="let arrete of selectedObsTaxonDetail?.statuts_protection">
+        <td>
+          <a [href]="arrete.url"> {{ arrete.intitule }} </a>
+        </td>
+      </tr>
+    </table>
+  </mat-tab>
+
+  <ng-container *ngIf="selectedObs?.medias?.length">
+    <mat-tab label="Médias">
+      <h5 class="underlined underlined-sm main-color">Médias</h5>
       <table class="font-xs table table-striped table-sm">
-        <tr>
-          <td>{{ 'Synthese.ObsState' | translate }}</td>
-          <td>{{ selectedObs?.nomenclature_observation_status?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>{{ 'Synthese.ObsTech' | translate }}</td>
-          <td>{{ selectedObs?.nomenclature_obs_technique?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>{{ 'Synthese.ObsStateBio' | translate }}</td>
-          <td>{{ selectedObs?.nomenclature_bio_condition?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>{{ 'Synthese.ObsStatusBio' | translate }}</td>
-          <td>{{ selectedObs?.nomenclature_bio_status?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>{{ 'Synthese.ObsStatBiogeo' | translate }}</td>
-          <td>{{ selectedObs?.nomenclature_occ_biogeo_status?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>{{ 'Synthese.ObsBehav' | translate }}</td>
-          <td>{{ selectedObs?.nomenclature_behaviour?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>{{ 'Synthese.ObsSex' | translate }}</td>
-          <td data-qa="synthese-info-obs-sexe-value">
-            {{ selectedObs?.nomenclature_sex?.label_default }}
-          </td>
-        </tr>
-        <tr>
-          <td>{{ 'Synthese.ObsLifeStep' | translate }}</td>
-          <td>{{ selectedObs?.nomenclature_life_stage?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Denombrement min</td>
-          <td>{{ selectedObs?.count_min }}</td>
-        </tr>
-        <tr>
-          <td>Denombrement max</td>
-          <td>{{ selectedObs?.count_max }}</td>
-        </tr>
-        <tr>
-          <td>Type de dénombrement</td>
-          <td>{{ selectedObs?.nomenclature_type_count?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Objet du dénombrement</td>
-          <td>{{ selectedObs?.nomenclature_obj_count?.label_default }}</td>
-        </tr>
-        <tr></tr>
-        <tr>
-          <td>Naturalité</td>
-          <td>{{ selectedObs?.nomenclature_naturalness?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Commentaire relevé</td>
-          <td>{{ selectedObs?.comment_context }}</td>
-        </tr>
-        <tr>
-          <td>Commentaire occurrence</td>
-          <td>{{ selectedObs?.comment_description }}</td>
-        </tr>
-        <tr>
-          <td>Determinateur</td>
-          <td>{{ selectedObs?.determiner }}</td>
-        </tr>
-        <tr>
-          <td>Preuve d'existence</td>
-          <td>{{ selectedObs?.nomenclature_exist_proof?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Preuve numérique</td>
-          <td>{{ selectedObs?.digital_proof }}</td>
-        </tr>
-        <tr>
-          <td>Preuve non numérique</td>
-          <td>{{ selectedObs?.non_digital_proof }}</td>
-        </tr>
-        <tr>
-          <td>Echantillon de preuve</td>
-          <td>{{ selectedObs?.sample_number_proof }}</td>
-        </tr>
-        <tr></tr>
-        <tr>
-          <td>Type de regroupement</td>
-          <td>{{ selectedObs?.nomenclature_grp_typ?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Méthode de regroupement</td>
-          <td>{{ selectedObs?.grp_method }}</td>
-        </tr>
-        <tr>
-          <td>Source de la donnée</td>
-          <td>{{ selectedObs?.nomenclature_source_status?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Statut de validation</td>
-          <td>{{ selectedObs?.nomenclature_valid_status?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Sensibilité</td>
-          <td>{{ selectedObs?.nomenclature_sensitivity?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Niveau de diffusion</td>
-          <td>{{ selectedObs?.nomenclature_diffusion_level?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Nature de l'objet géographique</td>
-          <td>{{ selectedObs?.nomenclature_geo_object_nature?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Floutage</td>
-          <td>{{ selectedObs?.nomenclature_blurring?.label_default }}</td>
-        </tr>
-        <tr>
-          <td>Identifiant unique SINP</td>
-          <td>{{ selectedObs?.unique_id_sinp }}</td>
-        </tr>
-        <tr>
-          <td>Champs additionnels</td>
-          <td>{{ selectedObs?.additional_data | json }}</td>
-        </tr>
+        <ng-container *ngFor="let media of selectedObs?.medias; index as i">
+          <tr>
+            <td>Titre</td>
+            <td>
+              <a
+                target="_blank"
+                [href]="mediaService.href(media)"
+              >{{ media.title_fr }}</a>
+            </td>
+          </tr>
+          <tr *ngIf="media.description_fr">
+            <td>Description</td>
+            <td>{{ media.description_fr }}</td>
+          </tr>
+          <tr *ngIf="media.author">
+            <td>Auteur</td>
+            <td>{{ media.author }}</td>
+          </tr>
+          <tr>
+            <td colspan="2">
+              <pnx-display-medias
+                diaporama="true"
+                [medias]="selectedObs?.medias"
+                [index]="i"
+                display="medium"
+              >
+              </pnx-display-medias>
+            </td>
+          </tr>
+        </ng-container>
       </table>
     </mat-tab>
+  </ng-container>
 
-    <mat-tab label="Métadonnées">
-      <table class="font-xs table table-striped table-sm">
+  <mat-tab label="Zonage">
+    <table class="font-xs table table-striped table-sm">
+      <thead>
         <tr>
-          <td>Jeu de données</td>
-          <td>{{ selectedObs?.dataset.dataset_name }}</td>
+          <th class="table_date">Type de zonage</th>
+          <th class="table_comment">Zones</th>
         </tr>
-        <tr>
-          <td>Cadre d'acquisition</td>
-          <td>{{ selectedObs?.dataset.acquisition_framework.acquisition_framework_name }}</td>
-        </tr>
-        <tr>
-          <td>Acteurs</td>
+      </thead>
+
+      <tbody>
+        <tr *ngFor="let area_type of formatedAreas">
           <td>
-            <ul>
-              <li *ngFor="let actor of selectedObs?.dataset.cor_dataset_actor">
-                {{ actor.display }}
-              </li>
-            </ul>
+            {{ area_type.area_type }}
+          </td>
+          <td>
+            <span *ngFor="let area of area_type.areas; let index = index">
+              {{ area.area_name }}<span *ngIf="index < area_type.areas.length - 1">,</span>
+            </span>
           </td>
         </tr>
-        <tr>
-          <td>Module de provenance</td>
-          <td>{{ selectedObs?.source.name_source }}</td>
-        </tr>
-      </table>
-    </mat-tab>
+      </tbody>
+    </table>
+  </mat-tab>
 
-    <mat-tab label="Taxonomie">
-      <table class="font-xs table table-striped table-sm">
-        <tr>
-          <td>
-            <b>Groupe taxonomique </b>
-          </td>
-          <td>{{ selectedObsTaxonDetail?.classe }}</td>
-        </tr>
-        <tr>
-          <td>
-            <b>Ordre</b>
-          </td>
-          <td>{{ selectedObsTaxonDetail?.ordre }}</td>
-        </tr>
-        <tr>
-          <td>
-            <b> Famille</b>
-          </td>
-          <td>{{ selectedObsTaxonDetail?.famille }}</td>
-        </tr>
-      </table>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <span>Validation</span>
+    </ng-template>
+    <div *ngIf="showValidation">
+      <h3>Historique de validation de la donnée</h3>
 
-      <h5 class="underlined underlined-sm main-color">Attribut(s) Taxonomique(s) locaux</h5>
-      <table class="font-xs table table-striped table-sm">
-        <tr
-          class="font-xs"
-          *ngFor="let attr of selectObsTaxonInfo?.attributs"
-        >
-          <td>
-            <b>{{ attr.label_attribut }} </b>
-          </td>
-          <td>{{ attr.valeur_attribut }}</td>
-        </tr>
-      </table>
-
-      <h5 class="underlined underlined-sm main-color">Réglementation</h5>
-      <table class="font-xs table table-striped table-sm">
-        <tr *ngFor="let arrete of selectedObsTaxonDetail?.statuts_protection">
-          <td>
-            <a [href]="arrete.url"> {{ arrete.intitule }} </a>
-          </td>
-        </tr>
-      </table>
-    </mat-tab>
-
-    <ng-container *ngIf="selectedObs?.medias?.length">
-      <mat-tab label="Médias">
-        <h5 class="underlined underlined-sm main-color">Médias</h5>
-        <table class="font-xs table table-striped table-sm">
-          <ng-container *ngFor="let media of selectedObs?.medias; index as i">
-            <tr>
-              <td>Titre</td>
-              <td>
-                <a
-                  target="_blank"
-                  [href]="mediaService.href(media)"
-                >{{ media.title_fr }}</a>
-              </td>
-            </tr>
-            <tr *ngIf="media.description_fr">
-              <td>Description</td>
-              <td>{{ media.description_fr }}</td>
-            </tr>
-            <tr *ngIf="media.author">
-              <td>Auteur</td>
-              <td>{{ media.author }}</td>
-            </tr>
-            <tr>
-              <td colspan="2">
-                <pnx-display-medias
-                  diaporama="true"
-                  [medias]="selectedObs?.medias"
-                  [index]="i"
-                  display="medium"
-                >
-                </pnx-display-medias>
-              </td>
-            </tr>
-          </ng-container>
-        </table>
-      </mat-tab>
-    </ng-container>
-
-    <mat-tab label="Zonage">
       <table class="font-xs table table-striped table-sm">
         <thead>
           <tr>
-            <th class="table_date">Type de zonage</th>
-            <th class="table_comment">Zones</th>
+            <th class="table_date">Date de validation</th>
+            <th class="table_status">Statut</th>
+            <th class="table_comment">Validateur</th>
+            <th class="table_comment">Commentaire</th>
           </tr>
         </thead>
 
         <tbody>
-          <tr *ngFor="let area_type of formatedAreas">
-            <td>
-              {{ area_type.area_type }}
-            </td>
-            <td>
-              <span *ngFor="let area of area_type.areas; let index = index">
-                {{ area.area_name }}<span *ngIf="index < area_type.areas.length - 1">,</span>
+          <tr *ngFor="let row of validationHistory">
+            <td width="15%">{{ row.date }}</td>
+            <td width="20%">
+              <span
+                class="validationCircle"
+                [ngStyle]="{ background: validationColor[row.cd_nomenclature] }"
+              >
+                <mat-icon
+                  *ngIf="row.typeValidation == 'True'"
+                  class="computer"
+                >computer</mat-icon>
+              </span>
+              <span
+                class="statusName"
+                class="ml-4"
+              >
+                {{ row.label_default }}
               </span>
             </td>
+            <td width="20%">
+              <span> {{ row.validator }} </span>
+            </td>
+            <td>{{ row.comment }}</td>
           </tr>
         </tbody>
       </table>
-    </mat-tab>
 
-    <mat-tab>
-      <ng-template mat-tab-label>
-        <span>Validation</span>
-      </ng-template>
-      <div *ngIf="showValidation">
-        <h3>Historique de validation de la donnée</h3>
+      <div *ngIf="CONFIG.FRONTEND.ENABLE_PROFILES">
+        <div *ngIf="profile; else noProfile">
+          <h3>Profil du taxon</h3>
+          <div class="row row-sm">
+            <div class="col-4 padding-sm">
+              <h5>Informations générales sur le taxon</h5>
+              <table class="font-xs table table-striped table-sm">
+                <tr>
+                  <td>Nombre de données valides</td>
+                  <td>{{ profile?.properties?.count_valid_data }}</td>
+                </tr>
+                <tr>
+                  <td>Altitude minimale valide</td>
+                  <td>{{ profile?.properties?.altitude_min }}</td>
+                </tr>
+                <tr>
+                  <td>Altitude maximale valide</td>
+                  <td>{{ profile?.properties?.altitude_max }}</td>
+                </tr>
 
-        <table class="font-xs table table-striped table-sm">
-          <thead>
-            <tr>
-              <th class="table_date">Date de validation</th>
-              <th class="table_status">Statut</th>
-              <th class="table_comment">Validateur</th>
-              <th class="table_comment">Commentaire</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <tr *ngFor="let row of validationHistory">
-              <td width="15%">{{ row.date }}</td>
-              <td width="20%">
-                <span
-                  class="validationCircle"
-                  [ngStyle]="{ background: validationColor[row.cd_nomenclature] }"
-                >
-                  <mat-icon
-                    *ngIf="row.typeValidation == 'True'"
-                    class="computer"
-                  >computer</mat-icon>
-                </span>
-                <span
-                  class="statusName"
-                  class="ml-4"
-                >
-                  {{ row.label_default }}
-                </span>
-              </td>
-              <td width="20%">
-                <span> {{ row.validator }} </span>
-              </td>
-              <td>{{ row.comment }}</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <div *ngIf="CONFIG.FRONTEND.ENABLE_PROFILES">
-          <div *ngIf="profile; else noProfile">
-            <h3>Profil du taxon</h3>
-            <div class="row row-sm">
-              <div class="col-4 padding-sm">
-                <h5>Informations générales sur le taxon</h5>
-                <table class="font-xs table table-striped table-sm">
-                  <tr>
-                    <td>Nombre de données valides</td>
-                    <td>{{ profile?.properties?.count_valid_data }}</td>
-                  </tr>
-                  <tr>
-                    <td>Altitude minimale valide</td>
-                    <td>{{ profile?.properties?.altitude_min }}</td>
-                  </tr>
-                  <tr>
-                    <td>Altitude maximale valide</td>
-                    <td>{{ profile?.properties?.altitude_max }}</td>
-                  </tr>
-
-                  <tr>
-                    <td>Première observation valide</td>
-                    <td>{{ profile?.properties?.first_valid_data | date: 'dd/MM/yyyy' }}</td>
-                  </tr>
-                  <tr>
-                    <td>Dernière observation valide</td>
-                    <td>{{ profile?.properties?.last_valid_data | date: 'dd/MM/yyyy' }}</td>
-                  </tr>
-                </table>
-              </div>
-              <div class="col-4 padding-sm">
-                <h5>Cohérence de la donnée</h5>
-                <table class="font-xs table table-sm table-striped">
-                  <tr>
-                    <td>Dans l'aire d'observation valide</td>
-                    <td *ngIf="profileDataChecks?.valid_distribution">
-                      <mat-icon class="success"> check </mat-icon>
-                    </td>
-                    <td *ngIf="!profileDataChecks?.valid_distribution">
-                      <mat-icon class="error"> close </mat-icon>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Cohérence phénologique</td>
-                    <td *ngIf="profileDataChecks?.valid_phenology">
-                      <mat-icon class="success"> check </mat-icon>
-                    </td>
-                    <td *ngIf="!profileDataChecks?.valid_phenology">
-                      <mat-icon class="error"> close </mat-icon>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Dans la fourchette altitudinale valide</td>
-                    <td *ngIf="profileDataChecks?.valid_altitude">
-                      <mat-icon class="success"> check </mat-icon>
-                    </td>
-                    <td *ngIf="!profileDataChecks?.valid_altitude">
-                      <mat-icon class="error"> close </mat-icon>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Score</td>
-                    <td>{{ profileDataChecks?.score }}</td>
-                  </tr>
-                </table>
-              </div>
+                <tr>
+                  <td>Première observation valide</td>
+                  <td>{{ profile?.properties?.first_valid_data | date: 'dd/MM/yyyy' }}</td>
+                </tr>
+                <tr>
+                  <td>Dernière observation valide</td>
+                  <td>{{ profile?.properties?.last_valid_data | date: 'dd/MM/yyyy' }}</td>
+                </tr>
+              </table>
+            </div>
+            <div class="col-4 padding-sm">
+              <h5>Cohérence de la donnée</h5>
+              <table class="font-xs table table-sm table-striped">
+                <tr>
+                  <td>Dans l'aire d'observation valide</td>
+                  <td *ngIf="profileDataChecks?.valid_distribution">
+                    <mat-icon class="success"> check </mat-icon>
+                  </td>
+                  <td *ngIf="!profileDataChecks?.valid_distribution">
+                    <mat-icon class="error"> close </mat-icon>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Cohérence phénologique</td>
+                  <td *ngIf="profileDataChecks?.valid_phenology">
+                    <mat-icon class="success"> check </mat-icon>
+                  </td>
+                  <td *ngIf="!profileDataChecks?.valid_phenology">
+                    <mat-icon class="error"> close </mat-icon>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Dans la fourchette altitudinale valide</td>
+                  <td *ngIf="profileDataChecks?.valid_altitude">
+                    <mat-icon class="success"> check </mat-icon>
+                  </td>
+                  <td *ngIf="!profileDataChecks?.valid_altitude">
+                    <mat-icon class="error"> close </mat-icon>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Score</td>
+                  <td>{{ profileDataChecks?.score }}</td>
+                </tr>
+              </table>
             </div>
           </div>
-
-          <h5>Aire de répartition des observations valides</h5>
-          <div class="mb-3 border border-secondary">
-            <pnx-map height="40vh">
-              <pnx-geojson
-                [geojson]="selectedGeom"
-                [style]="{ color: 'red' }"
-              > </pnx-geojson>
-              <pnx-geojson
-                [geojson]="profile"
-                [zoomOnFirstTime]="true"
-              > </pnx-geojson>
-            </pnx-map>
-          </div>
         </div>
-        <ng-template #noProfile>
-          <span class="alert alert-info"> Pas de profil pour ce taxon </span>
-          <br /><br />
-        </ng-template>
-      </div>
-    </mat-tab>
 
-    <mat-tab
-      label="{{ 'Synthese.Discussion' | translate }}"
-      *ngIf="APP_CONFIG.SYNTHESE.DISCUSSION_MODULES.includes(moduleInfos.code)"
-    >
-      <pnx-discussion-card
-        [validationColor]="validationColor"
-        [idSynthese]="idSynthese"
-        [codeModule]="moduleInfos.code"
-        [additionalData]="{ data: validationHistory, dateField: 'dateTime' }"
-      ></pnx-discussion-card>
-    </mat-tab>
-  </mat-tab-group>
+        <h5>Aire de répartition des observations valides</h5>
+        <div class="mb-3 border border-secondary">
+          <pnx-map height="40vh">
+            <pnx-geojson
+              [geojson]="selectedGeom"
+              [style]="{ color: 'red' }"
+            > </pnx-geojson>
+            <pnx-geojson
+              [geojson]="profile"
+              [zoomOnFirstTime]="true"
+            > </pnx-geojson>
+          </pnx-map>
+        </div>
+      </div>
+      <ng-template #noProfile>
+        <span class="alert alert-info"> Pas de profil pour ce taxon </span>
+        <br /><br />
+      </ng-template>
+    </div>
+  </mat-tab>
+
+  <mat-tab
+    label="{{ 'Synthese.Discussion' | translate }}"
+    *ngIf="APP_CONFIG.SYNTHESE.DISCUSSION_MODULES.includes(moduleInfos.code)"
+  >
+    <pnx-discussion-card
+      [validationColor]="validationColor"
+      [idSynthese]="idSynthese"
+      [codeModule]="moduleInfos.code"
+      [additionalData]="{ data: validationHistory, dateField: 'dateTime' }"
+    ></pnx-discussion-card>
+  </mat-tab>
+</mat-tab-group>

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.html
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.html
@@ -1,538 +1,610 @@
-<div id="cover-spin" *ngIf="isLoading"></div>
+<div
+  id="cover-spin"
+  *ngIf="isLoading"
+></div>
 
-<div *ngIf="header" class="modal-header padding-md-all">
+<<<<<<<
+  HEAD
+  <div
+  *ngIf="header"
+  class="modal-header padding-md-all"
+>
   <h5 class="my-3 ml-3">{{ 'Synthese.ModalTitle' | translate }}</h5>
-  <button
-    type="button"
-    class="close"
-    aria-label="Close"
-    (click)="activeModal.dismiss('Cross click')"
-    [ngStyle]="{
+  =======
+  <div
+    *ngIf="header"
+    class="modal-header padding-md-all"
+  >
+    <h5
+      *ngIf="!alertOpen"
+      class="my-3 ml-3"
+    >{{'Synthese.ModalTitle' | translate }}</h5>
+    <h5
+      *ngIf="alertOpen"
+      class="my-3 ml-3"
+    >Signalement</h5>
+    >>>>>>> 7fbe023d7 (create component alertInfoModule)
+    <button
+      type="button"
+      class="close"
+      aria-label="Close"
+      (click)="activeModal.dismiss('Cross click')"
+      [ngStyle]="{
       outlineWidth: '0px'
     }"
-  >
-    <span aria-hidden="true">&times;</span>
-  </button>
-</div>
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
 
-<mat-card class="modal-body">
-  <div class="d-flex w-100 justify-content-between">
-    <h4 class="mr-auto gn-color">
-      <a
-        class="no-link-style"
-        ngbTooltip="{{ 'Synthese.GnRecord' | translate }}"
-        placement="bottom"
-        *ngIf="selectedObsTaxonDetail && CONFIG.FRONTEND['ENABLE_PROFILES']"
-        [routerLink]="['/synthese/taxon', selectedObsTaxonDetail?.cd_ref]"
-        target="_blank"
-      >
-        <span *ngIf="selectedObsTaxonDetail?.nom_vern">
-          {{ selectedObsTaxonDetail?.nom_vern }} -
-        </span>
-        {{ selectedObsTaxonDetail?.nom_valide }}
-      </a>
-    </h4>
-    <div>
-      <mat-toolbar class="action-tbar">
-        <button
-          mat-mini-fab
-          *ngIf="selectedObs?.source?.url_source"
-          mat-raised-button
-          ngbTooltip="{{ 'Synthese.Edit' | translate }}"
+  <mat-card
+    class="modal-body"
+    *ngIf="idSynthese && alertOpen"
+  >
+    <mat-card-content *ngIf="activateAlert">
+      <span class="font-xs mb-2">
+        <pnx-alert-info
+          [idSynthese]="idSynthese"
+          [alert]="alert"
+          (changeVisibility)="openCloseAlert($event)"
+        ></pnx-alert-info>
+      </span>
+    </mat-card-content>
+  </mat-card>
+
+
+  <mat-card
+    class="modal-body"
+    *ngIf="!alertOpen"
+  >
+    <div class="d-flex w-100 justify-content-between">
+      <h4 class="mr-auto gn-color">
+        <a
+          class="no-link-style"
+          ngbTooltip="{{ 'Synthese.GnRecord' | translate }}"
           placement="bottom"
-          (click)="
+          *ngIf="selectedObsTaxonDetail && CONFIG.FRONTEND['ENABLE_PROFILES']"
+          [routerLink]="['/synthese/taxon', selectedObsTaxonDetail?.cd_ref]"
+          target="_blank"
+        >
+          <span *ngIf="selectedObsTaxonDetail?.nom_vern">
+            {{ selectedObsTaxonDetail?.nom_vern }} -
+          </span>
+          {{ selectedObsTaxonDetail?.nom_valide }}
+        </a>
+      </h4>
+      <div>
+        <mat-toolbar class="action-tbar">
+          <button
+            mat-mini-fab
+            *ngIf="selectedObs?.source?.url_source"
+            mat-raised-button
+            ngbTooltip="{{ 'Synthese.Edit' | translate }}"
+            placement="bottom"
+            (click)="
             backToModule(selectedObs?.source?.url_source, selectedObs?.entity_source_pk_value)
           "
-        >
-          <mat-icon>edit</mat-icon>
-        </button>
-        <button
-          *ngIf="selectedObs?.cor_observers?.length > 0 && CONFIG.FRONTEND.DISPLAY_EMAIL_INFO_OBS"
-          mat-mini-fab
-          ngbTooltip="{{ 'Synthese.Mailto' | translate }}"
-          placement="bottom"
-          (click)="sendMail()"
-          mat-raised-button
-        >
-          <mat-icon>mail</mat-icon>
-        </button>
-        <button
-          mat-mini-fab
-          ngbTooltip="{{ 'Synthese.copyPermalink' | translate }}"
-          placement="bottom"
-          [cdkCopyToClipboard]="
+          >
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button
+            *ngIf="selectedObs?.cor_observers?.length > 0 && CONFIG.FRONTEND.DISPLAY_EMAIL_INFO_OBS"
+            mat-mini-fab
+            ngbTooltip="{{ 'Synthese.Mailto' | translate }}"
+            placement="bottom"
+            (click)="sendMail()"
+            mat-raised-button
+          >
+            <mat-icon>mail</mat-icon>
+          </button>
+          <button
+            mat-mini-fab
+            ngbTooltip="{{ 'Synthese.copyPermalink' | translate }}"
+            placement="bottom"
+            [cdkCopyToClipboard]="
             APP_CONFIG.URL_APPLICATION + '/#/validation/occurrence/' + selectedObs?.id_synthese
           "
-          (click)="displaySuccessToaster()"
-          mat-raised-button
-        >
-          <mat-icon>share</mat-icon>
-        </button>
-      </mat-toolbar>
-    </div>
-  </div>
-  <mat-card-content>
-    <span class="font-xs mb-2">
-      <div>
-        <span *ngIf="selectedObs?.place_name">
-          <b>{{ 'Synthese.LocationName' | translate }} : </b> {{ selectedObs?.place_name }}
-        </span>
-        <span *ngIf="selectedObs?.precision">
-          <b>{{ 'Synthese.Accuracy' | translate }} : </b> {{ selectedObs?.precision }}
-        </span>
+            (click)="displaySuccessToaster()"
+            mat-raised-button
+          >
+            <mat-icon>share</mat-icon>
+          </button>
+          <button
+            mat-mini-fab
+            *ngIf="activateAlert"
+            [ngbTooltip]="alertExists() ? 'Signalement en cours' : 'Signaler'"
+            placement="bottom"
+            mat-raised-button
+            (click)="openCloseAlert()"
+            [ngStyle]="activateAlert && alertExists() ? {'background-color': 'white', 'color': 'rgb(252,63,42)'} : ''"
+          >
+            <mat-icon>flag</mat-icon>
+          </button>
+        </mat-toolbar>
       </div>
-      <b> {{ 'Synthese.Owner' | translate }} : </b>
-      <span data-qa="synthese-info-obs-observateur">
-        {{ selectedObs?.observers }}
-      </span>
-      <br />
-      <span *ngIf="selectedObs?.date_min != selectedObs?.date_max; else elseBlock">
-        <b> {{ 'Synthese.Date' | translate }} : </b
-        ><span>{{ selectedObs?.date_min }} -> {{ selectedObs?.date_max }}</span>
-      </span>
-      <ng-template #elseBlock>
-        <b> {{ 'Synthese.Date' | translate }} : </b
-        ><span data-qa="synthese-info-obs-date">{{ selectedObs?.date_min }}</span>
-      </ng-template>
-      <br />
-      <span *ngIf="selectedObs?.altitude_min || selectedObs?.altitude_max">
-        <b> {{ 'Synthese.Altitude' | translate }}</b> : {{ selectedObs?.altitude_min }} m -
-        {{ selectedObs?.altitude_max }} m
+    </div>
+    <mat-card-content>
+      <span class="font-xs mb-2">
+        <div>
+          <span *ngIf="selectedObs?.place_name">
+            <b>{{ 'Synthese.LocationName' | translate }} : </b> {{ selectedObs?.place_name }}
+          </span>
+          <span *ngIf="selectedObs?.precision">
+            <b>{{ 'Synthese.Accuracy' | translate }} : </b> {{ selectedObs?.precision }}
+          </span>
+        </div>
+        <b> {{ 'Synthese.Owner' | translate }} : </b>
+        <span data-qa="synthese-info-obs-observateur">
+          {{ selectedObs?.observers }}
+        </span>
         <br />
-      </span>
-      <span *ngIf="selectedObs?.depth_min || selectedObs?.depth_max">
-        <b> {{ 'Synthese.DeepMin' | translate }} </b> : {{ selectedObs?.depth_min }} m -
-        <b> {{ 'Synthese.DeepMax' | translate }} : </b> {{ selectedObs?.depth_max }} m
+        <span *ngIf="selectedObs?.date_min != selectedObs?.date_max; else elseBlock">
+          <b> {{ 'Synthese.Date' | translate }} : </b><span>{{ selectedObs?.date_min }} -> {{ selectedObs?.date_max
+            }}</span>
+        </span>
+        <ng-template #elseBlock>
+          <b> {{ 'Synthese.Date' | translate }} : </b><span data-qa="synthese-info-obs-date">{{ selectedObs?.date_min
+            }}</span>
+        </ng-template>
         <br />
-      </span>
-      <b> {{ 'Synthese.UidObs' | translate }} : </b> {{ selectedObs?.unique_id_sinp }}
-      <br />
-      <span *ngIf="selectedObs?.habitat">
-        <b> {{ 'Synthese.Habitat' | translate }}</b
-        >: {{ selectedObs?.habitat?.lb_hab_fr }} -
-        {{ selectedObs?.habitat?.lb_code }}
+        <span *ngIf="selectedObs?.altitude_min || selectedObs?.altitude_max">
+          <b> {{ 'Synthese.Altitude' | translate }}</b> : {{ selectedObs?.altitude_min }} m -
+          {{ selectedObs?.altitude_max }} m
+          <br />
+        </span>
+        <span *ngIf="selectedObs?.depth_min || selectedObs?.depth_max">
+          <b> {{ 'Synthese.DeepMin' | translate }} </b> : {{ selectedObs?.depth_min }} m -
+          <b> {{ 'Synthese.DeepMax' | translate }} : </b> {{ selectedObs?.depth_max }} m
+          <br />
+        </span>
+        <b> {{ 'Synthese.UidObs' | translate }} : </b> {{ selectedObs?.unique_id_sinp }}
         <br />
+        <span *ngIf="selectedObs?.habitat">
+          <b> {{ 'Synthese.Habitat' | translate }}</b>: {{ selectedObs?.habitat?.lb_hab_fr }} -
+          {{ selectedObs?.habitat?.lb_code }}
+          <br />
+        </span>
       </span>
-    </span>
-    <mat-toolbar class="tbar-bottom">
-      <a
-        color="primary"
-        class="btn btn-xs align-self-start mr-2 link-infos"
-        *ngIf="selectedObsTaxonDetail && CONFIG.FRONTEND['ENABLE_PROFILES']"
-        [routerLink]="['/synthese/taxon', selectedObsTaxonDetail?.cd_ref]"
-        target="_blank"
-        mat-stroked-button
-      >
-        {{ 'Synthese.GnRecord' | translate }}
-        <mat-icon aria-hidden="true">description</mat-icon>
-      </a>
-      <a
-        class="btn align-self-start mr-2 link-infos"
-        href="https://inpn.mnhn.fr/espece/cd_nom/{{ selectedObsTaxonDetail?.cd_nom }}"
-        target="_blank"
-        mat-stroked-button
-        color="primary"
-      >
-        {{ 'Synthese.InpnTaxon' | translate }}
-        <mat-icon aria-hidden="true">launch</mat-icon>
-      </a>
-      <span class="spacer"></span>
-      <ng-content></ng-content>
-    </mat-toolbar>
-  </mat-card-content>
-</mat-card>
+      <mat-toolbar class="tbar-bottom">
+        <a
+          color="primary"
+          class="btn btn-xs align-self-start mr-2 link-infos"
+          *ngIf="selectedObsTaxonDetail && CONFIG.FRONTEND['ENABLE_PROFILES']"
+          [routerLink]="['/synthese/taxon', selectedObsTaxonDetail?.cd_ref]"
+          target="_blank"
+          mat-stroked-button
+        >
+          {{ 'Synthese.GnRecord' | translate }}
+          <mat-icon aria-hidden="true">description</mat-icon>
+        </a>
+        <a
+          class="btn align-self-start mr-2 link-infos"
+          href="https://inpn.mnhn.fr/espece/cd_nom/{{ selectedObsTaxonDetail?.cd_nom }}"
+          target="_blank"
+          mat-stroked-button
+          color="primary"
+        >
+          {{ 'Synthese.InpnTaxon' | translate }}
+          <mat-icon aria-hidden="true">launch</mat-icon>
+        </a>
+        <span class="spacer"></span>
+        <ng-content></ng-content>
+      </mat-toolbar>
+    </mat-card-content>
+  </mat-card>
 
-<mat-tab-group (selectedTabChange)="setValidationTab($event)" #tabGroup class="my-tab-grp">
-  <mat-tab label="Détail de l'occurrence">
-    <table class="font-xs table table-striped table-sm">
-      <tr>
-        <td>{{ 'Synthese.ObsState' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_observation_status?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsTech' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_obs_technique?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsStateBio' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_bio_condition?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsStatusBio' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_bio_status?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsStatBiogeo' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_occ_biogeo_status?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsBehav' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_behaviour?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsSex' | translate }}</td>
-        <td data-qa="synthese-info-obs-sexe-value">
-          {{ selectedObs?.nomenclature_sex?.label_default }}
-        </td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsLifeStep' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_life_stage?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Denombrement min</td>
-        <td>{{ selectedObs?.count_min }}</td>
-      </tr>
-      <tr>
-        <td>Denombrement max</td>
-        <td>{{ selectedObs?.count_max }}</td>
-      </tr>
-      <tr>
-        <td>Type de dénombrement</td>
-        <td>{{ selectedObs?.nomenclature_type_count?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Objet du dénombrement</td>
-        <td>{{ selectedObs?.nomenclature_obj_count?.label_default }}</td>
-      </tr>
-      <tr></tr>
-      <tr>
-        <td>Naturalité</td>
-        <td>{{ selectedObs?.nomenclature_naturalness?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Commentaire relevé</td>
-        <td>{{ selectedObs?.comment_context }}</td>
-      </tr>
-      <tr>
-        <td>Commentaire occurrence</td>
-        <td>{{ selectedObs?.comment_description }}</td>
-      </tr>
-      <tr>
-        <td>Determinateur</td>
-        <td>{{ selectedObs?.determiner }}</td>
-      </tr>
-      <tr>
-        <td>Preuve d'existence</td>
-        <td>{{ selectedObs?.nomenclature_exist_proof?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Preuve numérique</td>
-        <td>{{ selectedObs?.digital_proof }}</td>
-      </tr>
-      <tr>
-        <td>Preuve non numérique</td>
-        <td>{{ selectedObs?.non_digital_proof }}</td>
-      </tr>
-      <tr>
-        <td>Echantillon de preuve</td>
-        <td>{{ selectedObs?.sample_number_proof }}</td>
-      </tr>
-      <tr></tr>
-      <tr>
-        <td>Type de regroupement</td>
-        <td>{{ selectedObs?.nomenclature_grp_typ?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Méthode de regroupement</td>
-        <td>{{ selectedObs?.grp_method }}</td>
-      </tr>
-      <tr>
-        <td>Source de la donnée</td>
-        <td>{{ selectedObs?.nomenclature_source_status?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Statut de validation</td>
-        <td>{{ selectedObs?.nomenclature_valid_status?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Sensibilité</td>
-        <td>{{ selectedObs?.nomenclature_sensitivity?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Niveau de diffusion</td>
-        <td>{{ selectedObs?.nomenclature_diffusion_level?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Nature de l'objet géographique</td>
-        <td>{{ selectedObs?.nomenclature_geo_object_nature?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Floutage</td>
-        <td>{{ selectedObs?.nomenclature_blurring?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Identifiant unique SINP</td>
-        <td>{{ selectedObs?.unique_id_sinp }}</td>
-      </tr>
-      <tr>
-        <td>Champs additionnels</td>
-        <td>{{ selectedObs?.additional_data | json }}</td>
-      </tr>
-    </table>
-  </mat-tab>
-
-  <mat-tab label="Métadonnées">
-    <table class="font-xs table table-striped table-sm">
-      <tr>
-        <td>Jeu de données</td>
-        <td>{{ selectedObs?.dataset.dataset_name }}</td>
-      </tr>
-      <tr>
-        <td>Cadre d'acquisition</td>
-        <td>{{ selectedObs?.dataset.acquisition_framework.acquisition_framework_name }}</td>
-      </tr>
-      <tr>
-        <td>Acteurs</td>
-        <td>
-          <ul>
-            <li *ngFor="let actor of selectedObs?.dataset.cor_dataset_actor">
-              {{ actor.display }}
-            </li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td>Module de provenance</td>
-        <td>{{ selectedObs?.source.name_source }}</td>
-      </tr>
-    </table>
-  </mat-tab>
-
-  <mat-tab label="Taxonomie">
-    <table class="font-xs table table-striped table-sm">
-      <tr>
-        <td>
-          <b>Groupe taxonomique </b>
-        </td>
-        <td>{{ selectedObsTaxonDetail?.classe }}</td>
-      </tr>
-      <tr>
-        <td>
-          <b>Ordre</b>
-        </td>
-        <td>{{ selectedObsTaxonDetail?.ordre }}</td>
-      </tr>
-      <tr>
-        <td>
-          <b> Famille</b>
-        </td>
-        <td>{{ selectedObsTaxonDetail?.famille }}</td>
-      </tr>
-    </table>
-
-    <h5 class="underlined underlined-sm main-color">Attribut(s) Taxonomique(s) locaux</h5>
-    <table class="font-xs table table-striped table-sm">
-      <tr class="font-xs" *ngFor="let attr of selectObsTaxonInfo?.attributs">
-        <td>
-          <b>{{ attr.label_attribut }} </b>
-        </td>
-        <td>{{ attr.valeur_attribut }}</td>
-      </tr>
-    </table>
-
-    <h5 class="underlined underlined-sm main-color">Réglementation</h5>
-    <table class="font-xs table table-striped table-sm">
-      <tr *ngFor="let arrete of selectedObsTaxonDetail?.statuts_protection">
-        <td>
-          <a [href]="arrete.url"> {{ arrete.intitule }} </a>
-        </td>
-      </tr>
-    </table>
-  </mat-tab>
-
-  <ng-container *ngIf="selectedObs?.medias?.length">
-    <mat-tab label="Médias">
-      <h5 class="underlined underlined-sm main-color">Médias</h5>
+  <mat-tab-group
+    (selectedTabChange)="setValidationTab($event)"
+    #tabGroup
+    class="my-tab-grp"
+  >
+    <mat-tab label="Détail de l'occurrence">
       <table class="font-xs table table-striped table-sm">
-        <ng-container *ngFor="let media of selectedObs?.medias; index as i">
-          <tr>
-            <td>Titre</td>
-            <td>
-              <a target="_blank" [href]="mediaService.href(media)">{{ media.title_fr }}</a>
-            </td>
-          </tr>
-          <tr *ngIf="media.description_fr">
-            <td>Description</td>
-            <td>{{ media.description_fr }}</td>
-          </tr>
-          <tr *ngIf="media.author">
-            <td>Auteur</td>
-            <td>{{ media.author }}</td>
-          </tr>
-          <tr>
-            <td colspan="2">
-              <pnx-display-medias
-                diaporama="true"
-                [medias]="selectedObs?.medias"
-                [index]="i"
-                display="medium"
-              >
-              </pnx-display-medias>
-            </td>
-          </tr>
-        </ng-container>
+        <tr>
+          <td>{{ 'Synthese.ObsState' | translate }}</td>
+          <td>{{ selectedObs?.nomenclature_observation_status?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>{{ 'Synthese.ObsTech' | translate }}</td>
+          <td>{{ selectedObs?.nomenclature_obs_technique?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>{{ 'Synthese.ObsStateBio' | translate }}</td>
+          <td>{{ selectedObs?.nomenclature_bio_condition?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>{{ 'Synthese.ObsStatusBio' | translate }}</td>
+          <td>{{ selectedObs?.nomenclature_bio_status?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>{{ 'Synthese.ObsStatBiogeo' | translate }}</td>
+          <td>{{ selectedObs?.nomenclature_occ_biogeo_status?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>{{ 'Synthese.ObsBehav' | translate }}</td>
+          <td>{{ selectedObs?.nomenclature_behaviour?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>{{ 'Synthese.ObsSex' | translate }}</td>
+          <td data-qa="synthese-info-obs-sexe-value">
+            {{ selectedObs?.nomenclature_sex?.label_default }}
+          </td>
+        </tr>
+        <tr>
+          <td>{{ 'Synthese.ObsLifeStep' | translate }}</td>
+          <td>{{ selectedObs?.nomenclature_life_stage?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Denombrement min</td>
+          <td>{{ selectedObs?.count_min }}</td>
+        </tr>
+        <tr>
+          <td>Denombrement max</td>
+          <td>{{ selectedObs?.count_max }}</td>
+        </tr>
+        <tr>
+          <td>Type de dénombrement</td>
+          <td>{{ selectedObs?.nomenclature_type_count?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Objet du dénombrement</td>
+          <td>{{ selectedObs?.nomenclature_obj_count?.label_default }}</td>
+        </tr>
+        <tr></tr>
+        <tr>
+          <td>Naturalité</td>
+          <td>{{ selectedObs?.nomenclature_naturalness?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Commentaire relevé</td>
+          <td>{{ selectedObs?.comment_context }}</td>
+        </tr>
+        <tr>
+          <td>Commentaire occurrence</td>
+          <td>{{ selectedObs?.comment_description }}</td>
+        </tr>
+        <tr>
+          <td>Determinateur</td>
+          <td>{{ selectedObs?.determiner }}</td>
+        </tr>
+        <tr>
+          <td>Preuve d'existence</td>
+          <td>{{ selectedObs?.nomenclature_exist_proof?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Preuve numérique</td>
+          <td>{{ selectedObs?.digital_proof }}</td>
+        </tr>
+        <tr>
+          <td>Preuve non numérique</td>
+          <td>{{ selectedObs?.non_digital_proof }}</td>
+        </tr>
+        <tr>
+          <td>Echantillon de preuve</td>
+          <td>{{ selectedObs?.sample_number_proof }}</td>
+        </tr>
+        <tr></tr>
+        <tr>
+          <td>Type de regroupement</td>
+          <td>{{ selectedObs?.nomenclature_grp_typ?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Méthode de regroupement</td>
+          <td>{{ selectedObs?.grp_method }}</td>
+        </tr>
+        <tr>
+          <td>Source de la donnée</td>
+          <td>{{ selectedObs?.nomenclature_source_status?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Statut de validation</td>
+          <td>{{ selectedObs?.nomenclature_valid_status?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Sensibilité</td>
+          <td>{{ selectedObs?.nomenclature_sensitivity?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Niveau de diffusion</td>
+          <td>{{ selectedObs?.nomenclature_diffusion_level?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Nature de l'objet géographique</td>
+          <td>{{ selectedObs?.nomenclature_geo_object_nature?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Floutage</td>
+          <td>{{ selectedObs?.nomenclature_blurring?.label_default }}</td>
+        </tr>
+        <tr>
+          <td>Identifiant unique SINP</td>
+          <td>{{ selectedObs?.unique_id_sinp }}</td>
+        </tr>
+        <tr>
+          <td>Champs additionnels</td>
+          <td>{{ selectedObs?.additional_data | json }}</td>
+        </tr>
       </table>
     </mat-tab>
-  </ng-container>
 
-  <mat-tab label="Zonage">
-    <table class="font-xs table table-striped table-sm">
-      <thead>
+    <mat-tab label="Métadonnées">
+      <table class="font-xs table table-striped table-sm">
         <tr>
-          <th class="table_date">Type de zonage</th>
-          <th class="table_comment">Zones</th>
+          <td>Jeu de données</td>
+          <td>{{ selectedObs?.dataset.dataset_name }}</td>
         </tr>
-      </thead>
-
-      <tbody>
-        <tr *ngFor="let area_type of formatedAreas">
+        <tr>
+          <td>Cadre d'acquisition</td>
+          <td>{{ selectedObs?.dataset.acquisition_framework.acquisition_framework_name }}</td>
+        </tr>
+        <tr>
+          <td>Acteurs</td>
           <td>
-            {{ area_type.area_type }}
-          </td>
-          <td>
-            <span *ngFor="let area of area_type.areas; let index = index">
-              {{ area.area_name }}<span *ngIf="index < area_type.areas.length - 1">,</span>
-            </span>
+            <ul>
+              <li *ngFor="let actor of selectedObs?.dataset.cor_dataset_actor">
+                {{ actor.display }}
+              </li>
+            </ul>
           </td>
         </tr>
-      </tbody>
-    </table>
-  </mat-tab>
+        <tr>
+          <td>Module de provenance</td>
+          <td>{{ selectedObs?.source.name_source }}</td>
+        </tr>
+      </table>
+    </mat-tab>
 
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <span>Validation</span>
-    </ng-template>
-    <div *ngIf="showValidation">
-      <h3>Historique de validation de la donnée</h3>
+    <mat-tab label="Taxonomie">
+      <table class="font-xs table table-striped table-sm">
+        <tr>
+          <td>
+            <b>Groupe taxonomique </b>
+          </td>
+          <td>{{ selectedObsTaxonDetail?.classe }}</td>
+        </tr>
+        <tr>
+          <td>
+            <b>Ordre</b>
+          </td>
+          <td>{{ selectedObsTaxonDetail?.ordre }}</td>
+        </tr>
+        <tr>
+          <td>
+            <b> Famille</b>
+          </td>
+          <td>{{ selectedObsTaxonDetail?.famille }}</td>
+        </tr>
+      </table>
 
+      <h5 class="underlined underlined-sm main-color">Attribut(s) Taxonomique(s) locaux</h5>
+      <table class="font-xs table table-striped table-sm">
+        <tr
+          class="font-xs"
+          *ngFor="let attr of selectObsTaxonInfo?.attributs"
+        >
+          <td>
+            <b>{{ attr.label_attribut }} </b>
+          </td>
+          <td>{{ attr.valeur_attribut }}</td>
+        </tr>
+      </table>
+
+      <h5 class="underlined underlined-sm main-color">Réglementation</h5>
+      <table class="font-xs table table-striped table-sm">
+        <tr *ngFor="let arrete of selectedObsTaxonDetail?.statuts_protection">
+          <td>
+            <a [href]="arrete.url"> {{ arrete.intitule }} </a>
+          </td>
+        </tr>
+      </table>
+    </mat-tab>
+
+    <ng-container *ngIf="selectedObs?.medias?.length">
+      <mat-tab label="Médias">
+        <h5 class="underlined underlined-sm main-color">Médias</h5>
+        <table class="font-xs table table-striped table-sm">
+          <ng-container *ngFor="let media of selectedObs?.medias; index as i">
+            <tr>
+              <td>Titre</td>
+              <td>
+                <a
+                  target="_blank"
+                  [href]="mediaService.href(media)"
+                >{{ media.title_fr }}</a>
+              </td>
+            </tr>
+            <tr *ngIf="media.description_fr">
+              <td>Description</td>
+              <td>{{ media.description_fr }}</td>
+            </tr>
+            <tr *ngIf="media.author">
+              <td>Auteur</td>
+              <td>{{ media.author }}</td>
+            </tr>
+            <tr>
+              <td colspan="2">
+                <pnx-display-medias
+                  diaporama="true"
+                  [medias]="selectedObs?.medias"
+                  [index]="i"
+                  display="medium"
+                >
+                </pnx-display-medias>
+              </td>
+            </tr>
+          </ng-container>
+        </table>
+      </mat-tab>
+    </ng-container>
+
+    <mat-tab label="Zonage">
       <table class="font-xs table table-striped table-sm">
         <thead>
           <tr>
-            <th class="table_date">Date de validation</th>
-            <th class="table_status">Statut</th>
-            <th class="table_comment">Validateur</th>
-            <th class="table_comment">Commentaire</th>
+            <th class="table_date">Type de zonage</th>
+            <th class="table_comment">Zones</th>
           </tr>
         </thead>
 
         <tbody>
-          <tr *ngFor="let row of validationHistory">
-            <td width="15%">{{ row.date }}</td>
-            <td width="20%">
-              <span
-                class="validationCircle"
-                [ngStyle]="{ background: validationColor[row.cd_nomenclature] }"
-              >
-                <mat-icon *ngIf="row.typeValidation == 'True'" class="computer">computer</mat-icon>
-              </span>
-              <span class="statusName" class="ml-4">
-                {{ row.label_default }}
+          <tr *ngFor="let area_type of formatedAreas">
+            <td>
+              {{ area_type.area_type }}
+            </td>
+            <td>
+              <span *ngFor="let area of area_type.areas; let index = index">
+                {{ area.area_name }}<span *ngIf="index < area_type.areas.length - 1">,</span>
               </span>
             </td>
-            <td width="20%">
-              <span> {{ row.validator }} </span>
-            </td>
-            <td>{{ row.comment }}</td>
           </tr>
         </tbody>
       </table>
+    </mat-tab>
 
-      <div *ngIf="CONFIG.FRONTEND.ENABLE_PROFILES">
-        <div *ngIf="profile; else noProfile">
-          <h3>Profil du taxon</h3>
-          <div class="row row-sm">
-            <div class="col-4 padding-sm">
-              <h5>Informations générales sur le taxon</h5>
-              <table class="font-xs table table-striped table-sm">
-                <tr>
-                  <td>Nombre de données valides</td>
-                  <td>{{ profile?.properties?.count_valid_data }}</td>
-                </tr>
-                <tr>
-                  <td>Altitude minimale valide</td>
-                  <td>{{ profile?.properties?.altitude_min }}</td>
-                </tr>
-                <tr>
-                  <td>Altitude maximale valide</td>
-                  <td>{{ profile?.properties?.altitude_max }}</td>
-                </tr>
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <span>Validation</span>
+      </ng-template>
+      <div *ngIf="showValidation">
+        <h3>Historique de validation de la donnée</h3>
 
-                <tr>
-                  <td>Première observation valide</td>
-                  <td>{{ profile?.properties?.first_valid_data | date: 'dd/MM/yyyy' }}</td>
-                </tr>
-                <tr>
-                  <td>Dernière observation valide</td>
-                  <td>{{ profile?.properties?.last_valid_data | date: 'dd/MM/yyyy' }}</td>
-                </tr>
-              </table>
-            </div>
-            <div class="col-4 padding-sm">
-              <h5>Cohérence de la donnée</h5>
-              <table class="font-xs table table-sm table-striped">
-                <tr>
-                  <td>Dans l'aire d'observation valide</td>
-                  <td *ngIf="profileDataChecks?.valid_distribution">
-                    <mat-icon class="success"> check </mat-icon>
-                  </td>
-                  <td *ngIf="!profileDataChecks?.valid_distribution">
-                    <mat-icon class="error"> close </mat-icon>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Cohérence phénologique</td>
-                  <td *ngIf="profileDataChecks?.valid_phenology">
-                    <mat-icon class="success"> check </mat-icon>
-                  </td>
-                  <td *ngIf="!profileDataChecks?.valid_phenology">
-                    <mat-icon class="error"> close </mat-icon>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Dans la fourchette altitudinale valide</td>
-                  <td *ngIf="profileDataChecks?.valid_altitude">
-                    <mat-icon class="success"> check </mat-icon>
-                  </td>
-                  <td *ngIf="!profileDataChecks?.valid_altitude">
-                    <mat-icon class="error"> close </mat-icon>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Score</td>
-                  <td>{{ profileDataChecks?.score }}</td>
-                </tr>
-              </table>
+        <table class="font-xs table table-striped table-sm">
+          <thead>
+            <tr>
+              <th class="table_date">Date de validation</th>
+              <th class="table_status">Statut</th>
+              <th class="table_comment">Validateur</th>
+              <th class="table_comment">Commentaire</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr *ngFor="let row of validationHistory">
+              <td width="15%">{{ row.date }}</td>
+              <td width="20%">
+                <span
+                  class="validationCircle"
+                  [ngStyle]="{ background: validationColor[row.cd_nomenclature] }"
+                >
+                  <mat-icon
+                    *ngIf="row.typeValidation == 'True'"
+                    class="computer"
+                  >computer</mat-icon>
+                </span>
+                <span
+                  class="statusName"
+                  class="ml-4"
+                >
+                  {{ row.label_default }}
+                </span>
+              </td>
+              <td width="20%">
+                <span> {{ row.validator }} </span>
+              </td>
+              <td>{{ row.comment }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div *ngIf="CONFIG.FRONTEND.ENABLE_PROFILES">
+          <div *ngIf="profile; else noProfile">
+            <h3>Profil du taxon</h3>
+            <div class="row row-sm">
+              <div class="col-4 padding-sm">
+                <h5>Informations générales sur le taxon</h5>
+                <table class="font-xs table table-striped table-sm">
+                  <tr>
+                    <td>Nombre de données valides</td>
+                    <td>{{ profile?.properties?.count_valid_data }}</td>
+                  </tr>
+                  <tr>
+                    <td>Altitude minimale valide</td>
+                    <td>{{ profile?.properties?.altitude_min }}</td>
+                  </tr>
+                  <tr>
+                    <td>Altitude maximale valide</td>
+                    <td>{{ profile?.properties?.altitude_max }}</td>
+                  </tr>
+
+                  <tr>
+                    <td>Première observation valide</td>
+                    <td>{{ profile?.properties?.first_valid_data | date: 'dd/MM/yyyy' }}</td>
+                  </tr>
+                  <tr>
+                    <td>Dernière observation valide</td>
+                    <td>{{ profile?.properties?.last_valid_data | date: 'dd/MM/yyyy' }}</td>
+                  </tr>
+                </table>
+              </div>
+              <div class="col-4 padding-sm">
+                <h5>Cohérence de la donnée</h5>
+                <table class="font-xs table table-sm table-striped">
+                  <tr>
+                    <td>Dans l'aire d'observation valide</td>
+                    <td *ngIf="profileDataChecks?.valid_distribution">
+                      <mat-icon class="success"> check </mat-icon>
+                    </td>
+                    <td *ngIf="!profileDataChecks?.valid_distribution">
+                      <mat-icon class="error"> close </mat-icon>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Cohérence phénologique</td>
+                    <td *ngIf="profileDataChecks?.valid_phenology">
+                      <mat-icon class="success"> check </mat-icon>
+                    </td>
+                    <td *ngIf="!profileDataChecks?.valid_phenology">
+                      <mat-icon class="error"> close </mat-icon>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Dans la fourchette altitudinale valide</td>
+                    <td *ngIf="profileDataChecks?.valid_altitude">
+                      <mat-icon class="success"> check </mat-icon>
+                    </td>
+                    <td *ngIf="!profileDataChecks?.valid_altitude">
+                      <mat-icon class="error"> close </mat-icon>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Score</td>
+                    <td>{{ profileDataChecks?.score }}</td>
+                  </tr>
+                </table>
+              </div>
             </div>
           </div>
-        </div>
 
-        <h5>Aire de répartition des observations valides</h5>
-        <div class="mb-3 border border-secondary">
-          <pnx-map height="40vh">
-            <pnx-geojson [geojson]="selectedGeom" [style]="{ color: 'red' }"> </pnx-geojson>
-            <pnx-geojson [geojson]="profile" [zoomOnFirstTime]="true"> </pnx-geojson>
-          </pnx-map>
+          <h5>Aire de répartition des observations valides</h5>
+          <div class="mb-3 border border-secondary">
+            <pnx-map height="40vh">
+              <pnx-geojson
+                [geojson]="selectedGeom"
+                [style]="{ color: 'red' }"
+              > </pnx-geojson>
+              <pnx-geojson
+                [geojson]="profile"
+                [zoomOnFirstTime]="true"
+              > </pnx-geojson>
+            </pnx-map>
+          </div>
         </div>
+        <ng-template #noProfile>
+          <span class="alert alert-info"> Pas de profil pour ce taxon </span>
+          <br /><br />
+        </ng-template>
       </div>
-      <ng-template #noProfile>
-        <span class="alert alert-info"> Pas de profil pour ce taxon </span>
-        <br /><br />
-      </ng-template>
-    </div>
-  </mat-tab>
+    </mat-tab>
 
-  <mat-tab
-    label="{{ 'Synthese.Discussion' | translate }}"
-    *ngIf="APP_CONFIG.SYNTHESE.DISCUSSION_MODULES.includes(moduleInfos.code)"
-  >
-    <pnx-discussion-card
-      [validationColor]="validationColor"
-      [idSynthese]="idSynthese"
-      [codeModule]="moduleInfos.code"
-      [additionalData]="{ data: validationHistory, dateField: 'dateTime' }"
-    ></pnx-discussion-card>
-  </mat-tab>
-  <mat-tab-group></mat-tab-group
-></mat-tab-group>
+    <mat-tab
+      label="{{ 'Synthese.Discussion' | translate }}"
+      *ngIf="APP_CONFIG.SYNTHESE.DISCUSSION_MODULES.includes(moduleInfos.code)"
+    >
+      <pnx-discussion-card
+        [validationColor]="validationColor"
+        [idSynthese]="idSynthese"
+        [codeModule]="moduleInfos.code"
+        [additionalData]="{ data: validationHistory, dateField: 'dateTime' }"
+      ></pnx-discussion-card>
+    </mat-tab>
+  </mat-tab-group>

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.ts
@@ -18,6 +18,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { MediaService } from '@geonature_common/service/media.service';
 import { finalize } from 'rxjs/operators';
 import { constants } from 'crypto';
+import { isEmpty } from 'lodash';
 import { GlobalSubService } from '@geonature/services/global-sub.service';
 
 @Component({
@@ -52,6 +53,9 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
 
   public profile: any;
   public phenology: any[];
+  public alertOpen: boolean;
+  public alert;
+  public activateAlert = false;
   public validationColor = {
     '0': '#FFFFFF',
     '1': '#8BC34A',
@@ -77,8 +81,11 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
     this.globalSubService.currentModuleSub.subscribe((module) => {
       if (module) {
         this.moduleInfos = { id: module.id_module, code: module.module_code };
+        this.activateAlert = AppConfig.SYNTHESE.ALERT_MODULES.includes(this.moduleInfos?.code);
       }
     });
+
+    this.getAlert();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -162,6 +169,7 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
     this._gnDataService.getProfileConsistancyData(this.idSynthese).subscribe((dataChecks) => {
       this.profileDataChecks = dataChecks;
     });
+    this.getAlert();
   }
 
   sendMail() {
@@ -283,5 +291,20 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
 
   displaySuccessToaster() {
     this._commonService.translateToaster('info', 'Synthese.copy');
+  }
+
+  getAlert() {
+    this._dataService.getReports(`idSynthese=${this.idSynthese}&type=alert&sort=asc`).subscribe(data => {
+      this.alert = data[0];
+    });
+  }
+
+  openCloseAlert() {
+    this.alertOpen = !this.alertOpen;
+    this.getAlert();
+  }
+
+  alertExists() {
+    return !isEmpty(this.alert);
   }
 }

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.ts
@@ -18,7 +18,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { MediaService } from '@geonature_common/service/media.service';
 import { finalize } from 'rxjs/operators';
 import { constants } from 'crypto';
-import { isEmpty } from 'lodash';
+import { isEmpty, find } from 'lodash';
 import { GlobalSubService } from '@geonature/services/global-sub.service';
 
 @Component({
@@ -84,8 +84,6 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
         this.activateAlert = AppConfig.SYNTHESE.ALERT_MODULES.includes(this.moduleInfos?.code);
       }
     });
-
-    this.getAlert();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -115,6 +113,7 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
       )
       .subscribe((data) => {
         this.selectedObs = data['properties'];
+        this.alert = find(data.properties.reports, ['report_type.type', 'alert']);
         this.selectCdNomenclature = this.selectedObs?.nomenclature_valid_status.cd_nomenclature;
         this.selectedGeom = data;
         this.selectedObs['municipalities'] = [];
@@ -169,7 +168,6 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
     this._gnDataService.getProfileConsistancyData(this.idSynthese).subscribe((dataChecks) => {
       this.profileDataChecks = dataChecks;
     });
-    this.getAlert();
   }
 
   sendMail() {
@@ -293,10 +291,15 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
     this._commonService.translateToaster('info', 'Synthese.copy');
   }
 
+  /**
+   * Get required id_report to delete an alert
+   */
   getAlert() {
-    this._dataService.getReports(`idSynthese=${this.idSynthese}&type=alert&sort=asc`).subscribe(data => {
-      this.alert = data[0];
-    });
+    this._dataService
+      .getReports(`idSynthese=${this.idSynthese}&type=alert&sort=asc`)
+      .subscribe((data) => {
+        this.alert = data[0];
+      });
   }
 
   openCloseAlert() {

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-shared.module.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-shared.module.ts
@@ -13,6 +13,6 @@ import { AlertInfoComponent } from '../alertInfoModule/alert-Info.component';
   imports: [CommonModule, GN2CommonModule, ChartsModule, RouterModule, ClipboardModule],
   exports: [SyntheseInfoObsComponent, DiscussionCardComponent, AlertInfoComponent],
   declarations: [SyntheseInfoObsComponent, DiscussionCardComponent, AlertInfoComponent],
-  providers: []
+  providers: [],
 })
-export class SharedSyntheseModule { }
+export class SharedSyntheseModule {}

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-shared.module.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-shared.module.ts
@@ -7,11 +7,12 @@ import { ClipboardModule } from '@angular/cdk/clipboard';
 
 import { SyntheseInfoObsComponent } from './synthese-info-obs/synthese-info-obs.component';
 import { DiscussionCardComponent } from '../discussionCardModule/discussion-card.component';
+import { AlertInfoComponent } from '../alertInfoModule/alert-Info.component';
 
 @NgModule({
   imports: [CommonModule, GN2CommonModule, ChartsModule, RouterModule, ClipboardModule],
-  exports: [SyntheseInfoObsComponent, DiscussionCardComponent],
-  declarations: [SyntheseInfoObsComponent, DiscussionCardComponent],
-  providers: [],
+  exports: [SyntheseInfoObsComponent, DiscussionCardComponent, AlertInfoComponent],
+  declarations: [SyntheseInfoObsComponent, DiscussionCardComponent, AlertInfoComponent],
+  providers: []
 })
-export class SharedSyntheseModule {}
+export class SharedSyntheseModule { }

--- a/frontend/src/app/syntheseModule/synthese.module.ts
+++ b/frontend/src/app/syntheseModule/synthese.module.ts
@@ -37,7 +37,12 @@ const routes: Routes = [
     SyntheseModalDownloadComponent,
     TaxonSheetComponent,
   ],
-  entryComponents: [SyntheseInfoObsComponent, SyntheseModalDownloadComponent, DiscussionCardComponent, AlertInfoComponent],
+  entryComponents: [
+    SyntheseInfoObsComponent,
+    SyntheseModalDownloadComponent,
+    DiscussionCardComponent,
+    AlertInfoComponent,
+  ],
   providers: [
     MapService,
     DynamicFormService,
@@ -46,4 +51,4 @@ const routes: Routes = [
     SyntheseFormService,
   ],
 })
-export class SyntheseModule { }
+export class SyntheseModule {}

--- a/frontend/src/app/syntheseModule/synthese.module.ts
+++ b/frontend/src/app/syntheseModule/synthese.module.ts
@@ -15,6 +15,7 @@ import { SharedSyntheseModule } from '@geonature/shared/syntheseSharedModule/syn
 import { SyntheseInfoObsComponent } from '@geonature/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component';
 import { SyntheseModalDownloadComponent } from './synthese-results/synthese-list/modal-download/modal-download.component';
 import { DiscussionCardComponent } from '@geonature/shared/discussionCardModule/discussion-card.component';
+import { AlertInfoComponent } from '../shared/alertInfoModule/alert-Info.component';
 import { TaxonSheetComponent } from './taxon-sheet/taxon-sheet.component';
 const routes: Routes = [
   { path: '', component: SyntheseComponent },
@@ -36,11 +37,7 @@ const routes: Routes = [
     SyntheseModalDownloadComponent,
     TaxonSheetComponent,
   ],
-  entryComponents: [
-    SyntheseInfoObsComponent,
-    SyntheseModalDownloadComponent,
-    DiscussionCardComponent,
-  ],
+  entryComponents: [SyntheseInfoObsComponent, SyntheseModalDownloadComponent, DiscussionCardComponent, AlertInfoComponent],
   providers: [
     MapService,
     DynamicFormService,
@@ -49,4 +46,4 @@ const routes: Routes = [
     SyntheseFormService,
   ],
 })
-export class SyntheseModule {}
+export class SyntheseModule { }


### PR DESCRIPTION
_Ref. issue #1750_ 

> Cette contribution a été réalisée selon les besoins de [picardie-nature](http://www.picardie-nature.org/) @jbdesbas 

Cette proposition de PR permet, depuis le module “Synthèse”, de pouvoir signaler une
observation semblant erronée ou suspecte.

 Une observation aberrantes / suspecte pourra alors être rapidement rendue visible via un bouton `signaler` et un formulaire afin d'ajouter un commentaire. Les observations signalées sont ensuite mise en évidence dans la liste des occurrences de la VALIDATION et recherchable via un filtre avancé "Est signalé".

Cette fonctionnalité est optionnelle car visible ou non dans les modules `SYNTHESE`, `VALIDATION` ou dans aucun des deux selon les détails fourni dans l'issue 1750.

Les éléments suivants on été modifiés ou rajoutés : 

- [x] Nouvelle route dédiée à la suppression d'un signalement (uniquement si validateur)
- [x] Ajout d'un bouton `Signaler` pour ouvrir ou fermer le formulaire (ou le détail du signalement)
- [x] Ajout d'un filtre `has_alert` pour filtrer la liste de validation sur les occurrences qui ont un signalement
- [x] Ajout d'un drapeau dans la liste pour indiquer qu'une occurrence contient un signalement (tableau VALIDATION uniquement)
- [x] Test backend
- [x]  squash
- [x] Configuration (rendre optionnel)

Tout le monde peut signaler une occurrence, seuls les validateurs peuvent la supprimer.

Toutes remarques sont les bienvenus.

 ### Aperçu
 
![pr-alert](https://user-images.githubusercontent.com/16317988/161053491-ec7383f3-c6fa-4fea-9ec3-4281e49b43a5.gif)

 