### PR TITLE
fix/affichage_date_occtax ref #2005

### DIFF
--- a/contrib/occtax/frontend/app/occtax-form/occtax-form.service.ts
+++ b/contrib/occtax/frontend/app/occtax-form/occtax-form.service.ts
@@ -169,11 +169,11 @@ export class OcctaxFormService {
 
 
   formatDate(strDate) {
-    const date = new Date(strDate);
+    const [year, month, day] = strDate.split('-').map(x => parseInt(x))
     return {
-      year: date.getFullYear(),
-      month: date.getMonth() + 1,
-      day: date.getDate(),
+      year,
+      month,
+      day
     };
   }
 

--- a/contrib/occtax/frontend/app/occtax-map-info/occtax-map-info.component.html
+++ b/contrib/occtax/frontend/app/occtax-map-info/occtax-map-info.component.html
@@ -59,9 +59,9 @@
                   </div>
                   <div>
                     <div class="label"> Entre le :</div>
-                    <div class="value">{{ releve.date_min | date:'dd/MM/yyyy' }} {{releve.hour_min}} </div>
+                    <div class="value">{{ releve.date_min }} {{ releve.hour_min }} </div>
                     <div class="label"> &nbsp; et le : </div>
-                    <div class="value">{{ releve.date_max | date:'dd/MM/yyyy' }} {{releve.hour_max}} </div>
+                    <div class="value">{{ releve.date_max }} {{ releve.hour_max }} </div>
                   </div>
                   <div *ngIf="occtaxConfig.form_fields.place_name">
                       <div class="label">  {{ 'Releve.PlaceName' | translate }} :</div>

--- a/contrib/occtax/frontend/app/occtax-map-info/occtax-map-info.component.ts
+++ b/contrib/occtax/frontend/app/occtax-map-info/occtax-map-info.component.ts
@@ -140,8 +140,8 @@ export class OcctaxMapInfoComponent implements OnInit, AfterViewInit {
         map((data) => {
           this.userReleveCruved = data.cruved;
           let releve = data.releve;
-          releve.properties.date_min = new Date(releve.properties.date_min);
-          releve.properties.date_max = new Date(releve.properties.date_max);
+          releve.properties.date_min = releve.properties.date_min.split('-').reverse().join('/');
+          releve.properties.date_max = releve.properties.date_min.split('-').reverse().join('/');
           this.getNomenclatures();
           return releve;
         })

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,7 @@ CHANGELOG
 **🐛 Corrections**
 
 * Remise en place de la rotation des fichiers de logs
+* Formatage des dates dans occtax pour ne pas dépendre du fuseau horaire (#2005)
 
 **⚠️ Notes de version**
 


### PR DESCRIPTION
Corrige #2005 en utilisant le moins possible la classe js `Date` (Seulement pour la date du jour)