### PR TITLE
[Carte] Améliorer la robustesse de la recherche OpenStreetMap et restreindre sur certains pays

### DIFF
--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -346,6 +346,12 @@ class MapConfig(Schema):
     # zoom appliqué sur la carte lorsque l'on clique sur une liste
     # ne s'applique qu'aux points
     ZOOM_ON_CLICK = fields.Integer(load_default=18)
+    # Restreindre la recherche OpenStreetMap à certains pays
+    # Les pays doivent être au format ISO_3166-1 : https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+    # et séparés par une virgule
+    # Exemple : COUNTRY_CODES = "fr,es,be,ch" (Restreint à France, Espagne, Belgique et Suisse)
+    # Laisser à null pour n'avoir aucune restriction
+    OSM_RESTRICT_COUNTRY_CODES = fields.String(load_default=None)
 
 
 class TaxHub(Schema):

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -347,9 +347,9 @@ class MapConfig(Schema):
     # ne s'applique qu'aux points
     ZOOM_ON_CLICK = fields.Integer(load_default=18)
     # Restreindre la recherche OpenStreetMap (sur la carte dans l'encart "Rechercher un lieu")
-    # à certains pays. Les pays doivent être au format ISO_3166-1 : 
+    # à certains pays. Les pays doivent être au format ISO_3166-1 :
     # https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 et séparés par une virgule.
-    # Exemple : OSM_RESTRICT_COUNTRY_CODES = "fr,es,be,ch" (Restreint à France, Espagne, Belgique 
+    # Exemple : OSM_RESTRICT_COUNTRY_CODES = "fr,es,be,ch" (Restreint à France, Espagne, Belgique
     # et Suisse)
     # Laisser à null pour n'avoir aucune restriction
     OSM_RESTRICT_COUNTRY_CODES = fields.String(load_default=None)

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -346,10 +346,11 @@ class MapConfig(Schema):
     # zoom appliqué sur la carte lorsque l'on clique sur une liste
     # ne s'applique qu'aux points
     ZOOM_ON_CLICK = fields.Integer(load_default=18)
-    # Restreindre la recherche OpenStreetMap à certains pays
-    # Les pays doivent être au format ISO_3166-1 : https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
-    # et séparés par une virgule
-    # Exemple : COUNTRY_CODES = "fr,es,be,ch" (Restreint à France, Espagne, Belgique et Suisse)
+    # Restreindre la recherche OpenStreetMap (sur la carte dans l'encart "Rechercher un lieu")
+    # à certains pays. Les pays doivent être au format ISO_3166-1 : 
+    # https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 et séparés par une virgule.
+    # Exemple : OSM_RESTRICT_COUNTRY_CODES = "fr,es,be,ch" (Restreint à France, Espagne, Belgique 
+    # et Suisse)
     # Laisser à null pour n'avoir aucune restriction
     OSM_RESTRICT_COUNTRY_CODES = fields.String(load_default=None)
 

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -198,10 +198,11 @@ MAIL_ON_ERROR = false
     # Zoom appliqué sur la carte lors du clic sur une liste
     ZOOM_ON_CLICK = 16
 
-    # Restreindre la recherche OpenStreetMap à certains pays
-    # Les pays doivent être au format ISO_3166-1 : https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 
-    # et séparés par une virgule
-    # Exemple : COUNTRY_CODES = "fr,es,be,ch" (Restreint à France, Espagne, Belgique et Suisse)
+    # Restreindre la recherche OpenStreetMap (sur la carte dans l'encart "Rechercher un lieu")
+    # à certains pays. Les pays doivent être au format ISO_3166-1 : 
+    # https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 et séparés par une virgule.
+    # Exemple : OSM_RESTRICT_COUNTRY_CODES = "fr,es,be,ch" (Restreint à France, Espagne, Belgique 
+    # et Suisse)
     # Laisser à null pour n'avoir aucune restriction
     OSM_RESTRICT_COUNTRY_CODES = null
 

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -198,6 +198,13 @@ MAIL_ON_ERROR = false
     # Zoom appliqué sur la carte lors du clic sur une liste
     ZOOM_ON_CLICK = 16
 
+    # Restreindre la recherche OpenStreetMap à certains pays
+    # Les pays doivent être au format ISO_3166-1 : https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 
+    # et séparés par une virgule
+    # Exemple : COUNTRY_CODES = "fr,es,be,ch" (Restreint à France, Espagne, Belgique et Suisse)
+    # Laisser à null pour n'avoir aucune restriction
+    OSM_RESTRICT_COUNTRY_CODES = null
+
 # Liste des fonds de carte proposés sur les cartes de GeoNature
 # chaque section [[MAPCONFIG.BASEMAP]] définit un fond de carte
 # l'option service est obligatoire uniquement pour les wms

--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, ViewChild, Injectable } from '@angular/core';
 import { MapService } from './map.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { Map, LatLngExpression } from 'leaflet';
+import { Map, LatLngExpression, LatLngBounds } from 'leaflet';
 import { AppConfig } from '@geonature_config/app.config';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import * as L from 'leaflet';
@@ -26,6 +26,7 @@ const PARAMS = new HttpParams({
     format: 'json',
     limit: '10',
     polygon_geojson: '1',
+    countrycodes: AppConfig.MAPCONFIG.OSM_RESTRICT_COUNTRY_CODES,
   },
 });
 
@@ -106,8 +107,18 @@ export class MapComponent implements OnInit {
     );
 
   onResultSelected(nomatimObject) {
-    const geojson = L.geoJSON(nomatimObject.item.geojson);
-    this.map.fitBounds(geojson.getBounds());
+    let bounds: LatLngBounds;
+    if (nomatimObject.item?.geojson) {
+      const geojson = L.geoJSON(nomatimObject.item.geojson);
+      bounds = geojson.getBounds();
+    } else {
+      const boundingBox: number[] = nomatimObject.item.boundingbox;
+      bounds = L.latLngBounds(
+        L.latLng(boundingBox[0], boundingBox[2]),
+        L.latLng(boundingBox[1], boundingBox[3])
+      );
+    }
+    this.map.fitBounds(bounds);
   }
 
   initialize() {


### PR DESCRIPTION
## Objectif
- Ajout d'une condition pour récupérer la `boundingbox` si le `geojson` n'est pas présent dans la réponse de nominatim OpenStreetMap lors de la recherche sur la carte.
- Ajout d'un nouveau paramètre dans la configuration pour pouvoir restreindre cette recherche pour certains pays.

Comme le stipule la [documentation de nominatim OpenStreeMap](https://nominatim.org/release-docs/latest/api/Search/#result-limitation), il est possible de restreindre la recherche à une liste de pays.
Le paramètre proposé permet à l'utilisateur de les fournir sous forme d'une chaîne de caractères respectant le format suivant : 
```toml
[MAPCONFIG]
OSM_RESTRICT_COUNTRY_CODES = "fr,ch,be,sp"
```
Les "pays" à fournir sont en réalité leur code [ISO_3166-1_alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Un exemple est donné dans le fichier `default_config.toml.example`.

Pour désactiver cette restriction, il suffit de retirer ce paramètre ou de le définir comme `null`.

En espérant que cela vous convienne

Closes #2010 