### PR TITLE
fix(api): confusing error msg in Validation

### DIFF
--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -230,7 +230,10 @@ class GnPySchemaConf(Schema):
                 or data["USERSHUB"].get("ADMIN_APPLICATION_PASSWORD", None) is None
             ):
                 raise ValidationError(
-                    "URL_USERSHUB, ADMIN_APPLICATION_LOGIN et ADMIN_APPLICATION_PASSWORD sont necessaires si ENABLE_SIGN_UP=True",
+                    (
+                        "URL_USERSHUB, ADMIN_APPLICATION_LOGIN et ADMIN_APPLICATION_PASSWORD sont necessaires si ENABLE_SIGN_UP=True "
+                        "ou si ENABLE_USER_MANAGEMENT=True"
+                    ),
                     "URL_USERSHUB",
                 )
             if data["MAIL_CONFIG"].get("MAIL_SERVER", None) is None:


### PR DESCRIPTION
Dans la validation des options ACCOUNT_MANAGEMENT, le message d'erreur sur les options USERSHUB était incomplet car ne spécifiait pas qu'il fallait les renseigner si ENABLE_USER_MANAGEMENT=True