### PR TITLE
move whole configuration process in config module

### DIFF
--- a/backend/geonature/app.py
+++ b/backend/geonature/app.py
@@ -5,7 +5,6 @@ Démarrage de l'application
 import logging, os
 from itertools import chain
 from pkg_resources import iter_entry_points, load_entry_point
-from urllib.parse import urlsplit
 from importlib import import_module
 
 from flask import Flask, g, request, current_app
@@ -78,16 +77,9 @@ def create_app(with_external_mods=True):
     app = Flask(__name__.split(".")[0], static_folder=static_folder)
 
     app.config.update(config)
-    api_uri = urlsplit(app.config["API_ENDPOINT"])
-    app.config["APPLICATION_ROOT"] = api_uri.path
-    app.config["PREFERRED_URL_SCHEME"] = api_uri.scheme
+
     if "SCRIPT_NAME" not in os.environ:
         os.environ["SCRIPT_NAME"] = app.config["APPLICATION_ROOT"].rstrip("/")
-    app.config["TEMPLATES_AUTO_RELOAD"] = True
-    # disable cache for downloaded files (PDF file stat for ex)
-    app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0
-    if "GEONATURE_SETTINGS" in os.environ:
-        app.config.from_object(os.environ["GEONATURE_SETTINGS"])
 
     # set from headers HTTP_HOST, SERVER_NAME, and SERVER_PORT
     app.wsgi_app = ProxyFix(app.wsgi_app, x_host=1)

--- a/backend/geonature/app.py
+++ b/backend/geonature/app.py
@@ -89,12 +89,6 @@ def create_app(with_external_mods=True):
     if "GEONATURE_SETTINGS" in os.environ:
         app.config.from_object(os.environ["GEONATURE_SETTINGS"])
 
-    if len(app.config["SECRET_KEY"]) < 20:
-        raise Exception(
-            "The SECRET_KEY config option must have a length "
-            "greater or equals to 20 characters."
-        )
-
     # set from headers HTTP_HOST, SERVER_NAME, and SERVER_PORT
     app.wsgi_app = ProxyFix(app.wsgi_app, x_host=1)
     app.wsgi_app = RequestID(app.wsgi_app)

--- a/backend/geonature/utils/config.py
+++ b/backend/geonature/utils/config.py
@@ -1,5 +1,9 @@
 import os
 from collections import ChainMap
+from urllib.parse import urlsplit
+
+from flask import Config
+from flask.helpers import get_root_path
 
 from geonature.utils.config_schema import (
     GnGeneralSchemaConf,
@@ -9,6 +13,24 @@ from geonature.utils.utilstoml import load_and_validate_toml
 from geonature.utils.env import CONFIG_FILE
 
 
-config_backend = load_and_validate_toml(CONFIG_FILE, GnPySchemaConf)
-config_frontend = load_and_validate_toml(CONFIG_FILE, GnGeneralSchemaConf)
-config = ChainMap({}, config_frontend, config_backend)
+config_programmatic = Config(get_root_path("geonature"))
+config_programmatic.from_prefixed_env(prefix="GEONATURE")
+if "GEONATURE_SETTINGS" in os.environ:
+    config_programmatic.from_object(os.environ["GEONATURE_SETTINGS"])
+partial = config_programmatic.keys()
+config_backend = load_and_validate_toml(CONFIG_FILE, GnPySchemaConf, partial=partial)
+config_frontend = load_and_validate_toml(CONFIG_FILE, GnGeneralSchemaConf, partial=partial)
+config_default = {
+    # disable cache for downloaded files (PDF file stat for ex)
+    # TODO: use Flask.get_send_file_max_age(filename) to return 0 only for generated PDF files
+    "SEND_FILE_MAX_AGE_DEFAULT": 0,
+    "TEMPLATES_AUTO_RELOAD": True,
+}
+
+config = ChainMap({}, config_programmatic, config_backend, config_frontend, config_default)
+
+api_uri = urlsplit(config["API_ENDPOINT"])
+if "APPLICATION_ROOT" not in config:
+    config["APPLICATION_ROOT"] = api_uri.path
+if "PREFERRED_URL_SCHEME" not in config:
+    config["PREFERRED_URL_SCHEME"] = api_uri.scheme

--- a/backend/geonature/utils/config.py
+++ b/backend/geonature/utils/config.py
@@ -24,7 +24,6 @@ config_default = {
     # disable cache for downloaded files (PDF file stat for ex)
     # TODO: use Flask.get_send_file_max_age(filename) to return 0 only for generated PDF files
     "SEND_FILE_MAX_AGE_DEFAULT": 0,
-    "TEMPLATES_AUTO_RELOAD": True,
 }
 
 config = ChainMap({}, config_programmatic, config_backend, config_frontend, config_default)

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -13,7 +13,7 @@ from marshmallow import (
     ValidationError,
     post_load,
 )
-from marshmallow.validate import OneOf, Regexp, Email
+from marshmallow.validate import OneOf, Regexp, Email, Length
 
 from geonature.core.gn_synthese.synthese_config import (
     DEFAULT_EXPORT_COLUMNS,
@@ -182,7 +182,7 @@ class GnPySchemaConf(Schema):
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = fields.Boolean(load_default=True)
     SESSION_TYPE = fields.String(load_default="filesystem")
-    SECRET_KEY = fields.String(required=True)
+    SECRET_KEY = fields.String(required=True, validate=Length(min=20))
     # le cookie expire toute les 7 jours par défaut
     COOKIE_EXPIRATION = fields.Integer(load_default=3600 * 24 * 7)
     COOKIE_AUTORENEW = fields.Boolean(load_default=True)

--- a/backend/geonature/utils/utilstoml.py
+++ b/backend/geonature/utils/utilstoml.py
@@ -7,7 +7,7 @@ from marshmallow.exceptions import ValidationError
 from geonature.utils.errors import ConfigError, GeoNatureError
 
 
-def load_and_validate_toml(toml_file, config_schema):
+def load_and_validate_toml(toml_file, config_schema, partial=None):
     """
     Fonction qui charge un fichier toml
      et le valide avec un Schema marshmallow
@@ -17,7 +17,7 @@ def load_and_validate_toml(toml_file, config_schema):
     else:
         toml_config = {}
     try:
-        configs_py = config_schema().load(toml_config, unknown=EXCLUDE)
+        configs_py = config_schema().load(toml_config, unknown=EXCLUDE, partial=partial)
     except ValidationError as e:
         raise ConfigError(toml_file, e.messages)
     return configs_py


### PR DESCRIPTION
This ensure app.config is identical to imported config object.
In addition, add support for GEONATURE prefixed env variables.
Finally, variables configured from env var or pyfile are not required in toml config file.