### PR TITLE
Filtrer les métadonnées par zonage

### DIFF
--- a/backend/geonature/core/gn_meta/models.py
+++ b/backend/geonature/core/gn_meta/models.py
@@ -573,7 +573,7 @@ class TAcquisitionFrameworkQuery(BaseQuery):
     def filter_by_params(self, params={}):
         # XXX frontend retro-compatibility
         selector = params.get("selector")
-        areas = params.pop("area") if "area" in params else None
+        areas = params.pop("area", None)
         if selector == "ds":
             params = {f"datasets.{key}": value for key, value in params.items()}
         f = TAcquisitionFramework.compute_filter(**params)

--- a/backend/geonature/core/gn_meta/models.py
+++ b/backend/geonature/core/gn_meta/models.py
@@ -334,17 +334,13 @@ class TDatasetsQuery(BaseQuery):
             scope = create_scope
         return query.filter_by_scope(scope)
 
-    def filter_by_area(self, areas):
+    def filter_by_areas(self, areas):
         from geonature.core.gn_synthese.models import Synthese
 
         areaFilter = []
         for type_area, id_area in areas:
             areaFilter.append(sa.and_(LAreas.id_type == type_area, LAreas.id_area == id_area))
-        return self.filter(
-            TAcquisitionFramework.t_datasets.any(
-                TDatasets.synthese_records.any(Synthese.areas.any(sa.or_(*areaFilter)))
-            )
-        )
+        return self.filter(TDatasets.synthese_records.any(Synthese.areas.any(sa.or_(*areaFilter))))
 
 
 @serializable(exclude=["user_actors", "organism_actors"])

--- a/backend/geonature/core/gn_meta/models.py
+++ b/backend/geonature/core/gn_meta/models.py
@@ -26,6 +26,8 @@ from utils_flask_sqla.serializers import serializable
 from geonature.utils.env import DB, db
 from geonature.core.gn_commons.models import cor_field_dataset, cor_module_dataset
 
+from ref_geo.models import LAreas
+
 
 class FilterMixin:
     @classmethod
@@ -556,13 +558,29 @@ class TAcquisitionFrameworkQuery(BaseQuery):
         """
         return self.filter_by_scope(self._get_read_scope())
 
+    def filter_by_areas(self, areas):
+        from geonature.core.gn_synthese.models import Synthese
+
+        areaFilter = []
+        for type_area, id_area in areas:
+            areaFilter.append(sa.and_(LAreas.id_type == type_area, LAreas.id_area == id_area))
+        return self.filter(
+            TAcquisitionFramework.t_datasets.any(
+                TDatasets.synthese_records.any(Synthese.areas.any(sa.or_(*areaFilter)))
+            )
+        )
+
     def filter_by_params(self, params={}):
         # XXX frontend retro-compatibility
         selector = params.get("selector")
+        areas = params.pop("area") if "area" in params else None
         if selector == "ds":
             params = {f"datasets.{key}": value for key, value in params.items()}
         f = TAcquisitionFramework.compute_filter(**params)
-        return self.filter(f)
+        qs = self.filter(f)
+        if areas and areas is not None:
+            qs = qs.filter_by_areas(areas)
+        return qs
 
 
 @serializable(exclude=["user_actors", "organism_actors"])

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -7,6 +7,7 @@ import pytest
 from flask import url_for
 from flask_sqlalchemy import BaseQuery
 from geoalchemy2.shape import to_shape
+
 from geojson import Point
 from sqlalchemy import func
 from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound, Unauthorized
@@ -14,14 +15,18 @@ from werkzeug.datastructures import MultiDict
 from ref_geo.models import BibAreasTypes, LAreas
 
 from geonature.core.gn_commons.models import TModules
-from geonature.core.gn_meta.models import CorDatasetActor, TAcquisitionFramework, TDatasets
+from geonature.core.gn_meta.models import (
+    CorDatasetActor,
+    TAcquisitionFramework,
+    TDatasets,
+)
 from geonature.core.gn_meta.routes import get_af_from_id
 from geonature.core.gn_permissions.models import (
     CorRoleActionFilterModuleObject,
     TActions,
     TFilters,
 )
-from geonature.core.gn_synthese.models import Synthese
+from geonature.core.gn_synthese.models import Synthese, CorAreaSynthese
 from geonature.utils.env import db
 
 from .fixtures import *
@@ -32,6 +37,18 @@ from .utils import logged_user_headers, set_logged_user_cookie
 def first_area_commune():
     commune = BibAreasTypes.query.filter_by(type_code="COM").one()
     return LAreas.query.filter(LAreas.id_type == commune.id_type).first()
+
+
+def getCommByIdSynthese(id_synthese):
+    """
+    Return area by synthese
+    """
+    areasSynthese = CorAreaSynthese.query.filter(CorAreaSynthese.id_synthese == id_synthese).all()
+    idsAreas = [d.id_area for d in areasSynthese]
+    commune = BibAreasTypes.query.filter_by(type_code="COM").one()
+    communes = LAreas.query.filter(LAreas.id_type == commune.id_type)
+    communeMatch = communes.filter(LAreas.id_area.in_(idsAreas)).one_or_none()
+    return communeMatch
 
 
 # TODO: maybe move it to global fixture
@@ -153,7 +170,10 @@ class TestGNMeta:
         # Post with only required attributes
         response = self.client.post(
             url_for("gn_meta.create_acquisition_framework"),
-            json={"acquisition_framework_name": "test", "acquisition_framework_desc": "desc"},
+            json={
+                "acquisition_framework_name": "test",
+                "acquisition_framework_desc": "desc",
+            },
         )
 
         assert response.status_code == 200
@@ -275,7 +295,53 @@ class TestGNMeta:
         response = self.client.get(url_for("gn_meta.get_acquisition_frameworks_list"))
         assert response.status_code == 200
 
-    def test_get_acquisition_frameworks_list_excluded_fields(self, users, acquisition_frameworks):
+    def test_filter_acquisition_by_geo(self, synthese_data, users, first_area_commune, datasets):
+        # security test already passed in previous tests
+        set_logged_user_cookie(self.client, users["admin_user"])
+
+        # will test if synthese CA is correctly return by a commune
+        entityDataset = synthese_data[0].dataset
+
+        # get commune from CoreArea Table or intersection
+        communeBySynthese = getCommByIdSynthese(synthese_data[0].id_synthese)
+        # return commune
+        response = self.client.post(
+            url_for("gn_meta.get_acquisition_frameworks"),
+            json={"area": [[communeBySynthese.id_type, communeBySynthese.id_area]]},
+        )
+        response = response.json[0]
+        # test id_acquisition framework return the correct synthese's parent id_acquisition_framework
+        assert response["id_acquisition_framework"] == entityDataset.id_acquisition_framework
+
+        # test no response if a commune have no CA
+        # get area without synthese
+        corAreaEmpty = [d.id_area for d in CorAreaSynthese.query.all()]
+        areaWithoutSynthese = LAreas.query.filter(~LAreas.id_area.in_(corAreaEmpty)).first()
+        # get CA
+        response = self.client.post(
+            url_for("gn_meta.get_acquisition_frameworks"),
+            json={"area": [[areaWithoutSynthese.id_type, areaWithoutSynthese.id_area]]},
+        )
+        resp = response.json
+        # will return empty response
+        assert len(resp) == 0
+
+        # will test if an other CA is correctly return for an other synthese and commune
+        # get synthese
+        firstSynthese = Synthese.query.filter(
+            Synthese.id_dataset != entityDataset.id_dataset
+        ).first()
+        # get commune for this id synthese
+        otherComm = getCommByIdSynthese(firstSynthese.id_synthese)
+        response = self.client.post(
+            url_for("gn_meta.get_acquisition_frameworks"),
+            json={"area": [[otherComm.id_type, otherComm.id_area]]},
+        )
+        assert len(response.json) > 0
+        response = response.json[0]
+        assert response["id_acquisition_framework"] != entityDataset.id_acquisition_framework
+
+    def test_get_acquisition_frameworks_list_excluded_fields(self, users):
         excluded = ["id_acquisition_framework", "id_digitizer"]
         set_logged_user_cookie(self.client, users["admin_user"])
 
@@ -287,9 +353,7 @@ class TestGNMeta:
         for field in excluded:
             assert all(field not in list(dic.keys()) for dic in response.json)
 
-    def test_get_acquisition_frameworks_list_excluded_fields_not_nested(
-        self, users, acquisition_frameworks
-    ):
+    def test_get_acquisition_frameworks_list_excluded_fields_not_nested(self, users):
         excluded = ["id_acquisition_framework", "id_digitizer"]
 
         set_logged_user_cookie(self.client, users["admin_user"])
@@ -324,7 +388,8 @@ class TestGNMeta:
 
         response = self.client.get(
             url_for(
-                "gn_meta.get_export_pdf_acquisition_frameworks", id_acquisition_framework=af_id
+                "gn_meta.get_export_pdf_acquisition_frameworks",
+                id_acquisition_framework=af_id,
             )
         )
 
@@ -335,7 +400,8 @@ class TestGNMeta:
 
         response = self.client.get(
             url_for(
-                "gn_meta.get_export_pdf_acquisition_frameworks", id_acquisition_framework=af_id
+                "gn_meta.get_export_pdf_acquisition_frameworks",
+                id_acquisition_framework=af_id,
             )
         )
 
@@ -348,7 +414,10 @@ class TestGNMeta:
         set_logged_user_cookie(self.client, users["user"])
 
         response = self.client.get(
-            url_for("gn_meta.get_acquisition_framework_stats", id_acquisition_framework=id_af)
+            url_for(
+                "gn_meta.get_acquisition_framework_stats",
+                id_acquisition_framework=id_af,
+            )
         )
         data = response.json
 
@@ -763,14 +832,20 @@ class TestGNMeta:
 
         af = acquisition_frameworks["own_af"]
         response = self.client.get(
-            url_for("gn_meta.publish_acquisition_framework", af_id=af.id_acquisition_framework)
+            url_for(
+                "gn_meta.publish_acquisition_framework",
+                af_id=af.id_acquisition_framework,
+            )
         )
         assert response.status_code == Conflict.code, response.json
         mocked_publish_mail.assert_not_called()
 
         af = acquisition_frameworks["orphan_af"]
         response = self.client.get(
-            url_for("gn_meta.publish_acquisition_framework", af_id=af.id_acquisition_framework)
+            url_for(
+                "gn_meta.publish_acquisition_framework",
+                af_id=af.id_acquisition_framework,
+            )
         )
         assert response.status_code == Conflict.code, response.json
         mocked_publish_mail.assert_not_called()
@@ -781,7 +856,10 @@ class TestGNMeta:
         set_logged_user_cookie(self.client, users["user"])
         af = acquisition_frameworks["orphan_af"]
         response = self.client.get(
-            url_for("gn_meta.publish_acquisition_framework", af_id=af.id_acquisition_framework)
+            url_for(
+                "gn_meta.publish_acquisition_framework",
+                af_id=af.id_acquisition_framework,
+            )
         )
         assert response.status_code == 200, response.json
         mocked_publish_mail.assert_called_once()

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -295,7 +295,7 @@ class TestGNMeta:
         response = self.client.get(url_for("gn_meta.get_acquisition_frameworks_list"))
         assert response.status_code == 200
 
-    def test_filter_acquisition_by_geo(self, synthese_data, users, first_area_commune, datasets):
+    def test_filter_acquisition_by_geo(self, synthese_data, users, isolate_synthese):
         # security test already passed in previous tests
         set_logged_user_cookie(self.client, users["admin_user"])
 
@@ -326,13 +326,9 @@ class TestGNMeta:
         # will return empty response
         assert len(resp) == 0
 
-        # will test if an other CA is correctly return for an other synthese and commune
-        # get synthese
-        firstSynthese = Synthese.query.filter(
-            Synthese.id_dataset != entityDataset.id_dataset
-        ).first()
+        # will test if an other CA is correctly return for an other synthese with diff location
         # get commune for this id synthese
-        otherComm = getCommByIdSynthese(firstSynthese.id_synthese)
+        otherComm = getCommByIdSynthese(isolate_synthese.id_synthese)
         response = self.client.post(
             url_for("gn_meta.get_acquisition_frameworks"),
             json={"area": [[otherComm.id_type, otherComm.id_area]]},

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -223,6 +223,32 @@ class TestGNMeta:
         )
         assert response.status_code == 200
 
+    def test_get_post_acquisition_frameworks(self, users):
+        response = self.client.get(url_for("gn_meta.get_acquisition_frameworks"))
+        assert response.status_code == Unauthorized.code
+
+        set_logged_user_cookie(self.client, users["admin_user"])
+        # POST EMPTY REQUEST FAIL
+        response = self.client.post(url_for("gn_meta.get_acquisition_frameworks"))
+        assert response.status_code == 400
+        # POST REQUEST WITHOUT JSON
+        response = self.client.post(
+            url_for("gn_meta.get_acquisition_frameworks"),
+            query_string={
+                "datasets": "1",
+                "creator": "1",
+                "actors": "1",
+            },
+            json={},
+        )
+        assert response.status_code == 200
+        # POST REQUEST WITHOUT JSON AND WITHOUT QUERY STRING
+        response = self.client.post(
+            url_for("gn_meta.get_acquisition_frameworks"),
+            json={},
+        )
+        assert response.status_code == 200
+
     def test_get_acquisition_frameworks_list(self, users):
         response = self.client.get(url_for("gn_meta.get_acquisition_frameworks_list"))
         assert response.status_code == Unauthorized.code

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -231,7 +231,7 @@ class TestGNMeta:
         assert response.status_code == 200
 
     def test_get_post_acquisition_frameworks(self, users, first_area_commune):
-        # SIMPLE TEST WITH GET REQUEST
+        # SIMPLE TEST WITH POST REQUEST
         response = self.client.post(
             url_for("gn_meta.get_acquisition_frameworks"),
             json={},
@@ -241,7 +241,7 @@ class TestGNMeta:
         set_logged_user_cookie(self.client, users["admin_user"])
         # POST EMPTY REQUEST FAIL WITHOUT ANY PARAMS
         response = self.client.post(url_for("gn_meta.get_acquisition_frameworks"))
-        assert response.status_code == 400
+        assert response.status_code == BadRequest.code
         # POST REQUEST WITHOUT JSON AND WITHOUT QUERY STRING
         response = self.client.post(
             url_for("gn_meta.get_acquisition_frameworks"),

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -168,7 +168,12 @@ class MetadataConfig(Schema):
     CD_NOMENCLATURE_ROLE_TYPE_DS = fields.List(fields.Str(), load_default=[])
     CD_NOMENCLATURE_ROLE_TYPE_AF = fields.List(fields.Str(), load_default=[])
     METADATA_AREA_FILTERS = fields.List(
-        fields.Dict, load_default=[{"label": "Communes", "type_code": "COM"}]
+        fields.Dict,
+        load_default=[
+            {"label": "Communes", "type_code": "COM"},
+            {"label": "Départements", "type_code": "DEP"},
+            {"label": "Régions", "type_code": "REG"},
+        ],
     )
 
 

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -167,6 +167,9 @@ class MetadataConfig(Schema):
     )
     CD_NOMENCLATURE_ROLE_TYPE_DS = fields.List(fields.Str(), load_default=[])
     CD_NOMENCLATURE_ROLE_TYPE_AF = fields.List(fields.Str(), load_default=[])
+    METADATA_AREA_FILTERS = fields.List(
+        fields.Dict, load_default=[{"label": "Communes", "type_code": "COM"}]
+    )
 
 
 # class a utiliser pour les paramètres que l'on ne veut pas passer au frontend

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -253,7 +253,7 @@ MAIL_ON_ERROR = false
     # les données déjà présentes dans la synthèse soient associées à
     # ces nouvelles géométries.
     AREA_FILTERS = [
-        { label = "Communes", "type_code": "COM" }
+        { "label" = "Communes", "type_code" = "COM" }
     ]
 
     # Colonne à afficher par défaut sur la liste des résultats de la synthese
@@ -536,3 +536,6 @@ MAIL_ON_ERROR = false
     # liste des types de role à afficher sur les formulaires JDD et CA
     CD_NOMENCLATURE_ROLE_TYPE_DS = ["2"]
     CD_NOMENCLATURE_ROLE_TYPE_AF = ["3"]
+    METADATA_AREA_FILTERS = [
+        { "label" = "Communes", "type_code"= "COM" }
+    ]

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -536,6 +536,9 @@ MAIL_ON_ERROR = false
     # liste des types de role à afficher sur les formulaires JDD et CA
     CD_NOMENCLATURE_ROLE_TYPE_DS = ["2"]
     CD_NOMENCLATURE_ROLE_TYPE_AF = ["3"]
+    # Liste des types de zonage filtrables dans les métadonnées
     METADATA_AREA_FILTERS = [
-        { "label" = "Communes", "type_code"= "COM" }
+        { "label" = "Communes", "type_code"= "COM" },
+        { "label" = "Départements", "type_code"= "DEP" },
+        { "label" = "Régions", "type_code"= "REG" }
     ]

--- a/frontend/src/app/GN2CommonModule/form/areas/areas.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/areas/areas.component.ts
@@ -60,6 +60,8 @@ export class AreasComponent extends GenericFormComponent implements OnInit {
    * tableau d'objets comprenant le champ identifiant et le champ pour
    * l'affichage (`area_name`), vous pouvez l'indiquer en passant une
    * valeur `null` à cet attribut.
+   * Exemple :
+   * [valueFieldName]="'id_type'"
    */
   @Input() valueFieldName: string = 'id_area';
   /**
@@ -96,9 +98,6 @@ export class AreasComponent extends GenericFormComponent implements OnInit {
   }
 
   ngOnInit() {
-    // Patch to force 'id_area' as default value for valueFieldName
-    // when this attribute is defined in HTML but with an undefined value
-    // TODO : try to resolve this problem in DynamicForm with conditional attribute maybe
     this.valueFieldName = this.valueFieldName === undefined ? 'id_area' : this.valueFieldName;
 
     this.getAreas();

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -331,6 +331,16 @@ export class DataFormService {
     return this._http.get<any>(`${AppConfig.API_ENDPOINT}/geo/areas`, { params: params });
   }
 
+  getAreasTypes() {
+    return this._http.get<any>(`${AppConfig.API_ENDPOINT}/geo/types`);
+  }
+
+  autocompleteRefGeo(area_name, id_type) {
+    return this._http.get<any>(
+      `${AppConfig.API_ENDPOINT}/geo/areas?area_name=${area_name}&id_type=${id_type}`
+    );
+  }
+
   getValidationHistory(uuid_attached_row) {
     return this._http.get<any>(
       `${AppConfig.API_ENDPOINT}/gn_commons/history/${uuid_attached_row}`,
@@ -354,14 +364,10 @@ export class DataFormService {
   }
 
   getAcquisitionFrameworksList(searchTerms = {}) {
-    let queryString: HttpParams = new HttpParams();
-    for (let key in searchTerms) {
-      queryString = queryString.set(key, searchTerms[key]);
-    }
-
-    return this._http.get<any>(`${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks`, {
-      params: queryString,
-    });
+    return this._http.post<any>(
+      `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks`,
+      searchTerms
+    );
   }
 
   /**

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -335,10 +335,15 @@ export class DataFormService {
     return this._http.get<any>(`${AppConfig.API_ENDPOINT}/geo/types`);
   }
 
-  autocompleteRefGeo(area_name, type_code) {
-    return this._http.get<any>(
-      `${AppConfig.API_ENDPOINT}/geo/areas?area_name=${area_name}&type_code=${type_code}`
-    );
+  autocompleteRefGeo(params) {
+    let queryString: HttpParams = new HttpParams();
+    for (let key in params) {
+      queryString = queryString.set(key, params[key]);
+    }
+
+    return this._http.get<any>(`${AppConfig.API_ENDPOINT}/geo/areas`, {
+      params: queryString,
+    });
   }
 
   getValidationHistory(uuid_attached_row) {
@@ -363,14 +368,15 @@ export class DataFormService {
     });
   }
 
-  getAcquisitionFrameworksList(searchTerms = {}) {
-    let urlGetParams = Object.keys(searchTerms).map((k) =>
-      searchTerms[k] ? `${k}=${searchTerms[k] || null}` : ''
-    );
-    return this._http.post<any>(
-      `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks?${urlGetParams.join('&')}`,
-      searchTerms
-    );
+  getAcquisitionFrameworksList(selectors = {}, params = {}) {
+    let queryString: HttpParams = new HttpParams();
+    for (let key in selectors) {
+      queryString = queryString.set(key, selectors[key]);
+    }
+
+    return this._http.post<any>(`${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks`, params, {
+      params: queryString,
+    });
   }
 
   /**

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -335,9 +335,9 @@ export class DataFormService {
     return this._http.get<any>(`${AppConfig.API_ENDPOINT}/geo/types`);
   }
 
-  autocompleteRefGeo(area_name, id_type) {
+  autocompleteRefGeo(area_name, type_code) {
     return this._http.get<any>(
-      `${AppConfig.API_ENDPOINT}/geo/areas?area_name=${area_name}&id_type=${id_type}`
+      `${AppConfig.API_ENDPOINT}/geo/areas?area_name=${area_name}&type_code=${type_code}`
     );
   }
 
@@ -364,8 +364,11 @@ export class DataFormService {
   }
 
   getAcquisitionFrameworksList(searchTerms = {}) {
+    let urlGetParams = Object.keys(searchTerms).map((k) =>
+      searchTerms[k] ? `${k}=${searchTerms[k] || null}` : ''
+    );
     return this._http.post<any>(
-      `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks`,
+      `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks?${urlGetParams.join('&')}`,
       searchTerms
     );
   }

--- a/frontend/src/app/metadataModule/metadata.component.html
+++ b/frontend/src/app/metadataModule/metadata.component.html
@@ -1,4 +1,7 @@
-<div class="container-fluid" data-qa="pnx-metadata">
+<div
+  class="container-fluid"
+  data-qa="pnx-metadata"
+>
   <div class="card card-page">
     <div class="card-header">
       <h3 class="main-color">Catalogue des jeux de données</h3>
@@ -39,7 +42,11 @@
           >
         </div>
         <div class="col-sm-3">
-          <button mat-raised-button color="primary" (click)="openSearchModal(searchModal)">
+          <button
+            mat-raised-button
+            color="primary"
+            (click)="openSearchModal(searchModal)"
+          >
             Recherche avancée
           </button>
           <button
@@ -58,22 +65,27 @@
       <div>Liste des cadres d'acquisition et des jeux de données associés</div>
       <br />
 
-      <ng-container
-        *ngIf="(acquisitionFrameworks | async)?.length || isLoading; else noAcquisitionFrameworks"
-      >
+      <ng-container *ngIf="(acquisitionFrameworks | async)?.length || isLoading; else noAcquisitionFrameworks">
         <mat-accordion [multi]="true">
-          <div class="tab-title" *ngIf="!isLoading">
+          <div
+            class="tab-title"
+            *ngIf="!isLoading"
+          >
             <div class="col-md-1">ID</div>
             <div class="col-md-2">Nom</div>
             <div class="col-md-2">Date de création</div>
             <div class="col-md-5">Acteurs</div>
             <div class="col-md-1">Actions</div>
           </div>
-          <mat-spinner *ngIf="isLoading" diameter="50" strokeWidth="2" style="margin: 0 auto">
+          <mat-spinner
+            *ngIf="isLoading"
+            diameter="50"
+            strokeWidth="2"
+            style="margin: 0 auto"
+          >
           </mat-spinner>
 
-          <ng-container *ngFor="let af of (acquisitionFrameworks | async); let idx = index"
-          >
+          <ng-container *ngFor="let af of (acquisitionFrameworks | async); let idx = index">
             <mat-expansion-panel
               [expanded]="expandAccordions"
               [attr.data-qa]='"pnx-metadata-acq-framework"'
@@ -90,7 +102,10 @@
 
                   <div class="col-md-1">{{ af.id_acquisition_framework }}</div>
                   <div class="col-md-2">
-                    <a [routerLink]="['/metadata/af_detail', af.id_acquisition_framework]" [attr.data-qa]='"pnx-metadata-acq-framework-"+af.unique_acquisition_framework_id'>
+                    <a
+                      [routerLink]="['/metadata/af_detail', af.id_acquisition_framework]"
+                      [attr.data-qa]='"pnx-metadata-acq-framework-"+af.unique_acquisition_framework_id'
+                    >
                       {{ af.acquisition_framework_name }}
                       <br />
                       <small style="color: gray"> {{ af.unique_acquisition_framework_id }} </small>
@@ -209,11 +224,21 @@
   </div>
 </div>
 
-<ng-template #searchModal let-c="close" let-d="dismiss">
+<ng-template
+  #searchModal
+  let-c="close"
+  let-d="dismiss"
+>
   <div class="modal-header">
-    <h5 class="modal-title" id="exampleModalLabel">Rechercher</h5>
+    <h5
+      class="modal-title"
+      id="exampleModalLabel"
+    >Rechercher</h5>
   </div>
-  <div class="modal-body" style="align-items: flex-end">
+  <div
+    class="modal-body"
+    style="align-items: flex-end"
+  >
     <label> Rechercher sur:</label>
     <select
       [formControl]="metadataService.form.get('selector')"
@@ -232,7 +257,10 @@
     />
     <label>Nom</label>
 
-    <input [formControl]="metadataService.form.get('name')" class="form-control form-control-sm" />
+    <input
+      [formControl]="metadataService.form.get('name')"
+      class="form-control form-control-sm"
+    />
 
     <pnx-date
       [parentFormControl]="metadataService.form.get('date')"
@@ -240,20 +268,50 @@
     ></pnx-date>
     <label>Acteur (organisme)</label>
 
-    <select [formControl]="metadataService.form.get('organism')" class="form-control form-control">
-      <option value="" selected>--</option>
-      <option *ngFor="let org of organisms" value="{{ org.id_organisme }}">
+    <select
+      [formControl]="metadataService.form.get('organism')"
+      class="form-control form-control"
+    >
+      <option
+        value=""
+        selected
+      >--</option>
+      <option
+        *ngFor="let org of organisms"
+        value="{{ org.id_organisme }}"
+      >
         {{ org.nom_organisme }}
       </option>
     </select>
     <label> Acteur (personne)</label>
 
-    <select class="form-control form-control" [formControl]="metadataService.form.get('person')">
-      <option value="" selected>--</option>
-      <option *ngFor="let role of roles" value="{{ role.id_role }}">
+    <select
+      class="form-control form-control"
+      [formControl]="metadataService.form.get('person')"
+    >
+      <option
+        value=""
+        selected
+      >--</option>
+      <option
+        *ngFor="let role of roles"
+        value="{{ role.id_role }}"
+      >
         {{ role?.nom_complet }}
       </option>
     </select>
+
+    <div *ngIf="displayMetaAreaFilters() && metadataService.formBuilded">
+      <div *ngFor="let area of areaFilters; let i = index">
+        <pnx-areas
+          [parentFormControl]="area.control"
+          [label]="area.label"
+          [typeCodes]="area.type_code_array"
+          [valueFieldName]="null"
+        >
+        </pnx-areas>
+      </div>
+    </div>
 
     <div class="mt-2">
       <button
@@ -263,17 +321,32 @@
       >
         Rechercher
       </button>
-      <button mat-raised-button color="warn" class="uppercase" (click)="c()">Fermer</button>
+      <button
+        mat-raised-button
+        color="warn"
+        class="uppercase"
+        (click)="c()"
+      >Fermer</button>
     </div>
   </div>
 </ng-template>
 
-<ng-template #publishModal let-c="close" let-d="dismiss">
+<ng-template
+  #publishModal
+  let-c="close"
+  let-d="dismiss"
+>
   <div class="modal-header">
-    <h5 class="modal-title" id="publishModalLabel">{{ afPublishModalLabel }}</h5>
+    <h5
+      class="modal-title"
+      id="publishModalLabel"
+    >{{ afPublishModalLabel }}</h5>
   </div>
 
-  <div class="modal-body" style="align-items: flex-end">
+  <div
+    class="modal-body"
+    style="align-items: flex-end"
+  >
     <div class="col">
       <span>
         <p style="text-align: justify">{{ afPublishModalContent }}</p>
@@ -283,9 +356,21 @@
 
   <div class="modal-footer">
     <div class="col"></div>
-    <div mat-dialog-actions align="end">
-      <button mat-raised-button cdkFocusInitial class="mr-1" (click)="c()">Annuler</button>
-      <button mat-raised-button color="primary" (click)="publishAf()">Confirmer</button>
+    <div
+      mat-dialog-actions
+      align="end"
+    >
+      <button
+        mat-raised-button
+        cdkFocusInitial
+        class="mr-1"
+        (click)="c()"
+      >Annuler</button>
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="publishAf()"
+      >Confirmer</button>
     </div>
     <br />
   </div>

--- a/frontend/src/app/metadataModule/metadata.component.scss
+++ b/frontend/src/app/metadataModule/metadata.component.scss
@@ -117,3 +117,8 @@ mat-expansion-panel {
 [data-qa="pnx-metadata-dataset-name-Mon jeu de données"] .delete-btn {
   background-color: black!important;
 }
+
+.metadata-area-value {
+  margin-top: 15px;
+  width: 100%;
+}

--- a/frontend/src/app/metadataModule/metadata.component.ts
+++ b/frontend/src/app/metadataModule/metadata.component.ts
@@ -31,8 +31,6 @@ export class MetadataComponent implements OnInit {
   public organisms: any[] = [];
   /* liste des roles issues de l'API pour le select. */
   public roles: any[] = [];
-  /* list des types de ref geo */
-  public typeAreas: any[] = [];
 
   public areaFilters: Array<any>;
 
@@ -62,8 +60,6 @@ export class MetadataComponent implements OnInit {
     this._dfs.getOrganisms().subscribe((organisms) => (this.organisms = organisms));
 
     this._dfs.getRoles({ group: false }).subscribe((roles) => (this.roles = roles));
-
-    this._dfs.getAreasTypes().subscribe((types) => (this.typeAreas = types));
 
     this.afPublishModalLabel = AppConfig.METADATA.CLOSED_MODAL_LABEL;
     this.afPublishModalContent = AppConfig.METADATA.CLOSED_MODAL_CONTENT;
@@ -127,7 +123,6 @@ export class MetadataComponent implements OnInit {
     });
     let finalFormValue = { ...omited, area: area.length ? area : null };
     this.metadataService.formatFormValue(Object.assign({}, formValues));
-    console.log(Object.assign({}, finalFormValue));
     this.metadataService.getMetadata(finalFormValue);
     this.metadataService.expandAccordions = true;
   }

--- a/frontend/src/app/metadataModule/services/metadata-search-form.service.ts
+++ b/frontend/src/app/metadataModule/services/metadata-search-form.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { FormGroup, FormBuilder, FormControl } from '@angular/forms';
 import { NgbDateParserFormatter } from '@ng-bootstrap/ng-bootstrap';
-
 @Injectable()
 export class MetadataSearchFormService {
   public form: FormGroup;
@@ -14,6 +13,7 @@ export class MetadataSearchFormService {
       date: null,
       organism: null,
       person: null,
+      codeTypeArea: null,
     });
     this.rapidSearchControl = new FormControl();
   }

--- a/frontend/src/app/metadataModule/services/metadata.service.ts
+++ b/frontend/src/app/metadataModule/services/metadata.service.ts
@@ -104,15 +104,22 @@ export class MetadataService {
   }
   //recuperation cadres d'acquisition
   getMetadata(params = {}) {
-    params['datasets'] = 1;
-    params['creator'] = 1;
-    params['actors'] = 1;
     this.isLoading = true;
     this._acquisitionFrameworks.next([]);
 
+    let selectors = {
+      datasets: 1,
+      creator: 1,
+      actors: 1,
+    };
+
+    delete params['datasets'];
+    delete params['creator'];
+    delete params['actors'];
+
     //forkJoin pour lancer les 2 requetes simultanément
     forkJoin({
-      afs: this.dataFormService.getAcquisitionFrameworksList(params),
+      afs: this.dataFormService.getAcquisitionFrameworksList(selectors, params),
       datasetNbObs: this._syntheseDataService.getObsCountByColumn('id_dataset'),
     })
       .pipe(

--- a/frontend/src/app/metadataModule/services/metadata.service.ts
+++ b/frontend/src/app/metadataModule/services/metadata.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { FormGroup, FormBuilder, FormControl } from '@angular/forms';
 import { NgbDateParserFormatter } from '@ng-bootstrap/ng-bootstrap';
-import { forkJoin, Observable, BehaviorSubject, combineLatest } from 'rxjs';
+import { forkJoin, Observable, BehaviorSubject, combineLatest, of } from 'rxjs';
 import {
   tap,
   map,
@@ -9,7 +9,7 @@ import {
   distinctUntilChanged,
   debounceTime,
   filter,
-  pairwise,
+  switchMap,
 } from 'rxjs/operators';
 import { PageEvent, MatPaginator } from '@angular/material/paginator';
 
@@ -31,9 +31,10 @@ export class MetadataService {
 
   /* resultat du filtre sur _acquisitionFrameworks */
   public filteredAcquisitionFrameworks: Observable<any[]>;
-
   public isLoading: boolean = false;
   public expandAccordions: boolean = false;
+
+  public formBuilded = false;
 
   pageSizeOptions: number[] = [10, 25, 50, 100];
   pageSize: BehaviorSubject<number> = new BehaviorSubject(AppConfig.METADATA.NB_AF_DISPLAYED);
@@ -93,10 +94,15 @@ export class MetadataService {
         tap((term) => (this.expandAccordions = term !== ''))
       )
       .subscribe(() => this.pageIndex.next(0));
+    AppConfig.METADATA.METADATA_AREA_FILTERS.forEach((area) => {
+      const control_name = 'area_' + area['type_code'].toLowerCase();
+      this.form.addControl(control_name, new FormControl(new Array()));
+      const control = this.form.controls[control_name];
+      area['control'] = control;
+    });
+    this.formBuilded = true;
   }
-
   //recuperation cadres d'acquisition
-
   getMetadata(params = {}) {
     params['datasets'] = 1;
     params['creator'] = 1;

--- a/frontend/src/app/syntheseModule/synthese.component.ts
+++ b/frontend/src/app/syntheseModule/synthese.component.ts
@@ -37,8 +37,6 @@ export class SyntheseComponent implements OnInit {
   ) {}
 
   loadAndStoreData(formParams) {
-    console.log(formParams);
-
     this.searchService.dataLoaded = false;
     this.searchService.getSyntheseData(formParams).subscribe(
       (data) => {
@@ -93,6 +91,7 @@ export class SyntheseComponent implements OnInit {
         initialFilter['id_dataset'] = params.get('id_dataset');
       } else {
         initialFilter['limit'] = AppConfig.SYNTHESE.NB_LAST_OBS;
+        initialFilter['limit'] = 6000;
       }
 
       // reinitialize the form

--- a/frontend/src/app/syntheseModule/synthese.component.ts
+++ b/frontend/src/app/syntheseModule/synthese.component.ts
@@ -91,7 +91,6 @@ export class SyntheseComponent implements OnInit {
         initialFilter['id_dataset'] = params.get('id_dataset');
       } else {
         initialFilter['limit'] = AppConfig.SYNTHESE.NB_LAST_OBS;
-        initialFilter['limit'] = 6000;
       }
 
       // reinitialize the form

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -15,6 +15,10 @@ mat-sidenav-content {
   background-color: $solitude;
 }
 
+.cdk-overlay-container {
+  z-index: 2000 !important; 
+}
+
 .purple {
   color: #673ab7;
 }


### PR DESCRIPTION
ref #1768 

> Cette PR a été commandité par le [MNHN](https://www.mnhn.fr/fr).

> Merci à @camillemonchicourt  @bouttier @TheoLechemia pour le support technique et la réactivité

## Description

Cette PR  permet de pouvoir filtrer les CA ou les JDD par zonage, notamment par région ou département.

Les développements avaient pour objectif que ce filtre supplémentaire fonctionne comme les autres : tous les JDD des CA retournés.

La PR pourra être mergée après la totale réalisation de ces tâches : 
- [x] développements (voir issue #1768 pour les détails)
- [x] Mise à jour de la branche avec develop (Rebase)
- [x] Respect du code style
- [ ] Revue technique et fonctionnelle
- [x] Cypress frontend test
- [x] Pytest backend test
- [x] Documentation => `default_config.toml.example`