### PR TITLE
Suppression de la virgule MAPCONFIG.REF_LAYERS

### DIFF
--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -254,7 +254,7 @@ NOTIFICATIONS_ENABLED = true
 
 # There are no defaut layers, but this document how to add one:
 #[[MAPCONFIG.REF_LAYERS]]
-#    code = "COM",
+#    code = "COM"
 #    label = "Communes"
 #    type = "area"
 #    activate = false


### PR DESCRIPTION
Suppression de la virgule sur la config par défaut des entités MAPCONFIG.REF_LAYERS

    #[[MAPCONFIG.REF_LAYERS]]
    #    code = "COM",

vers

    #[[MAPCONFIG.REF_LAYERS]]
    #    code = "COM"