### PR TITLE
fix(db): update taxref_version in commons.sql

### DIFF
--- a/backend/geonature/migrations/data/core/commons.sql
+++ b/backend/geonature/migrations/data/core/commons.sql
@@ -711,7 +711,7 @@ INSERT INTO bib_tables_location (table_desc, schema_name, table_name, pk_field, 
 ;
 
 INSERT INTO t_parameters (id_organism, parameter_name, parameter_desc, parameter_value, parameter_extra_value) VALUES
-((SELECT id_organisme FROM utilisateurs.bib_organismes WHERE nom_organisme = 'ALL'),'taxref_version','Version du référentiel taxonomique','Taxref V14.0',NULL)
+((SELECT id_organisme FROM utilisateurs.bib_organismes WHERE nom_organisme = 'ALL'),'taxref_version','Version du référentiel taxonomique','Taxref V16.0',NULL)
 ,((SELECT id_organisme FROM utilisateurs.bib_organismes WHERE nom_organisme = 'ALL'),'local_srid','Valeur du SRID local', :local_srid, NULL)
 ,((SELECT id_organisme FROM utilisateurs.bib_organismes WHERE nom_organisme = 'ALL'),'annee_ref_commune', 'Année du référentiel géographique des communes utilisé', '2017', NULL)
 ,((SELECT id_organisme FROM utilisateurs.bib_organismes WHERE nom_organisme = 'ALL'),'occtaxmobile_area_type', 'Type de zonage pour lequel la couleur des taxons est calculée pour Occtax-mobile', 'M5', NULL)


### PR DESCRIPTION
Salut !

Suite à une installation complète de la dernière version (2.11) de GeoNature, taxref est automatiquement mis à jour : https://github.com/PnX-SI/GeoNature/blob/2c300fc4b465b68a08801943b208dcd532fab560/install/03_create_db.sh#L109-L111  mais `gn_commons.t_parameters` n'est pas modifié. Le but de cette PR est de mettre à jour cette table