### PR TITLE
fix/synthese_model_entity_source

### DIFF
--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -183,7 +183,7 @@ class Synthese(DB.Model):
     source = relationship(TSources)
     id_module = DB.Column(DB.Integer, ForeignKey(TModules.id_module))
     module = DB.relationship(TModules)
-    entity_source_pk_value = DB.Column(DB.Integer)  # FIXME varchar in db!
+    entity_source_pk_value = DB.Column(DB.Unicode)
     id_dataset = DB.Column(DB.Integer, ForeignKey(TDatasets.id_dataset))
     dataset = DB.relationship(TDatasets, backref=DB.backref("synthese_records", lazy="dynamic"))
     grp_method = DB.Column(DB.Unicode(length=255))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,10 @@ CHANGELOG
 
 - Suppression de l'utilisation de `get_role` dans les modules Synthese & Validation (#2162)
 
+**🐛 Corrections**
+
+  - modèle de la synthese : changement du type de `entity_source_pk_value` de `Integer` à `Unicode` pour coller à la base.
+
 **⚠️ Notes de version**
 
 - La configuration dynamique nécessite de renseigner l’URL de l’API dans un nouveau fichier.


### PR DESCRIPTION
Corrige le type de la colonne `Synthese.entity_source_pk_value` de `Integer` en `Unicode`