### PR TITLE
fix(back): docker cmd command syntax

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -143,16 +143,14 @@ ENV GEONATURE_CONFIG_FILE ""
 
 EXPOSE 8000
 
-CMD [ \
-        "gunicorn", \
-        "geonature:create_app()", \
-        "--worker-tmp-dir=/dev/shm", \
-        "--name=geonature", \
-        "--workers=2", \
-        "--threads=2", \
-        "--access-logfile=-", \
-        "--error-logfile=-", \
-        "--bind=0.0.0.0:8000", \
+CMD [ "gunicorn", "geonature:create_app()", \
+    "--worker-tmp-dir=/dev/shm", \
+    "--name=geonature", \
+    "--workers=2", \
+    "--threads=2", \
+    "--access-logfile=-", \
+    "--error-logfile=-", \
+    "--bind=0.0.0.0:8000" \
 ]
 
 


### PR DESCRIPTION
La syntaxe précédente donne une erreur lors du docker run :
```
bin/sh: 1: [: gunicorn,: unexpected operator
```

Je crois que le premier retour à la ligne casse la compréhension de docker.

Testé sur Docker version 20.10.18