### PR TITLE
Suppression de la vue v_synthese_for_web_app

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -92,6 +92,7 @@ jobs:
         geonature db autoupgrade -x local-srid=2154
         geonature db upgrade geonature-samples@head
         geonature db upgrade taxonomie_taxons_example@head
+        geonature db upgrade taxonomie_attributes_example@head
         geonature db upgrade ref_geo_fr_departments@head
         geonature db upgrade ref_geo_fr_municipalities@head
         geonature db upgrade ref_geo_inpn_grids_5@head

--- a/backend/geonature/core/gn_meta/repositories.py
+++ b/backend/geonature/core/gn_meta/repositories.py
@@ -27,7 +27,6 @@ from geonature.core.gn_meta.models import (
     CorAcquisitionFrameworkActor,
     TDatasetDetails,
 )
-from geonature.core.gn_synthese.models import Synthese
 from pypnusershub.db.models import Organisme as BibOrganismes
 from werkzeug.exceptions import Unauthorized
 

--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -3,7 +3,14 @@ from collections import OrderedDict
 import sqlalchemy as sa
 import datetime
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import relationship, column_property, foreign, joinedload, contains_eager
+from sqlalchemy.orm import (
+    relationship,
+    column_property,
+    foreign,
+    joinedload,
+    contains_eager,
+    deferred,
+)
 from sqlalchemy.sql import select, func, exists
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from geoalchemy2 import Geometry
@@ -279,8 +286,9 @@ class Synthese(DB.Model):
     depth_max = DB.Column(DB.Integer)
     place_name = DB.Column(DB.Unicode(length=500))
     the_geom_4326 = DB.Column(Geometry("GEOMETRY", 4326))
-    the_geom_point = DB.Column(Geometry("GEOMETRY", 4326))
-    the_geom_local = DB.Column(Geometry("GEOMETRY"))
+    the_geom_4326_geojson = column_property(func.ST_AsGeoJSON(the_geom_4326), deferred=True)
+    the_geom_point = deferred(DB.Column(Geometry("GEOMETRY", 4326)))
+    the_geom_local = deferred(DB.Column(Geometry("GEOMETRY")))
     precision = DB.Column(DB.Integer)
     id_area_attachment = DB.Column(DB.Integer)
     date_min = DB.Column(DB.DateTime, nullable=False)

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -73,7 +73,6 @@ routes = Blueprint("gn_synthese", __name__)
 
 @routes.route("/for_web", methods=["GET", "POST"])
 @permissions.check_cruved_scope("R", True, module_code="SYNTHESE")
-@json_resp
 def get_observations_for_web(info_role):
     """Optimized route to serve data for the frontend with all filters.
 
@@ -172,16 +171,14 @@ def get_observations_for_web(info_role):
             "unique_id_sinp": str(r["unique_id_sinp"]),
             "entity_source_pk_value": r["entity_source_pk_value"],
         }
-        geojson = json.loads(r["st_asgeojson"])
-        geojson["properties"] = properties
-        geojson_features.append(geojson)
-    return {
-        "data": FeatureCollection(geojson_features),
-        "nb_total": len(geojson_features),
-        "nb_obs_limited": (
-            len(geojson_features) == int(current_app.config["SYNTHESE"]["NB_MAX_OBS_MAP"])
-        ),
-    }
+        geometry = json.loads(r["st_asgeojson"])
+        geojson_features.append(
+            Feature(
+                geometry=geometry,
+                properties=properties,
+            )
+        )
+    return jsonify(FeatureCollection(geojson_features))
 
 
 @routes.route("", methods=["GET"])

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -1,4 +1,3 @@
-import logging
 import json
 import datetime
 import time
@@ -63,17 +62,8 @@ from ref_geo.models import LAreas, BibAreasTypes
 from pypnusershub.db.tools import user_from_token
 from pypnusershub.db.models import User
 
-# debug
-# current_app.config['SQLALCHEMY_ECHO'] = True
 
 routes = Blueprint("gn_synthese", __name__)
-
-# get the root logger
-log = logging.getLogger()
-
-
-def current_milli_time():
-    return time.time()
 
 
 ############################################

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -8,8 +8,7 @@ much more efficient
 import datetime
 import uuid
 
-from flask import current_app, request
-from sqlalchemy import func, or_, and_, select, join
+from sqlalchemy import func, or_, and_, select
 from sqlalchemy.sql import text
 from sqlalchemy.orm import aliased
 from shapely.wkt import loads
@@ -21,15 +20,12 @@ from utils_flask_sqla_geo.utilsgeometry import circle_from_point
 from geonature.utils.env import DB
 from geonature.core.taxonomie.models import Taxref, CorTaxonAttribut, TaxrefLR
 from geonature.core.gn_synthese.models import (
-    Synthese,
     CorObserverSynthese,
-    TSources,
     CorAreaSynthese,
     BibReportsTypes,
     TReport,
 )
 from geonature.core.gn_meta.models import (
-    TAcquisitionFramework,
     CorDatasetActor,
     TDatasets,
 )

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -201,27 +201,6 @@ def datasets(users, acquisition_frameworks):
     return datasets
 
 
-# @pytest.fixture(scope='class')
-# def sample_data(app):
-#    with db.session.begin_nested():
-#        for sql_file in ['delete_sample_data.sql', 'sample_data.sql']:
-#            operations = pkg_resources.resource_string("geonature.tests", f"data/{sql_file}") \
-#                                      .decode('utf-8')
-#            db.session.execute(operations)
-
-
-@pytest.fixture()
-def taxon_attribut():
-    from apptax.taxonomie.models import BibAttributs, BibNoms, CorTaxonAttribut
-
-    nom = BibNoms.query.filter_by(cd_ref=209902).one()
-    attribut = BibAttributs.query.filter_by(nom_attribut="atlas_milieu").one()
-    with db.session.begin_nested():
-        c = CorTaxonAttribut(bib_nom=nom, bib_attribut=attribut, valeur_attribut="eau")
-        db.session.add(c)
-    return c
-
-
 @pytest.fixture()
 def source():
     with db.session.begin_nested():

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -186,8 +186,8 @@ class TestSynthese:
         )
         data = response.get_json()
 
-        features = data["data"]["features"]
-        assert len(data["data"]["features"]) > 0
+        features = data["features"]
+        assert len(features) > 0
         assert all(
             feat["properties"]["lb_nom"] in [synt.nom_cite for synt in synthese_data]
             for feat in features
@@ -204,7 +204,7 @@ class TestSynthese:
         data = response.get_json()
 
         # le résultat doit être supérieur ou égal à 2
-        assert len(data["data"]["features"]) != 0
+        assert len(data["features"]) != 0
         # le requete doit etre OK marlgré la geom NULL
         assert response.status_code == 200
 

--- a/backend/geonature/tests/utils.py
+++ b/backend/geonature/tests/utils.py
@@ -15,3 +15,79 @@ def login(client, username="admin", password=None):
     }
     response = client.post(url_for("auth.login"), json=data)
     assert response.status_code == 200
+
+
+jsonschema_definitions = {
+    "geometries": {
+        "BoundingBox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {"type": "number"},
+        },
+        "PointCoordinates": {"type": "array", "minItems": 2, "items": {"type": "number"}},
+        "Point": {
+            "title": "GeoJSON Point",
+            "type": "object",
+            "required": ["type", "coordinates"],
+            "properties": {
+                "type": {"type": "string", "enum": ["Point"]},
+                "coordinates": {
+                    "$ref": "#/definitions/geometries/PointCoordinates",
+                },
+                "bbox": {
+                    "$ref": "#/definitions/geometries/BoundingBox",
+                },
+            },
+        },
+    },
+    "feature": {
+        "title": "GeoJSON Feature",
+        "type": "object",
+        "required": ["type", "properties", "geometry"],
+        "properties": {
+            "type": {"type": "string", "enum": ["Feature"]},
+            "id": {"oneOf": [{"type": "number"}, {"type": "string"}]},
+            "properties": {
+                "oneOf": [
+                    {"type": "null"},
+                    {"$ref": "#/$defs/props"},
+                ],
+            },
+            "geometry": {
+                "oneOf": [
+                    {"type": "null"},
+                    {"$ref": "#/definitions/geometries/Point"},
+                    # {"$ref": "#/definitions/geometries/LineString"},
+                    # {"$ref": "#/definitions/geometries/Polygon"},
+                    # {"$ref": "#/definitions/geometries/MultiPoint"},
+                    # {"$ref": "#/definitions/geometries/MultiLineString"},
+                    # {"$ref": "#/definitions/geometries/MultiPolygon"},
+                    # {"$ref": "#/definitions/geometries/GeometryCollection"},
+                ],
+            },
+            "bbox": {
+                "$ref": "#/definitions/geometries/BoundingBox",
+            },
+        },
+    },
+    "featurecollection": {
+        "title": "GeoJSON FeatureCollection",
+        "type": "object",
+        "required": ["type", "features"],
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": ["FeatureCollection"],
+            },
+            "features": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/feature",
+                },
+            },
+            "bbox": {
+                "$ref": "#/definitions/geometries/BoundingBox",
+            },
+        },
+    },
+}

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -22,9 +22,6 @@ from geonature.utils.env import GEONATURE_VERSION
 from geonature.utils.utilsmails import clean_recipients
 
 
-DEFAULT_ID_MUNICIPALITY = 25
-
-
 class EmailStrOrListOfEmailStrField(fields.Field):
     def _deserialize(self, value, attr, data, **kwargs):
         if isinstance(value, str):
@@ -73,7 +70,6 @@ class MTDSchemaConf(Schema):
 
 
 class BddConfig(Schema):
-    id_area_type_municipality = fields.Integer(load_default=DEFAULT_ID_MUNICIPALITY)
     ID_USER_SOCLE_1 = fields.Integer(load_default=8)
     ID_USER_SOCLE_2 = fields.Integer(load_default=6)
 

--- a/frontend/src/app/GN2CommonModule/form/areas/areas.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/areas/areas.component.ts
@@ -140,7 +140,7 @@ export class AreasComponent extends GenericFormComponent implements OnInit {
    * @param data Liste d'objets contenant des infos sur des zones géographiques.
    */
   private formatAreas(data: Partial<{ id_type: number; area_code: string }>[]) {
-    if (data.length > 0 && data[0]['id_type'] === AppConfig.BDD.id_area_type_municipality) {
+    if (data.length > 0 && data[0]['area_type']['type_code'] === 'COM') {
       return data.map((element) => {
         element['area_name'] = `${element['area_name']} (${element.area_code.substring(0, 2)}) `;
         return element;

--- a/frontend/src/app/components/home-content/home-content.component.ts
+++ b/frontend/src/app/components/home-content/home-content.component.ts
@@ -54,8 +54,8 @@ export class HomeContentComponent implements OnInit {
     this.appConfig = AppConfig;
 
     if (this.showLastObsMap) {
-      this._syntheseApi.getSyntheseData({ limit: 100 }).subscribe((result) => {
-        this.lastObs = result.data;
+      this._syntheseApi.getSyntheseData({ limit: 100 }).subscribe((data) => {
+        this.lastObs = data;
       });
     }
 

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
@@ -142,24 +142,24 @@ export class SyntheseCarteComponent implements OnInit, AfterViewInit, OnChanges 
       change.inputSyntheseData.currentValue.features.forEach((geojson) => {
         // we don't create a generic function for setStyle and event on each layer to avoid
         // a if on possible milion of point (with multipoint we must set the event on each point)
-        if (geojson.type == 'Point' || geojson.type == 'MultiPoint') {
-          if (geojson.type == 'Point') {
-            geojson.coordinates = [geojson.coordinates];
+        if (geojson.geometry.type == 'Point' || geojson.geometry.type == 'MultiPoint') {
+          if (geojson.geometry.type == 'Point') {
+            geojson.geometry.coordinates = [geojson.geometry.coordinates];
           }
-          for (let i = 0; i < geojson.coordinates.length; i++) {
-            const latLng = L.GeoJSON.coordsToLatLng(geojson.coordinates[i]);
+          for (let i = 0; i < geojson.geometry.coordinates.length; i++) {
+            const latLng = L.GeoJSON.coordsToLatLng(geojson.geometry.coordinates[i]);
             this.setStyleEventAndAdd(L.circleMarker(latLng), geojson.properties.id);
           }
         } else if (geojson.type == 'Polygon' || geojson.type == 'MultiPolygon') {
           const latLng = L.GeoJSON.coordsToLatLngs(
-            geojson.coordinates,
-            geojson.type === 'Polygon' ? 1 : 2
+            geojson.geometry.coordinates,
+            geojson.geometry.type === 'Polygon' ? 1 : 2
           );
           this.setStyleEventAndAdd(new L.Polygon(latLng), geojson.properties.id);
-        } else if (geojson.type == 'LineString' || geojson.type == 'MultiLineString') {
+        } else if (geojson.geometry.type == 'LineString' || geojson.geometry.type == 'MultiLineString') {
           const latLng = L.GeoJSON.coordsToLatLngs(
-            geojson.coordinates,
-            geojson.type === 'LineString' ? 0 : 1
+            geojson.geometry.coordinates,
+            geojson.geometry.type === 'LineString' ? 0 : 1
           );
           this.setStyleEventAndAdd(new L.Polyline(latLng), geojson.properties.id);
         }

--- a/frontend/src/app/syntheseModule/synthese.component.ts
+++ b/frontend/src/app/syntheseModule/synthese.component.ts
@@ -37,8 +37,8 @@ export class SyntheseComponent implements OnInit {
   loadAndStoreData(formParams) {
     this.searchService.dataLoaded = false;
     this.searchService.getSyntheseData(formParams).subscribe(
-      (result) => {
-        if (result['nb_obs_limited']) {
+      (data) => {
+        if (data.length >= AppConfig.SYNTHESE.NB_MAX_OBS_MAP) {
           const modalRef = this._modalService.open(SyntheseModalDownloadComponent, {
             size: 'lg',
           });
@@ -46,13 +46,13 @@ export class SyntheseComponent implements OnInit {
           modalRef.componentInstance.queryString = this.searchService.buildQueryUrl(formatedParams);
           modalRef.componentInstance.tooManyObs = true;
         }
-        this._mapListService.geojsonData = result['data'];
-        this._mapListService.tableData = result['data'];
-        this._mapListService.loadTableData(result['data']);
+        this._mapListService.geojsonData = data;
+        this._mapListService.tableData = data;
+        this._mapListService.loadTableData(data);
         this._mapListService.idName = 'id';
         this.searchService.dataLoaded = true;
         // store the list of id_synthese for exports
-        this._syntheseStore.idSyntheseList = result['data']['features'].map((row) => {
+        this._syntheseStore.idSyntheseList = data['features'].map((row) => {
           return row['properties']['id'];
         });
       },


### PR DESCRIPTION
Cette vue est inutile : elle se contente de joindre d’autres tables, et de demander le calcule de la géométrie en *geojson*. Il n’y a pas d’intérêt à maintenir cette vue, et devoir gérer un deuxième modèle (ainsi que la générécité du filtre générique SyntheseQuery qui découle de ces 2 modèles) alors que ces jointures et le calcule du *geojson* peuvent être fait très simplement avec SQLAlchemy.

Une colonne ``the_geom_4326_geojson`` a été rajouté sur le modèle ``Synthese`` :
```
the_geom_4326_geojson = column_property(func.ST_AsGeoJSON(the_geom_4326), deferred=True)
```