### PR TITLE
patch module without frontend

### DIFF
--- a/backend/geonature/utils/command.py
+++ b/backend/geonature/utils/command.py
@@ -42,16 +42,13 @@ def create_frontend_module_config(module_code, output_file=None):
     """
     Create the frontend config
     """
-
-    # for modules without frontend
-    if not (FRONTEND_DIR / "external_modules" / module_code.lower()).exists():
+    module_frontend_dir = FRONTEND_DIR / "external_modules" / module_code.lower()
+    # for modules without frontend or with disabled frontend
+    if not module_frontend_dir.exists():
         return
-
-    module_config = get_module_config(get_dist_from_code(module_code))
+    module_config = get_module_config(get_dist_from_code(module_code.upper()))
     if output_file is None:
-        output_file = (
-            FRONTEND_DIR / "external_modules" / module_code.lower() / "app/module.config.ts"
-        ).open("w")
+        output_file = (module_frontend_dir / "app/module.config.ts").open("w")
     else:
         output_file = nullcontext(output_file)
     with output_file as f:

--- a/backend/geonature/utils/command.py
+++ b/backend/geonature/utils/command.py
@@ -42,7 +42,11 @@ def create_frontend_module_config(module_code, output_file=None):
     """
     Create the frontend config
     """
-    module_code = module_code.upper()
+
+    # for modules without frontend
+    if not (FRONTEND_DIR / "external_modules" / module_code.lower()).exists():
+        return
+
     module_config = get_module_config(get_dist_from_code(module_code))
     if output_file is None:
         output_file = (


### PR DESCRIPTION
Pour pouvoir exécuter la commande `update_configuration` quand on a des modules packagés qui n'ont pas de frontend (par ex. sous modules gn_modulator)
