### PR TITLE
load module config in main config

### DIFF
--- a/backend/geonature/core/command/create_gn_module.py
+++ b/backend/geonature/core/command/create_gn_module.py
@@ -125,7 +125,7 @@ def install_packaged_gn_module(module_path, module_code, skip_frontend):
         os.symlink(os.path.abspath(module_path), module_symlink)
 
     # creation du fichier conf_gn_module.toml
-    module_config_path = get_module_config_path(module_object)
+    module_config_path = get_module_config_path(module_object.module_code)
     module_config_path.touch(exist_ok=True)
 
     ### Frontend

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -417,16 +417,3 @@ class GnGeneralSchemaConf(Schema):
                 "Si AUTO_ACCOUNT_CREATION = False, veuillez remplir le paramètre VALIDATOR_EMAIL",
                 "AUTO_ACCOUNT_CREATION, VALIDATOR_EMAIL",
             )
-
-
-class ManifestSchemaConf(Schema):
-    package_format_version = fields.String(required=True)
-    module_code = fields.String(required=True)
-    module_version = fields.String(required=True)
-    min_geonature_version = fields.String(required=True)
-    max_geonature_version = fields.String(required=True)
-    exclude_geonature_versions = fields.List(fields.String)
-
-
-class ManifestSchemaProdConf(Schema):
-    module_code = fields.String(required=True)

--- a/backend/geonature/utils/gn_module_import.py
+++ b/backend/geonature/utils/gn_module_import.py
@@ -31,7 +31,7 @@ from geonature.utils.env import (
     DB,
     import_requirements,
 )
-from geonature.utils.config_schema import ManifestSchemaConf
+from geonature.utils.schemas import ManifestSchemaConf
 
 log = logging.getLogger(__name__)
 

--- a/backend/geonature/utils/module.py
+++ b/backend/geonature/utils/module.py
@@ -5,7 +5,7 @@ from importlib import import_module
 from pkg_resources import load_entry_point, get_entry_info, iter_entry_points
 
 from geonature.utils.utilstoml import load_and_validate_toml
-from geonature.utils.config_schema import ManifestSchemaProdConf
+from geonature.utils.schemas import ManifestSchemaProdConf
 from geonature.utils.env import GN_EXTERNAL_MODULE
 from geonature.core.gn_commons.models import TModules
 

--- a/backend/geonature/utils/module.py
+++ b/backend/geonature/utils/module.py
@@ -14,14 +14,12 @@ class NoManifestFound(Exception):
     pass
 
 
-def get_module_config_path(module_object):
-    config_path = os.environ.get(f"GEONATURE_{module_object.module_code}_CONFIG_FILE")
+def get_module_config_path(module_code):
+    config_path = os.environ.get(f"GEONATURE_{module_code.lower()}_CONFIG_FILE")
     if config_path:  # fallback to legacy conf path guessing
         config_path = Path(config_path)
     else:
-        config_path = (
-            GN_EXTERNAL_MODULE / module_object.module_path / "config" / "conf_gn_module.toml"
-        )
+        config_path = GN_EXTERNAL_MODULE / module_code.lower() / "config" / "conf_gn_module.toml"
     return config_path
 
 
@@ -73,7 +71,7 @@ def import_packaged_module(module_dist, module_object):
     except ImportError:
         pass
     else:
-        config_path = get_module_config_path(module_object)
+        config_path = get_module_config_path(module_object.module_code)
         module_config.update(load_and_validate_toml(str(config_path), module_schema))
 
     blueprint_entry_point = get_entry_info(module_dist, "gn_module", "blueprint")

--- a/backend/geonature/utils/schemas.py
+++ b/backend/geonature/utils/schemas.py
@@ -1,0 +1,14 @@
+from marshmallow import Schema, fields
+
+
+class ManifestSchemaConf(Schema):
+    package_format_version = fields.String(required=True)
+    module_code = fields.String(required=True)
+    module_version = fields.String(required=True)
+    min_geonature_version = fields.String(required=True)
+    max_geonature_version = fields.String(required=True)
+    exclude_geonature_versions = fields.List(fields.String)
+
+
+class ManifestSchemaProdConf(Schema):
+    module_code = fields.String(required=True)


### PR DESCRIPTION
Add all module config in the `utils.config.config` variable. 
Module config can now be use without the app_context anywhere in the app