### PR TITLE
ng-select upgrade

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.html
+++ b/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.html
@@ -7,14 +7,17 @@
   [placeholder]="label"
   [multiple]="multiSelect"
   [clearable]="clearable"
-  [virtualScroll]="true"
+  [virtualScroll]="false"
   [formControl]="parentFormControl"
+  [searchFn]="searchFn"
 >
-  <ng-template ng-option-tmp let-item="item" let-index="index" let-search="searchTerm">
-    <div
-      matTooltip="{{ item.acquisition_framework_name }}"
-      [attr.data-qa]="item.acquisition_framework_name"
-    >
+  <ng-template 
+    ng-option-tmp 
+    let-item="item" 
+    let-index="index" 
+    let-search="searchTerm"
+  >
+    <div [attr.data-qa]="item.acquisition_framework_name">
       <span class="pre-wrap">{{ item.acquisition_framework_name }}</span>
     </div>
   </ng-template>

--- a/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.ts
@@ -31,7 +31,7 @@ export class AcquisitionFrameworksComponent extends GenericFormComponent impleme
   //upgrade la fonction de recherche de ng-select
   searchFn(term, item) {
     return customSearchFn(term, item, 'acquisition_framework_name');
-  };
+  }
 
   getAcquisitionFrameworks() {
     this.acquisitionFrameworks = this._dfs.getAcquisitionFrameworks().pipe(

--- a/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { DataFormService } from '@geonature_common/form/data-form.service';
 import { GenericFormComponent } from '@geonature_common/form/genericForm.component';
+import { customSearchFn } from '@geonature/utils/ng-select-searchFn';
 
 /**
  *  Ce composant permet de créer un "input" de type "select" ou "multiselect" affichant l'ensemble des cadres d'acquisition sur lesquels l'utilisateur connecté a des droits (table ``gn_meta.t_acqusitions_framework`` et ``gn_meta.cor_acquisition_framework_actor``)
@@ -26,6 +27,11 @@ export class AcquisitionFrameworksComponent extends GenericFormComponent impleme
   ngOnInit() {
     this.getAcquisitionFrameworks();
   }
+
+  //upgrade la fonction de recherche de ng-select
+  searchFn(term, item) {
+    return customSearchFn(term, item, 'acquisition_framework_name');
+  };
 
   getAcquisitionFrameworks() {
     this.acquisitionFrameworks = this._dfs.getAcquisitionFrameworks().pipe(

--- a/frontend/src/app/GN2CommonModule/form/areas/areas.component.html
+++ b/frontend/src/app/GN2CommonModule/form/areas/areas.component.html
@@ -9,7 +9,7 @@
   [placeholder]="label"
   [multiple]="true"
   [clearable]="clearable"
-  [virtualScroll]="true"
+  [virtualScroll]="false"
   [typeahead]="areas_input$"
   [loading]="loading"
   [formControl]="parentFormControl"
@@ -51,7 +51,7 @@
   </ng-template>
 
   <ng-template ng-option-tmp let-item="item">
-    <div matTooltip="{{ item.area_name }}">
+    <div>
       <span class="pre-wrap">{{ item.area_name }}</span>
     </div>
   </ng-template>

--- a/frontend/src/app/GN2CommonModule/form/areas/areas.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/areas/areas.component.ts
@@ -12,6 +12,7 @@ import {
 
 import { DataFormService } from '../data-form.service';
 import { GenericFormComponent } from '@geonature_common/form/genericForm.component';
+import { customSearchFn } from '@geonature/utils/ng-select-searchFn';
 
 /**
  * Ce composant permet de sélectionner une ou plusieurs zones géographiques.

--- a/frontend/src/app/GN2CommonModule/form/datasets/datasets.component.html
+++ b/frontend/src/app/GN2CommonModule/form/datasets/datasets.component.html
@@ -7,11 +7,17 @@
   placeholder="Jeux de données"
   [multiple]="multiSelect"
   [clearable]="clearable"
-  [virtualScroll]="true"
+  [virtualScroll]="false"
   [formControl]="parentFormControl"
+  [searchFn]="searchFn"
 >
-  <ng-template ng-option-tmp let-item="item" let-index="index" let-search="searchTerm">
-    <div matTooltip="{{ item.dataset_name }}" [attr.data-qa]="item.dataset_name">
+  <ng-template 
+    ng-option-tmp 
+    let-item="item" 
+    let-index="index" 
+    let-search="searchTerm"
+  >
+    <div [attr.data-qa]="item.dataset_name">
       <span class="pre-wrap">{{ item.dataset_name }}</span>
     </div>
   </ng-template>

--- a/frontend/src/app/GN2CommonModule/form/multiselect/multiselect.component.html
+++ b/frontend/src/app/GN2CommonModule/form/multiselect/multiselect.component.html
@@ -1,6 +1,6 @@
 <small> {{ label }} </small>
 <ng-select
-  [ngClass]="null"
+  ngClass="auto"
   [items]="values"
   [bindLabel]="keyLabel"
   [bindValue]="keyValue"
@@ -11,9 +11,15 @@
   [formControl]="parentFormControl"
   (add)="onChange.emit($event)"
   (remove)="onDelete.emit($event)"
+  [searchFn]="searchFn.bind(this)"
 >
-  <ng-template ng-option-tmp let-item="item" let-index="index" let-search="searchTerm">
-    <div [matTooltip]="item[keyLabel]">
+  <ng-template 
+    ng-option-tmp 
+    let-item="item" 
+    let-index="index" 
+    let-search="searchTerm"
+  >
+    <div>
       <span class="pre-wrap">{{ item[keyLabel] }}</span>
     </div>
   </ng-template>

--- a/frontend/src/app/GN2CommonModule/form/multiselect/multiselect.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/multiselect/multiselect.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
+import { customSearchFn } from '@geonature/utils/ng-select-searchFn';
 
 /**
  * Ce composant permet d'afficher un input de type multiselect à partir
@@ -85,4 +86,9 @@ export class MultiSelectComponent implements OnInit {
     this.disabled = this.disabled || false;
     this.displayAll = this.displayAll || false;
   }
+
+  //upgrade la fonction de recherche de ng-select
+  searchFn(term, item) {
+    return customSearchFn(term, item, this.keyLabel);
+  };
 }

--- a/frontend/src/app/GN2CommonModule/form/multiselect/multiselect.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/multiselect/multiselect.component.ts
@@ -90,5 +90,5 @@ export class MultiSelectComponent implements OnInit {
   //upgrade la fonction de recherche de ng-select
   searchFn(term, item) {
     return customSearchFn(term, item, this.keyLabel);
-  };
+  }
 }

--- a/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.html
+++ b/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.html
@@ -6,12 +6,18 @@
   [bindLabel]="labelLang"
   [bindValue]="keyValue"
   [placeholder]="label"
-  [virtualScroll]="true"
+  [virtualScroll]="false"
   [formControl]="parentFormControl"
   [attr.qa-test]="label"
   appendTo="body"
+  [searchFn]="searchFn.bind(this)"
 >
-  <ng-template ng-option-tmp let-item="item" let-index="index" let-search="searchTerm">
+  <ng-template 
+    ng-option-tmp 
+    let-item="item" 
+    let-index="index" 
+    let-search="searchTerm"
+  >
     <div matTooltip="{{ item[definitionLang] }}" [attr.data-qa]="item['cd_nomenclature']">
       <span class="pre-wrap">{{ item[labelLang] }}</span>
     </div>

--- a/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.ts
@@ -13,6 +13,7 @@ import { DataFormService } from '../data-form.service';
 import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
 import { GenericFormComponent } from '@geonature_common/form/genericForm.component';
+import { customSearchFn } from '@geonature/utils/ng-select-searchFn';
 
 /**
  * Ce composant permet de créer un "input" de type "select" ou "multiselect" à partir d'une liste d'items définie dans le référentiel de nomenclatures
@@ -144,6 +145,11 @@ export class NomenclatureComponent
         this.labelsLoaded.emit(this.labels);
       });
   }
+
+  //upgrade la fonction de recherche de ng-select
+  searchFn(term, item) {
+    return customSearchFn(term, item, this.labelLang);
+  };
 
   ngOnDestroy() {
     this.subscription.unsubscribe();

--- a/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.ts
@@ -149,7 +149,7 @@ export class NomenclatureComponent
   //upgrade la fonction de recherche de ng-select
   searchFn(term, item) {
     return customSearchFn(term, item, this.labelLang);
-  };
+  }
 
   ngOnDestroy() {
     this.subscription.unsubscribe();

--- a/frontend/src/app/GN2CommonModule/form/observers/observers.component.html
+++ b/frontend/src/app/GN2CommonModule/form/observers/observers.component.html
@@ -9,8 +9,9 @@
   [clearable]="clearable"
   placeholder="Observateur(s)"
   data-qa="gn-common-form-observers-select"
-  [virtualScroll]="true"
+  [virtualScroll]="false"
   [formControl]="parentFormControl"
+  [searchFn]="searchFn"
 >
 	<ng-template 
     ng-option-tmp 
@@ -18,7 +19,7 @@
     let-index="index" 
     let-search="searchTerm"
   >
-    <div matTooltip="{{item.nom_complet}}">
+    <div>
       <span class="pre-wrap" [attr.data-qa]='"gn-common-form-observers-select-"+item.nom_complet'>{{item.nom_complet}}</span>
     </div>
   </ng-template>

--- a/frontend/src/app/GN2CommonModule/form/observers/observers.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/observers/observers.component.ts
@@ -3,6 +3,7 @@ import { DataFormService } from '../data-form.service';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { GenericFormComponent } from '@geonature_common/form/genericForm.component';
+import { customSearchFn } from '@geonature/utils/ng-select-searchFn';
 
 /**
  * Ce composant permet d'afficher un input de type "autocomplete" sur un liste d'observateur définit dans le schéma ``utilisateur.t_menus`` et ``utilisateurs.cor_role_menu``.
@@ -63,6 +64,11 @@ export class ObserversComponent extends GenericFormComponent {
       );
     }
   }
+
+  //upgrade la fonction de recherche de ng-select
+  searchFn(term, item) {
+    return customSearchFn(term, item, 'nom_complet');
+  };
 
   formatobs(obs: string): string {
     return obs.toLowerCase().replace(' ', '');

--- a/frontend/src/app/GN2CommonModule/form/observers/observers.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/observers/observers.component.ts
@@ -68,7 +68,7 @@ export class ObserversComponent extends GenericFormComponent {
   //upgrade la fonction de recherche de ng-select
   searchFn(term, item) {
     return customSearchFn(term, item, 'nom_complet');
-  };
+  }
 
   formatobs(obs: string): string {
     return obs.toLowerCase().replace(' ', '');

--- a/frontend/src/app/metadataModule/actors/actors.component.html
+++ b/frontend/src/app/metadataModule/actors/actors.component.html
@@ -57,7 +57,7 @@
         placeholder="Organisme"
         [multiple]="false"
         [clearable]="false"
-        [virtualScroll]="true"
+        [virtualScroll]="false"
         formControlName="id_organism"
       >
         <ng-template
@@ -84,7 +84,7 @@
         placeholder="Personne"
         [multiple]="false"
         [clearable]="false"
-        [virtualScroll]="true"
+        [virtualScroll]="false"
         formControlName="id_role"
       >
         <ng-template ng-option-tmp let-item="item" let-index="index" let-search="searchTerm">

--- a/frontend/src/app/utils/ng-select-searchFn.ts
+++ b/frontend/src/app/utils/ng-select-searchFn.ts
@@ -1,11 +1,17 @@
 export function customSearchFn(term: string, item: any, search_field: string) {
   const terms = _removeAccent(term).split(' ');
-  return terms.map(el => _removeAccent(item[search_field]).includes(el)) //return true or false
-       .filter(res => res === false) //filter les elements qui ne sont pas matché
-       .length === 0 //s'il yen a l'item ne doit pas être affiché
+  return (
+    terms
+      .map((el) => _removeAccent(item[search_field]).includes(el)) //return true or false
+      .filter((res) => res === false).length === 0 //filter les elements qui ne sont pas matché
+  ); //s'il yen a l'item ne doit pas être affiché
 }
 
 //Fonction permettant une mise en minuscule + suppression des accents
 function _removeAccent(term) {
-  return ((term.toLowerCase()).trim()).normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-} 
+  return term
+    .toLowerCase()
+    .trim()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+}

--- a/frontend/src/app/utils/ng-select-searchFn.ts
+++ b/frontend/src/app/utils/ng-select-searchFn.ts
@@ -1,0 +1,11 @@
+export function customSearchFn(term: string, item: any, search_field: string) {
+  const terms = _removeAccent(term).split(' ');
+  return terms.map(el => _removeAccent(item[search_field]).includes(el)) //return true or false
+       .filter(res => res === false) //filter les elements qui ne sont pas matché
+       .length === 0 //s'il yen a l'item ne doit pas être affiché
+}
+
+//Fonction permettant une mise en minuscule + suppression des accents
+function _removeAccent(term) {
+  return ((term.toLowerCase()).trim()).normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+} 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -546,6 +546,9 @@ pnx-root:empty + #cover-spin-removable {
   .ng-value-icon.left {
   border-right: none;
 }
+.ng-dropdown-panel .ng-dropdown-panel-items .ng-option {
+  white-space: normal!important;
+}
 a.mat-raised-button:hover {
   text-decoration: none !important;
 }


### PR DESCRIPTION
En lien avec #2372.

Permet le multiligne sur les ng-select du module GN2Common.
Il ya des ng-select dans le module metadata mais il faudrait probablement les charger à partir de ceux du GN2Common.

Dans cette PR j'ai amélioré le fonctionnement de la recherche en splitant le terme recherché par les espaces, ce qui permet de recherché via des bout de mot peu importe l'ordre du texte saisie. Au passage la recherche fonctionne sans prendre en compte les accents.
_Par contre ce n'est pas mis en place pour le component pnx-areas où la recherche se déroule côté serveur._ 