### PR TITLE
ref#2195 - META - change PDF export code

### DIFF
--- a/backend/geonature/core/gn_meta/mtd/mtd_utils.py
+++ b/backend/geonature/core/gn_meta/mtd/mtd_utils.py
@@ -148,6 +148,7 @@ def post_acquisition_framework(uuid=None):
         uuid (str): uuid of the acquisition framework
     """
     xml_af = None
+    # Récupère un CA localisé dans l'application MTD par son UUID <XML>
     xml_af = get_acquisition_framework(uuid)
 
     if xml_af:
@@ -165,6 +166,7 @@ def post_acquisition_framework(uuid=None):
             )
             DB.session.execute(delete_q)
             DB.session.commit()
+
             create_cor_object_actors(actors, new_af)
             DB.session.merge(new_af)
 

--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -490,12 +490,11 @@ def get_export_pdf_dataset(scope):
         "date": date,
     }
     # chart
-    dataset["chart"] = request.data[22:]
-
-    print(dataset["chart"])
+    dataset["chart"] = request.json["chart"]
 
     # Appel de la methode pour generer un pdf
-    return fm.generate_pdf2("dataset_template_pdf.html", dataset)
+    return fm.generate_pdf("dataset_template_pdf.html", dataset)
+
 
 @routes.route("/acquisition_frameworks", methods=["GET", "POST"])
 @permissions.check_cruved_scope(
@@ -713,7 +712,8 @@ def get_export_pdf_acquisition_frameworks():
         acquisition_framework["closed_title"] = current_app.config["METADATA"]["CLOSED_AF_TITLE"]
 
     # Appel de la methode pour generer un pdf
-    return fm.generate_pdf2("acquisition_framework_template_pdf.html", acquisition_framework)
+    return fm.generate_pdf("acquisition_framework_template_pdf.html", acquisition_framework)
+
 
 @routes.route("/acquisition_framework/<id_acquisition_framework>", methods=["GET"])
 @permissions.check_cruved_scope("R", get_scope=True, module_code="METADATA")

--- a/backend/geonature/templates/acquisition_framework_template_pdf.html
+++ b/backend/geonature/templates/acquisition_framework_template_pdf.html
@@ -267,7 +267,7 @@
                     <p class="repartition-especes">Répartition des espèces</p>
                     <img
                         class="taxons"
-                        src="{{url_for('static', filename='images/taxa.svg')}}"
+                        src="{{data['chart']}}"
                         alt="Pas d'espèces à afficher."
                     >
                 </div>

--- a/backend/geonature/templates/dataset_template_pdf.html
+++ b/backend/geonature/templates/dataset_template_pdf.html
@@ -210,6 +210,7 @@
           <img
             class="taxons test"
             alt="Pas d'espèces à afficher."
+            src="{{data['chart']}}"
           >
         </div>
         <div class="ca">
@@ -329,11 +330,6 @@
       </div>
     </div>
     {% endif %}
-    <style>
-      .test{
-        background: url('data:image/png;base64,{{data["chart"]}}')
-      }
-    </style>
   </body>
 
 </html>

--- a/backend/geonature/templates/dataset_template_pdf.html
+++ b/backend/geonature/templates/dataset_template_pdf.html
@@ -205,18 +205,13 @@
                     <div class="map"></div>
                 </div> -->
         <!-- A modifier lorsque la carte sera prete -->
-
-        {% if data['chart']: %}
         <div class="repartition">
           <p class="repartition-especes">Répartition des espèces</p>
           <img
-            class="taxons"
-            src="{{url_for('static', filename='images/taxa.png')}}"
+            class="taxons test"
             alt="Pas d'espèces à afficher."
           >
         </div>
-        {% endif %}
-
         <div class="ca">
           <hr class="ligne-titre main-color">
           <p class="ca-initial">Cadre d'acquisition</p>
@@ -334,6 +329,11 @@
       </div>
     </div>
     {% endif %}
+    <style>
+      .test{
+        background: url('data:image/png;base64,{{data["chart"]}}')
+      }
+    </style>
   </body>
 
 </html>

--- a/backend/geonature/templates/dataset_template_pdf.html
+++ b/backend/geonature/templates/dataset_template_pdf.html
@@ -205,14 +205,16 @@
                     <div class="map"></div>
                 </div> -->
         <!-- A modifier lorsque la carte sera prete -->
+        {% if data['chart']: %}
         <div class="repartition">
           <p class="repartition-especes">Répartition des espèces</p>
           <img
-            class="taxons test"
+            class="taxons"
             alt="Pas d'espèces à afficher."
             src="{{data['chart']}}"
           >
         </div>
+        {% endif %}
         <div class="ca">
           <hr class="ligne-titre main-color">
           <p class="ca-initial">Cadre d'acquisition</p>

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -390,11 +390,8 @@ class TestGNMeta:
 
         set_logged_user_cookie(self.client, users["user"])
 
-        response = self.client.get(
-            url_for(
-                "gn_meta.get_export_pdf_acquisition_frameworks",
-                id_acquisition_framework=af_id,
-            )
+        response = self.client.post(
+            url_for("gn_meta.get_export_pdf_acquisition_frameworks", af=af_id, json={})
         )
 
         assert response.status_code == 200
@@ -402,10 +399,10 @@ class TestGNMeta:
     def test_get_export_pdf_acquisition_frameworks_unauthorized(self, acquisition_frameworks):
         af_id = acquisition_frameworks["own_af"].id_acquisition_framework
 
-        response = self.client.get(
+        response = self.client.post(
             url_for(
                 "gn_meta.get_export_pdf_acquisition_frameworks",
-                id_acquisition_framework=af_id,
+                af=af_id,
             )
         )
 
@@ -637,27 +634,31 @@ class TestGNMeta:
         unexisting_id = db.session.query(func.max(TDatasets.id_dataset)).scalar() + 1
         ds = datasets["own_dataset"]
 
-        response = self.client.get(
-            url_for("gn_meta.get_export_pdf_dataset", id_dataset=ds.id_dataset)
+        response = self.client.post(
+            url_for("gn_meta.get_export_pdf_dataset", dataset=ds.id_dataset, json={})
         )
         assert response.status_code == Unauthorized.code
 
         set_logged_user_cookie(self.client, users["self_user"])
 
-        response = self.client.get(
-            url_for("gn_meta.get_export_pdf_dataset", id_dataset=unexisting_id)
+        response = self.client.post(
+            url_for("gn_meta.get_export_pdf_dataset", dataset=unexisting_id, json={})
         )
         assert response.status_code == NotFound.code
 
-        response = self.client.get(
-            url_for("gn_meta.get_export_pdf_dataset", id_dataset=ds.id_dataset)
+        response = self.client.post(
+            url_for("gn_meta.get_export_pdf_dataset", dataset=ds.id_dataset, json={})
         )
         assert response.status_code == Forbidden.code
 
         set_logged_user_cookie(self.client, users["user"])
-
-        response = self.client.get(
-            url_for("gn_meta.get_export_pdf_dataset", id_dataset=ds.id_dataset)
+        print("LAST")
+        response = self.client.post(
+            url_for(
+                "gn_meta.get_export_pdf_dataset",
+                dataset=ds.id_dataset
+                # json chart is not required
+            )
         )
         assert response.status_code == 200
 

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -391,7 +391,9 @@ class TestGNMeta:
         set_logged_user_cookie(self.client, users["user"])
 
         response = self.client.post(
-            url_for("gn_meta.get_export_pdf_acquisition_frameworks", af=af_id, json={})
+            url_for(
+                "gn_meta.get_export_pdf_acquisition_frameworks", id_acquisition_framework=af_id
+            )
         )
 
         assert response.status_code == 200
@@ -401,8 +403,7 @@ class TestGNMeta:
 
         response = self.client.post(
             url_for(
-                "gn_meta.get_export_pdf_acquisition_frameworks",
-                af=af_id,
+                "gn_meta.get_export_pdf_acquisition_frameworks", id_acquisition_framework=af_id
             )
         )
 
@@ -635,30 +636,25 @@ class TestGNMeta:
         ds = datasets["own_dataset"]
 
         response = self.client.post(
-            url_for("gn_meta.get_export_pdf_dataset", dataset=ds.id_dataset, json={})
+            url_for("gn_meta.get_export_pdf_dataset", id_dataset=ds.id_dataset)
         )
         assert response.status_code == Unauthorized.code
 
         set_logged_user_cookie(self.client, users["self_user"])
 
         response = self.client.post(
-            url_for("gn_meta.get_export_pdf_dataset", dataset=unexisting_id, json={})
+            url_for("gn_meta.get_export_pdf_dataset", id_dataset=unexisting_id)
         )
         assert response.status_code == NotFound.code
 
         response = self.client.post(
-            url_for("gn_meta.get_export_pdf_dataset", dataset=ds.id_dataset, json={})
+            url_for("gn_meta.get_export_pdf_dataset", id_dataset=ds.id_dataset)
         )
         assert response.status_code == Forbidden.code
 
         set_logged_user_cookie(self.client, users["user"])
-        print("LAST")
         response = self.client.post(
-            url_for(
-                "gn_meta.get_export_pdf_dataset",
-                dataset=ds.id_dataset
-                # json chart is not required
-            )
+            url_for("gn_meta.get_export_pdf_dataset", id_dataset=ds.id_dataset)
         )
         assert response.status_code == 200
 

--- a/backend/geonature/utils/filemanager.py
+++ b/backend/geonature/utils/filemanager.py
@@ -83,18 +83,7 @@ def delete_recursively(path_folder, period=1, excluded_files=[]):
             log.error(e)
 
 
-def generate_pdf(template, data, filename):
-    # flask render template
-    template_rendered = render_template(template, data=data)
-    # weasyprint create PDF
-    html_file = HTML(
-        string=template_rendered, base_url=current_app.config["API_ENDPOINT"], encoding="utf-8"
-    )
-    file_abs_path = str(Path(current_app.static_folder) / "pdf" / filename)
-    # create PDF
-    return html_file.write_pdf(file_abs_path)
-
-def generate_pdf2(template, data):
+def generate_pdf(template, data):
     # flask render a template by name with the given context
     template_rendered = render_template(template, data=data)
     # weasyprint HTML document parsed
@@ -103,4 +92,3 @@ def generate_pdf2(template, data):
     )
     # weasyprint render the document to a PDF file
     return html_file.write_pdf()
-    

--- a/backend/geonature/utils/filemanager.py
+++ b/backend/geonature/utils/filemanager.py
@@ -4,6 +4,7 @@ import shutil
 import logging
 import datetime
 import re
+from io import BytesIO
 from pathlib import Path
 
 from werkzeug.utils import secure_filename
@@ -83,10 +84,23 @@ def delete_recursively(path_folder, period=1, excluded_files=[]):
 
 
 def generate_pdf(template, data, filename):
+    # flask render template
     template_rendered = render_template(template, data=data)
+    # weasyprint create PDF
     html_file = HTML(
         string=template_rendered, base_url=current_app.config["API_ENDPOINT"], encoding="utf-8"
     )
     file_abs_path = str(Path(current_app.static_folder) / "pdf" / filename)
-    html_file.write_pdf(file_abs_path)
-    return file_abs_path
+    # create PDF
+    return html_file.write_pdf(file_abs_path)
+
+def generate_pdf2(template, data):
+    # flask render a template by name with the given context
+    template_rendered = render_template(template, data=data)
+    # weasyprint HTML document parsed
+    html_file = HTML(
+        string=template_rendered, base_url=current_app.config["API_ENDPOINT"], encoding="utf-8"
+    )
+    # weasyprint render the document to a PDF file
+    return html_file.write_pdf()
+    

--- a/backend/geonature/utils/filemanager.py
+++ b/backend/geonature/utils/filemanager.py
@@ -4,7 +4,6 @@ import shutil
 import logging
 import datetime
 import re
-from io import BytesIO
 from pathlib import Path
 
 from werkzeug.utils import secure_filename

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "start": "ng serve",
     "build": "ng build",
     "format": "prettier --write '**/*.ts'",
+    "format:checking": "prettier --config .prettierrc --check ./src/app/**/*.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run"
   },

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -471,19 +471,13 @@ export class DataFormService {
     );
   }
 
-  exportPDF(img, params, endPoint, prefix) {
-    let queryString = new HttpParams();
-    for (let key in params) {
-      queryString = queryString.set(key, params[key]);
-    }
+  exportPDF(img, endPoint, prefix) {
     const source = this._http.post(
       endPoint,
       {
         chart: img,
       },
       {
-        params: queryString,
-        headers: new HttpHeaders().set('Content-Type', 'application/json'),
         observe: 'events',
         responseType: 'blob',
         reportProgress: false,
@@ -555,16 +549,12 @@ export class DataFormService {
     const subscription = source.subscribe(
       (event) => {
         if (event.type === HttpEventType.Response) {
-          this._blob = new Blob([event.body], { type: event.headers.get('Content-Type') });
+          this._blob = event.body;
         }
       },
-      (e: HttpErrorResponse) => {
-        //this._commonService.translateToaster('error', 'ErrorMessage');
-        //this.isDownloading = false;
-      },
+      (e: HttpErrorResponse) => {},
       // response OK
       () => {
-        //this.isDownloading = false;
         const date = new Date();
         const extension = format === 'shapefile' ? 'zip' : format;
         this.saveBlob(this._blob, `${fileName}_${date.toISOString()}.${extension}`);
@@ -572,18 +562,12 @@ export class DataFormService {
       }
     );
   }
-
   saveBlob(blob, filename) {
     const link = document.createElement('a');
     link.href = URL.createObjectURL(blob);
-    link.setAttribute('visibility', 'hidden');
     link.download = filename;
-    link.onload = () => {
-      URL.revokeObjectURL(link.href);
-    };
-    document.body.appendChild(link);
     link.click();
-    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
   }
 
   //liste des lieux

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -4,6 +4,7 @@ import {
   HttpParams,
   HttpEventType,
   HttpErrorResponse,
+  HttpHeaders,
   HttpEvent,
 } from '@angular/common/http';
 import { AppConfig } from '../../../conf/app.config';
@@ -470,9 +471,26 @@ export class DataFormService {
     );
   }
 
-  uploadCanvas(img: any) {
-    return this._http.post<any>(`${AppConfig.API_ENDPOINT}/meta/upload_canvas`, img);
+  exportPDF(img, params, endPoint, prefix) {
+    let queryString = new HttpParams();
+    for (let key in params) {
+      queryString = queryString.set(key, params[key]);
+    }
+    const source = this._http.post(
+      endPoint,
+      img,
+      {
+        params: queryString,
+        headers: new HttpHeaders().set('Content-Type', 'application/pdf'),
+        observe: 'events',
+        responseType: 'blob',
+        reportProgress: false,
+      }
+    );
+
+    this.subscribeAndDownload(source, prefix, "pdf");
   }
+
   getTaxaDistribution(taxa_rank, params?: ParamsDict) {
     let queryString = new HttpParams();
     queryString = queryString.set('taxa_rank', taxa_rank);

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -478,17 +478,19 @@ export class DataFormService {
     }
     const source = this._http.post(
       endPoint,
-      img,
+      {
+        chart: img,
+      },
       {
         params: queryString,
-        headers: new HttpHeaders().set('Content-Type', 'application/pdf'),
+        headers: new HttpHeaders().set('Content-Type', 'application/json'),
         observe: 'events',
         responseType: 'blob',
         reportProgress: false,
       }
     );
 
-    this.subscribeAndDownload(source, prefix, "pdf");
+    this.subscribeAndDownload(source, prefix, 'pdf');
   }
 
   getTaxaDistribution(taxa_rank, params?: ParamsDict) {

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,7 +1,6 @@
 // Angular core
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule, APP_INITIALIZER, Injector } from '@angular/core';
-import { Observable } from "rxjs";
 
 import {
   HttpClientModule,
@@ -81,15 +80,6 @@ export function getModulesAndInitRouting(injector) {
   };
 }
 
-function initializeAppFactory(httpClient: HttpClient): () => Observable<any> {
-  return () => httpClient.get("https://dummyjson.com/products")
-    .pipe(
-      tap(user => {
-        console.log(user);
-        return user
-       })
-    );
- }
 @NgModule({
   imports: [
     BrowserModule,
@@ -141,12 +131,6 @@ function initializeAppFactory(httpClient: HttpClient): () => Observable<any> {
     { provide: APP_CONFIG_TOKEN, useValue: AppConfig },
     { provide: HTTP_INTERCEPTORS, useClass: MyCustomInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: UnauthorizedInterceptor, multi: true },
-    {
-      provide: APP_INITIALIZER,
-      useFactory: initializeAppFactory,
-      deps: [HttpClient],
-      multi: true
-    },
     // { provide: APP_INITIALIZER, useFactory: get_cruved, deps: [CruvedStoreService], multi: true},
     {
       provide: APP_INITIALIZER,

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,6 +1,7 @@
 // Angular core
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule, APP_INITIALIZER, Injector } from '@angular/core';
+import { Observable } from "rxjs";
 
 import {
   HttpClientModule,
@@ -80,6 +81,15 @@ export function getModulesAndInitRouting(injector) {
   };
 }
 
+function initializeAppFactory(httpClient: HttpClient): () => Observable<any> {
+  return () => httpClient.get("https://dummyjson.com/products")
+    .pipe(
+      tap(user => {
+        console.log(user);
+        return user
+       })
+    );
+ }
 @NgModule({
   imports: [
     BrowserModule,
@@ -131,6 +141,12 @@ export function getModulesAndInitRouting(injector) {
     { provide: APP_CONFIG_TOKEN, useValue: AppConfig },
     { provide: HTTP_INTERCEPTORS, useClass: MyCustomInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: UnauthorizedInterceptor, multi: true },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializeAppFactory,
+      deps: [HttpClient],
+      multi: true
+    },
     // { provide: APP_INITIALIZER, useFactory: get_cruved, deps: [CruvedStoreService], multi: true},
     {
       provide: APP_INITIALIZER,

--- a/frontend/src/app/metadataModule/af/af-card.component.ts
+++ b/frontend/src/app/metadataModule/af/af-card.component.ts
@@ -145,8 +145,7 @@ export class AfCardComponent implements OnInit {
   getPdf() {
     this._dfs.exportPDF(
       this.chart ? this.chart.toBase64Image() : '',
-      { af: this.af.id_acquisition_framework },
-      `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks/export_pdf`,
+      `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks/export_pdf/${this.af.id_acquisition_framework}`,
       'af'
     );
   }

--- a/frontend/src/app/metadataModule/af/af-card.component.ts
+++ b/frontend/src/app/metadataModule/af/af-card.component.ts
@@ -143,12 +143,11 @@ export class AfCardComponent implements OnInit {
   }
 
   getPdf() {
-    const dataUrl = this.chart ? this.chart.ctx['canvas'].toDataURL('image/svg') : '';
     this._dfs.exportPDF(
-      dataUrl,
+      this.chart ? this.chart.toBase64Image() : '',
       { af: this.af.id_acquisition_framework },
       `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks/export_pdf`,
-      "af"
-    )
+      'af'
+    );
   }
 }

--- a/frontend/src/app/metadataModule/af/af-card.component.ts
+++ b/frontend/src/app/metadataModule/af/af-card.component.ts
@@ -143,10 +143,12 @@ export class AfCardComponent implements OnInit {
   }
 
   getPdf() {
-    const url = `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks/export_pdf/${this.af.id_acquisition_framework}`;
-    const chart_img = this.chart ? this.chart.ctx['canvas'].toDataURL('image/png') : '';
-    this._dfs.uploadCanvas(chart_img).subscribe((data) => {
-      window.open(url);
-    });
+    const dataUrl = this.chart ? this.chart.ctx['canvas'].toDataURL('image/svg') : '';
+    this._dfs.exportPDF(
+      dataUrl,
+      { af: this.af.id_acquisition_framework },
+      `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks/export_pdf`,
+      "af"
+    )
   }
 }

--- a/frontend/src/app/metadataModule/af/af-form.component.ts
+++ b/frontend/src/app/metadataModule/af/af-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormArray, FormGroup } from '@angular/forms';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { ToastrService } from 'ngx-toastr';
 import { Router, ActivatedRoute } from '@angular/router';
 import { NgbDateParserFormatter } from '@ng-bootstrap/ng-bootstrap';
@@ -132,7 +132,7 @@ export class AfFormComponent implements OnInit {
       null,
       { af: this.afFormS.acquisition_framework.getValue().id_acquisition_framework },
       `${AppConfig.API_ENDPOINT}/meta/dataset/export_pdf`,
-      "af"
-    )
+      'af'
+    );
   }
 }

--- a/frontend/src/app/metadataModule/af/af-form.component.ts
+++ b/frontend/src/app/metadataModule/af/af-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormArray, FormGroup } from '@angular/forms';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { ToastrService } from 'ngx-toastr';
 import { Router, ActivatedRoute } from '@angular/router';
 import { NgbDateParserFormatter } from '@ng-bootstrap/ng-bootstrap';
@@ -128,9 +128,11 @@ export class AfFormComponent implements OnInit {
   }
 
   getPdf() {
-    const url = `${AppConfig.API_ENDPOINT}/meta/acquisition_frameworks/export_pdf/${
-      this.afFormS.acquisition_framework.getValue().id_acquisition_framework
-    }`;
-    window.open(url);
+    this._dfs.exportPDF(
+      null,
+      { af: this.afFormS.acquisition_framework.getValue().id_acquisition_framework },
+      `${AppConfig.API_ENDPOINT}/meta/dataset/export_pdf`,
+      "af"
+    )
   }
 }

--- a/frontend/src/app/metadataModule/af/af-form.component.ts
+++ b/frontend/src/app/metadataModule/af/af-form.component.ts
@@ -126,13 +126,4 @@ export class AfFormComponent implements OnInit {
         }
       );
   }
-
-  getPdf() {
-    this._dfs.exportPDF(
-      null,
-      { af: this.afFormS.acquisition_framework.getValue().id_acquisition_framework },
-      `${AppConfig.API_ENDPOINT}/meta/dataset/export_pdf`,
-      'af'
-    );
-  }
 }

--- a/frontend/src/app/metadataModule/datasets/dataset-card.component.ts
+++ b/frontend/src/app/metadataModule/datasets/dataset-card.component.ts
@@ -142,11 +142,11 @@ export class DatasetCardComponent implements OnInit {
 
   getPdf() {
     this._dfs.exportPDF(
-      this.chart ? this.chart.toBase64Image() : "",
+      this.chart ? this.chart.toBase64Image() : '',
       { dataset: this.id_dataset },
       `${AppConfig.API_ENDPOINT}/meta/dataset/export_pdf`,
-      "jdd"
-    )
+      'jdd'
+    );
   }
 
   delete_Dataset(idDataset) {

--- a/frontend/src/app/metadataModule/datasets/dataset-card.component.ts
+++ b/frontend/src/app/metadataModule/datasets/dataset-card.component.ts
@@ -141,11 +141,12 @@ export class DatasetCardComponent implements OnInit {
   }
 
   getPdf() {
-    const url = `${AppConfig.API_ENDPOINT}/meta/dataset/export_pdf/${this.id_dataset}`;
-    const dataUrl = this.chart ? this.chart.ctx['canvas'].toDataURL('image/png') : '';
-    this._dfs.uploadCanvas(dataUrl).subscribe((data) => {
-      window.open(url);
-    });
+    this._dfs.exportPDF(
+      this.chart ? this.chart.toBase64Image() : "",
+      { dataset: this.id_dataset },
+      `${AppConfig.API_ENDPOINT}/meta/dataset/export_pdf`,
+      "jdd"
+    )
   }
 
   delete_Dataset(idDataset) {

--- a/frontend/src/app/metadataModule/datasets/dataset-card.component.ts
+++ b/frontend/src/app/metadataModule/datasets/dataset-card.component.ts
@@ -143,8 +143,7 @@ export class DatasetCardComponent implements OnInit {
   getPdf() {
     this._dfs.exportPDF(
       this.chart ? this.chart.toBase64Image() : '',
-      { dataset: this.id_dataset },
-      `${AppConfig.API_ENDPOINT}/meta/dataset/export_pdf`,
+      `${AppConfig.API_ENDPOINT}/meta/dataset/export_pdf/${this.id_dataset}`,
       'jdd'
     );
   }


### PR DESCRIPTION
> PR dans le cadre d'une contribution financée par MNHN / PatriNat
> ref #2195 

Cette PR modifie la génération des PDF de métadonnées :

- Aucun fichier (temporaire) n'est déposé sur le serveur (suppression de la méthode `upload_canvas`)
- L'image est ajoutée en tant que data URL b64 dans la source de l'image du template/HTML
- La création du PDF se réalise via un seul appel
- Réutilisation de la méthode `subscribeAndDownload`
- Correction du graph qui n'était pas ajouté dans l'export PDF d'une AF - #2231
- Modification de la route (POST à la place de GET). L'envoi d'un `objet/json` dans le body permet de se soustraire des problèmes d'encodage que l'on a pu voir lorsque l'image était directement passée dans le body en tant que type `data` et qui empêché la bonne représentation dune image type data URL dans le template HTML du PDF (voir méthode render Weasyprint).

En cours sur cette PR :

- [x] Test backend
- [x] Prettier / Linter
- [x] Bonus : Analyse issue #2034
- [ ] Revue