### PR TITLE
display map coordinate on mouse move

### DIFF
--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -353,6 +353,8 @@ class MapConfig(Schema):
     # et Suisse)
     # Laisser à null pour n'avoir aucune restriction
     OSM_RESTRICT_COUNTRY_CODES = fields.String(load_default=None)
+    # Affichage des coordonées sur la carte (lon, lat) au survol de la souris
+    DISPLAY_MOUSE_COORDINATES = fields.Boolean(load_default=False)
 
 
 class TaxHub(Schema):

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -206,6 +206,9 @@ MAIL_ON_ERROR = false
     # Laisser à null pour n'avoir aucune restriction
     OSM_RESTRICT_COUNTRY_CODES = null
 
+    # Affichage des coordonées du point survolé par le pointer de la souris
+    DISPLAY_MOUSE_COORDINATES = false
+
 # Liste des fonds de carte proposés sur les cartes de GeoNature
 # chaque section [[MAPCONFIG.BASEMAP]] définit un fond de carte
 # l'option service est obligatoire uniquement pour les wms

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -12,7 +12,8 @@ CHANGELOG
 * Ajout d’un worker Celery pour l’exécution de tâches asynchrones
 * Déplacement du fichier de log GeoNature dans le dossier ``/var/log/geonature/``
 * Suppression de la table ``gn_sensitivity.cor_sensitivity_synthese`` et des triggers associés.
-
+* Possibilité de voir les coordonnées quand le pointer de la souris survole une carte et de copier ces coordonnées dans le presse papier avec un click droit.
+    * options ``MAP_CONFIG.DISPLAY_MOUSE_COORDINATES`` (par défaut à ``false``)
 **🐛 Corrections**
 
 * Remise en place de la rotation des fichiers de logs

--- a/frontend/src/app/GN2CommonModule/map/map.component.html
+++ b/frontend/src/app/GN2CommonModule/map/map.component.html
@@ -17,5 +17,6 @@
       </ng-template>
     </div>
   </div>
+  <div class="coordinates" *ngIf="coordinatesTxt"> {{ coordinatesTxt }}</div>
   <div #mapDiv [ngStyle]="{ height: height }"></div>
 </div>

--- a/frontend/src/app/GN2CommonModule/map/map.component.scss
+++ b/frontend/src/app/GN2CommonModule/map/map.component.scss
@@ -47,3 +47,18 @@
   background-position: right center;
   background-repeat: no-repeat;
 }
+
+
+.coordinates {
+  position: absolute;
+  bottom: 5px;
+  z-index: 9999;
+  text-align: center;
+  width: 200px;
+  left: 50%;
+  margin-left: -100px;
+  background-color: rgba(255, 255, 255, 0.5);
+  border-radius: 5px;
+  border: 1px solid rgba(0,0,0,0.5);
+  font-size: 0.8em;
+}

--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -196,7 +196,7 @@ export class MapComponent implements OnInit {
       // 6 decimales
       const lat = Math.round(event.latlng.lat * 1e6) / 1e6;
       const lng = Math.round(event.latlng.lng * 1e6) / 1e6;
-      this.coordinatesTxt = `${lat}, ${lng}`;
+      this.coordinatesTxt = `${lng}, ${lat}`;
     });
 
     // quand le pointeur de la soouris quitte la carte
@@ -211,7 +211,7 @@ export class MapComponent implements OnInit {
       // 6 decimales
       const lat = Math.round(event.latlng.lat * 1e6) / 1e6;
       const lng = Math.round(event.latlng.lng * 1e6) / 1e6;
-      this.coordinatesTxt = `${lat}, ${lng}`;
+      this.coordinatesTxt = `${lng}, ${lat}`;
       if (!(navigator as any).clipboard) {
         return;
       }

--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -212,7 +212,10 @@ export class MapComponent implements OnInit {
       const lat = Math.round(event.latlng.lat * 1e6) / 1e6;
       const lng = Math.round(event.latlng.lng * 1e6) / 1e6;
       this.coordinatesTxt = `${lat}, ${lng}`;
-      navigator.clipboard.writeText(this.coordinatesTxt);
+      if (!(navigator as any).clipboard) {
+        return;
+      }
+      (navigator as any).clipboard.writeText(this.coordinatesTxt);
       this._commonService.regularToaster(
         'success',
         `Le point\n(lon: ${lng}, lat: ${lat})\na été copié dans le presse papier`

--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -180,7 +180,7 @@ export class MapComponent implements OnInit {
     });
 
     if (AppConfig.MAPCONFIG.DISPLAY_MOUSE_COORDINATES) {
-      this.initDisplayCoordinates()
+      this.initDisplayCoordinates();
     }
 
     setTimeout(() => {
@@ -192,7 +192,7 @@ export class MapComponent implements OnInit {
   initDisplayCoordinates() {
     // au survol de la carte
     // - on affiche les coordonnées en bas au milieu
-    this.map.on("mousemove", (event: any) => {
+    this.map.on('mousemove', (event: any) => {
       // 6 decimales
       const lat = Math.round(event.latlng.lat * 1e6) / 1e6;
       const lng = Math.round(event.latlng.lng * 1e6) / 1e6;
@@ -201,25 +201,23 @@ export class MapComponent implements OnInit {
 
     // quand le pointeur de la soouris quitte la carte
     // - on affiche plus les coordonnées
-    this.map.on("mouseout", () => {
+    this.map.on('mouseout', () => {
       this.coordinatesTxt = '';
     });
 
     // sur un clik droit
     // - on copie les coordonées dans le presse papier
-    this.map.on('contextmenu',  (event: any) => {
+    this.map.on('contextmenu', (event: any) => {
       // 6 decimales
       const lat = Math.round(event.latlng.lat * 1e6) / 1e6;
       const lng = Math.round(event.latlng.lng * 1e6) / 1e6;
       this.coordinatesTxt = `${lat}, ${lng}`;
-      navigator.clipboard.writeText(
-        this.coordinatesTxt
-      )
+      navigator.clipboard.writeText(this.coordinatesTxt);
       this._commonService.regularToaster(
         'success',
         `Le point\n(lon: ${lng}, lat: ${lat})\na été copié dans le presse papier`
       );
-    })
+    });
   }
 
   /** Retrocompatibility hack to format map config to the expected format:

--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -75,6 +75,8 @@ export class MapComponent implements OnInit {
   public searchFailed = false;
   public locationControl = new FormControl();
   public map: Map;
+  public coordinatesTxt: string; /** Texte pour l'affichage des coordonnées */
+
   constructor(
     private mapService: MapService,
     private _commonService: CommonService,
@@ -177,9 +179,47 @@ export class MapComponent implements OnInit {
       }
     });
 
+    if (AppConfig.MAPCONFIG.DISPLAY_MOUSE_COORDINATES) {
+      this.initDisplayCoordinates()
+    }
+
     setTimeout(() => {
       this.map.invalidateSize();
     }, 50);
+  }
+
+  /** Initialise l'affichage des coordonées au survol de la carte */
+  initDisplayCoordinates() {
+    // au survol de la carte
+    // - on affiche les coordonnées en bas au milieu
+    this.map.on("mousemove", (event: any) => {
+      // 6 decimales
+      const lat = Math.round(event.latlng.lat * 1e6) / 1e6;
+      const lng = Math.round(event.latlng.lng * 1e6) / 1e6;
+      this.coordinatesTxt = `${lat}, ${lng}`;
+    });
+
+    // quand le pointeur de la soouris quitte la carte
+    // - on affiche plus les coordonnées
+    this.map.on("mouseout", () => {
+      this.coordinatesTxt = '';
+    });
+
+    // sur un clik droit
+    // - on copie les coordonées dans le presse papier
+    this.map.on('contextmenu',  (event: any) => {
+      // 6 decimales
+      const lat = Math.round(event.latlng.lat * 1e6) / 1e6;
+      const lng = Math.round(event.latlng.lng * 1e6) / 1e6;
+      this.coordinatesTxt = `${lat}, ${lng}`;
+      navigator.clipboard.writeText(
+        this.coordinatesTxt
+      )
+      this._commonService.regularToaster(
+        'success',
+        `Le point\n(lon: ${lng}, lat: ${lat})\na été copié dans le presse papier`
+      );
+    })
   }
 
   /** Retrocompatibility hack to format map config to the expected format:


### PR DESCRIPTION
Pour pouvoir 
- afficher les coordonnées du point de la carte survolé par le pointer de la souris
- copier ces coordonées dans le presse papier avec un click droit