### PR TITLE
feat(install): allow remote geonature db servers

### DIFF
--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -22,9 +22,6 @@ my_url=http://url.com/
 drop_apps_db=false
 
 # DB host
-# Attention les scripts d'installation automatique (install_db.sh et install_all.sh) ne fonctionneront
-# que si votre BDD est installée en local (localhost). Si vous souhaitez installer votre BDD sur un autre serveur,
-# les scripts n'auront pas les droits suffisants pour créer la BDD sur un autre serveur et cela devra être fait manuellement.
 db_host=localhost
 
 # PostgreSQL port
@@ -33,11 +30,18 @@ db_port=5432
 # GeoNature database name
 db_name=geonature2db
 
+
 # GeoNature database owner username
 user_pg=geonatadmin
 
 # GeoNature database owner password
 user_pg_pass=monpassachanger
+
+# Postgres SuperUser that can create Geonature DB and grant permissions to Geonature database owner
+# Only needed if DB is not on the same machine as the app (i.e db_host != localhost)
+remote_super_user_database_name=postgres
+remote_super_user_name=postgres
+remote_super_user_pass=monpassachanger
 
 # Local projection SRID
 srid_local=2154

--- a/install/03_create_db.sh
+++ b/install/03_create_db.sh
@@ -26,6 +26,13 @@ fi
 mkdir -p tmp
 mkdir -p var/log
 
+if [ "${db_host}" != "localhost" ] && [ "${db_host}" != "127.0.0.1" ]; then
+    export $PGHOST=$db_host
+    export $PGPORT=$db_port
+    export $PGDATABASE=$remote_super_user_database_name
+    export $PGUSER=$remote_super_user_name
+    export $PGPASSWORD=$remote_super_user_pass
+fi
 
 if database_exists "${db_name}"; then
     if $drop_apps_db; then
@@ -34,10 +41,10 @@ if database_exists "${db_name}"; then
             "FROM pg_stat_activity "
             "WHERE pg_stat_activity.datname = '${db_name}' "
             "AND pid <> pg_backend_pid() ;")
-        sudo -u "postgres" -s psql -d "postgres" -c "${query[*]}"
+        sudo -E -u "postgres" -s psql -d "postgres" -c "${query[*]}"
 
         echo "Drop database..."
-        sudo -u "postgres" -s dropdb "${db_name}"
+        sudo -E -u "postgres" -s dropdb "${db_name}"
     else
         echo "Database exists but the settings file indicates that we don't have to drop it."
         exit 0
@@ -49,20 +56,20 @@ fi
 ###################
 
 write_log "Check GeoNature database user '$user_pg' exists…"
-user_pg_exists=$(sudo -u postgres -s psql -t -c "SELECT COUNT(1) FROM pg_catalog.pg_roles WHERE  rolname = '${user_pg}';")
+user_pg_exists=$(sudo -E -u postgres -s psql -t -c "SELECT COUNT(1) FROM pg_catalog.pg_roles WHERE  rolname = '${user_pg}';")
 if [ ${user_pg_exists} -eq 0 ]; then
   write_log "Create GeoNature database user…"
-  sudo -u postgres -s psql -c "CREATE ROLE $user_pg WITH LOGIN PASSWORD '$user_pg_pass';" |& tee -a "${LOG_FILE}"
+  sudo -E -u postgres -s psql -c "CREATE ROLE $user_pg WITH LOGIN PASSWORD '$user_pg_pass';" |& tee -a "${LOG_FILE}"
 fi
 
 write_log "Creating GeoNature database..."
-sudo -u postgres -s createdb -O $user_pg $db_name -T template0 -E UTF-8 -l $my_local |& tee -a "${LOG_FILE}"
+sudo -E -u postgres -s createdb -O $user_pg $db_name -T template0 -E UTF-8 -l $my_local |& tee -a "${LOG_FILE}"
 
 write_log "Adding default PostGIS extension"
-sudo -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS postgis;" |& tee -a "${LOG_FILE}"
+sudo -E -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS postgis;" |& tee -a "${LOG_FILE}"
 
 write_log "Extracting PostGIS version"
-postgis_full_version=$(sudo -u postgres -s psql -d "${db_name}" -c "SELECT PostGIS_Version();")
+postgis_full_version=$(sudo -E -u postgres -s psql -d "${db_name}" -c "SELECT PostGIS_Version();")
 postgis_short_version=$(echo "${postgis_full_version}" | sed -n 's/^\s*\([0-9]*\.[0-9]*\)\s.*/\1/p')
 write_log "PostGIS full version:\n ${postgis_full_version}"
 write_log  "PostGIS short version extract: '${postgis_short_version}'"
@@ -71,23 +78,23 @@ write_log "Adding Raster PostGIS extension if necessary"
 postgis_required_version="3.0"
 if [[ "$(printf '%s\n' "${postgis_required_version}" "${postgis_short_version}" | sort -V | head -n1)" = "${postgis_required_version}" ]]; then
     write_log "PostGIS version greater than or equal to ${postgis_required_version} --> adding Raster extension"
-    sudo -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;" |& tee -a "${LOG_FILE}"
+    sudo -E -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;" |& tee -a "${LOG_FILE}"
 else
     write_log "PostGIS version lower than ${postgis_required_version} --> do nothing"
 fi
 
 write_log "Adding other use PostgreSQL extensions"
-sudo -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS hstore;" |& tee -a "${LOG_FILE}"
-sudo -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog; COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';" |& tee -a "${LOG_FILE}"
-sudo -u postgres -s psql -d $db_name -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";' |& tee -a "${LOG_FILE}"
-sudo -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA pg_catalog;" |& tee -a "${LOG_FILE}"
-sudo -u postgres -s psql -d $db_name -c 'CREATE EXTENSION IF NOT EXISTS "unaccent";' |& tee -a "${LOG_FILE}"
+sudo -E -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS hstore;" |& tee -a "${LOG_FILE}"
+sudo -E -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog; COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';" |& tee -a "${LOG_FILE}"
+sudo -E -u postgres -s psql -d $db_name -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";' |& tee -a "${LOG_FILE}"
+sudo -E -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA pg_catalog;" |& tee -a "${LOG_FILE}"
+sudo -E -u postgres -s psql -d $db_name -c 'CREATE EXTENSION IF NOT EXISTS "unaccent";' |& tee -a "${LOG_FILE}"
 
 
 # Mise en place de la structure de la BDD et des données permettant son fonctionnement avec l'application
 write_log 'GRANT access to GeoNature user to necessary tables...'
 for table in geometry_columns geography_columns spatial_ref_sys; do
-  sudo -u postgres -s psql -d $db_name -c "GRANT SELECT ON TABLE ${table} TO ${user_pg}" |& tee -a "${LOG_FILE}"
+  sudo -E -u postgres -s psql -d $db_name -c "GRANT SELECT ON TABLE ${table} TO ${user_pg}" |& tee -a "${LOG_FILE}"
 done
 
 

--- a/install/install_all/install_all.ini
+++ b/install/install_all/install_all.ini
@@ -13,7 +13,6 @@ my_url=http://mon.domaine.com/
 ### CONFIGURATION PostgreSQL ###
 
 # Localisation du server PostgreSQL.
-# Les scripts d'installation automatique ne fonctionnent que si votre BDD est sur le même serveur (localhost)
 pg_host=localhost
 # Port sur lequel PostgreSQL ecoute
 pg_port=5432
@@ -21,6 +20,18 @@ pg_port=5432
 user_pg=geonatadmin
 # Mot de passe de l'utilisateur propriétaire des bases UsersHub, GeoNature, TaxHub
 user_pg_pass=monpassachanger
+
+## CONFIGURATION PostgreSQL distante ##
+
+# Configuration si le serveur PostgreSQL ne se trouve pas sur la même machine que l'application.
+# (i.e si pg_host != localhost)
+
+# Nom de la database par défaut sur laquelle le super user va se connecter
+remote_super_user_database_name=postgres
+# Nom du super user qui a le droit de creation de database + créer notre user pg et de lui donner des permissions
+remote_super_user_name=postgres
+# Mot de passe du super user
+remote_super_user_pass=monpassachanger
 
 ### CONFIGURATION USERSHUB ###
 

--- a/install/install_all/install_all.sh
+++ b/install/install_all/install_all.sh
@@ -178,6 +178,9 @@ sed -i "s/db_port=.*$/db_port=$pg_port/g" settings.ini
 sed -i "s/db_name=.*$/db_name=$geonaturedb_name/g" settings.ini
 sed -i "s/user_pg=.*$/user_pg=$user_pg/g" settings.ini
 sed -i "s/user_pg_pass=.*$/user_pg_pass=$user_pg_pass/g" settings.ini
+sed -i "s/remote_super_user_database_name=.*$/remote_super_user_database_name=$remote_super_user_database_name/g" settings.ini
+sed -i "s/remote_super_user_name=.*$/remote_super_user_name=$remote_super_user_name/g" settings.ini
+sed -i "s/remote_super_user_pass=.*$/remote_super_user_pass=$remote_super_user_pass/g" settings.ini
 sed -i "s/user_schema=.*$/user_schema=local/g" settings.ini
 sed -i "s/usershub_host=.*$/usershub_host=$pg_host/g" settings.ini
 sed -i "s/usershub_port=.*$/usershub_port=$pg_port/g" settings.ini

--- a/install/utils
+++ b/install/utils
@@ -40,7 +40,7 @@ function database_exists () {
         return 0
     else
         # Grep DB name in the list of databases
-        sudo -u postgres -s -- psql -tAl | grep -q "^$1|"
+        sudo -E -u postgres -s -- psql -tAl | grep -q "^$1|"
         return $?
     fi
 }


### PR DESCRIPTION
Cette PR vise à permettre la configuration de db geonature même lorsqu'elles sont situées sur un serveur distant.

Le point qui me semble le plus à même d'être discuté est sur l'aspect sécurité de la chose.

En effet avec cette PR, on entre "en dur" les credentials d'un super user postgres, ou du moins un utilisateur avec suffisamment de droits pour créer une DB, de créer un user et de lui donner des droits.

Une autre version pourrait être de demander à l'utilisateur de créer un .pgpassfile en amont avec : 
```
touch $HOME/.pgpass
# Modifier le pgpassfile avec le bon host/port/db/user/pwd
sudo chown postgres:postgres $HOME/.pgpass
sudo chmod 600 $HOME/.pgpass
```

et d'ensuite exporter la variable PGPASSFILE dans le script à la place de PGPASSWORD.
et d'ainsi retirer la nouvelle variable `remote_super_user_pass`
Qu'en pensez vous ?