### PR TITLE
add UsersHub submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "backend/dependencies/RefGeo"]
 	path = backend/dependencies/RefGeo
 	url = https://github.com/PnX-SI/RefGeo.git
+[submodule "backend/dependencies/UsersHub"]
+	path = backend/dependencies/UsersHub
+	url = https://github.com/PnX-SI/UsersHub

--- a/backend/requirements-dependencies.in
+++ b/backend/requirements-dependencies.in
@@ -5,3 +5,4 @@ utils-flask-sqlalchemy-geo>=0.2.5,<1.0.0
 utils-flask-sqlalchemy>=0.3.0,<1.0.0
 taxhub>=1.10.4,<2.0.0
 pypn-ref-geo>=1.2.1,<2.0.0
+usershub>=2.3.2,<3.0.0

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -17,10 +17,13 @@
     #   -r requirements-submodules.in
     #   pypnnomenclature
     #   taxhub
+    #   usershub
 -e file:dependencies/TaxHub#egg=taxhub
     # via
     #   -r requirements-submodules.in
     #   pypnnomenclature
+-e file:dependencies/UsersHub#egg=usershub
+    # via -r requirements-submodules.in
 -e file:dependencies/Utils-Flask-SQLAlchemy#egg=utils-flask-sqlalchemy
     # via
     #   -r requirements-submodules.in
@@ -107,10 +110,16 @@ cssselect2==0.6.0
     # via
     #   cairosvg
     #   weasyprint
+decorator==5.1.1
+    # via validators
 defusedxml==0.7.1
     # via cairosvg
 deprecated==1.2.13
     # via redis
+dnspython==2.2.1
+    # via email-validator
+email-validator==1.3.0
+    # via wtforms-components
 fiona==1.8.21
     # via
     #   -r requirements-common.in
@@ -130,6 +139,7 @@ flask==2.2.2
     #   pypnnomenclature
     #   pypnusershub
     #   taxhub
+    #   usershub
     #   utils-flask-sqlalchemy
 flask-admin==1.6.0
     # via pypnnomenclature
@@ -151,6 +161,7 @@ flask-migrate==3.1.0
     #   pypn-habref-api
     #   pypnnomenclature
     #   taxhub
+    #   usershub
     #   utils-flask-sqlalchemy
 flask-sqlalchemy==2.5.1
     # via
@@ -161,11 +172,14 @@ flask-sqlalchemy==2.5.1
     #   pypnnomenclature
     #   pypnusershub
     #   taxhub
+    #   usershub
     #   utils-flask-sqlalchemy
 flask-weasyprint==1.0.0
     # via -r requirements-common.in
 flask-wtf==1.0.1
-    # via -r requirements-common.in
+    # via
+    #   -r requirements-common.in
+    #   usershub
 geoalchemy2==0.11.1
     # via utils-flask-sqlalchemy-geo
 geojson==2.5.0
@@ -176,10 +190,13 @@ gunicorn==20.1.0
     # via
     #   -r requirements-common.in
     #   taxhub
+    #   usershub
 html5lib==1.1
     # via weasyprint
 idna==3.3
-    # via requests
+    # via
+    #   email-validator
+    #   requests
 importlib-metadata==4.12.0
     # via
     #   alembic
@@ -191,6 +208,10 @@ importlib-metadata==4.12.0
     #   redis
 importlib-resources==5.9.0
     # via alembic
+infinity==1.5
+    # via intervals
+intervals==0.9.2
+    # via wtforms-components
 itsdangerous==2.1.2
     # via
     #   flask
@@ -213,6 +234,7 @@ markupsafe==2.1.1
     #   mako
     #   werkzeug
     #   wtforms
+    #   wtforms-components
 marshmallow==3.17.1
     # via
     #   -r requirements-common.in
@@ -227,6 +249,7 @@ marshmallow-sqlalchemy==0.28.1
     #   pypnnomenclature
     #   pypnusershub
     #   taxhub
+    #   usershub
 munch==2.5.0
     # via fiona
 packaging==21.3
@@ -251,6 +274,7 @@ psycopg2==2.9.3
     #   pypnnomenclature
     #   pypnusershub
     #   taxhub
+    #   usershub
 pycparser==2.21
     # via cffi
 pyparsing==3.0.9
@@ -261,12 +285,14 @@ python-dateutil==2.8.2
     # via
     #   -r requirements-common.in
     #   botocore
+    #   usershub
     #   utils-flask-sqlalchemy
 python-dotenv==0.20.0
     # via
     #   pypn-habref-api
     #   pypnnomenclature
     #   taxhub
+    #   usershub
 pytz==2022.2.1
     # via celery
 redis==4.3.4
@@ -290,6 +316,7 @@ six==1.16.0
     #   html5lib
     #   munch
     #   python-dateutil
+    #   wtforms-components
 sqlalchemy==1.3.24
     # via
     #   -r requirements-common.in
@@ -319,6 +346,8 @@ urllib3==1.26.12
     #   botocore
     #   requests
     #   taxhub
+validators==0.20.0
+    # via wtforms-components
 vine==5.0.0
     # via
     #   amqp
@@ -344,7 +373,11 @@ wtforms==3.0.1
     #   -r requirements-common.in
     #   flask-admin
     #   flask-wtf
+    #   usershub
+    #   wtforms-components
     #   wtforms-sqlalchemy
+wtforms-components==0.10.5
+    # via usershub
 wtforms-sqlalchemy==0.3
     # via -r requirements-common.in
 xmltodict==0.13.0

--- a/backend/requirements-submodules.in
+++ b/backend/requirements-submodules.in
@@ -5,3 +5,4 @@
 -e file:dependencies/Utils-Flask-SQLAlchemy#egg=utils-flask-sqlalchemy
 -e file:dependencies/Utils-Flask-SQLAlchemy-Geo#egg=utils-flask-sqlalchemy-geo
 -e file:dependencies/RefGeo#egg=pypn-ref-geo
+-e file:dependencies/UsersHub#egg=usershub


### PR DESCRIPTION
Ajout de UsersHub comme submodule tout comme TaxHub. Ceci afin que le Alembic de GeoNature puisse connaître les révisions Alembic de UsersHub.
Actuellement on utilise le paramètre ``VERSION_LOCATIONS`` pour indiquer à GeoNature le chemin vers les révisions de UsersHub, mais cela a pour limitation :
- On ne contrôle pas la version de UsersHub à côté, contrairement à un submodule
- Dans un environnement Docker, on a pas accès aux fichiers de UsersHub, il faut donc l’installer dans l’image de GeoNature, ce que permet cette PR.

Cette PR ajoute UsersHub uniquement aux dépendances de dev, mais pas de prod.
Je pense le rajouter également aux dépendances de prod (ce qui permettra de supprimer le la configuration via ``VERSION_LOCATIONS``) mais il faut pour cela créer un nouveau paquet pypi pour UsersHub également et mettre en place l’upload automatique des nouvelles releases.