### PR TITLE
[METADONNEES] perf/amélioration des performances de la route /meta/datasets

### DIFF
--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -106,6 +106,17 @@ def get_datasets():
     fields = params.get("fields", type=str, default=[])
     if fields:
         fields = fields.split(",")
+    only = params.get("only", type=str, default=[])
+    if only:
+        only = only.split(",")
+    else:
+        only = [
+            "+cruved",
+            "cor_dataset_actor",
+            "cor_dataset_actor.nomenclature_actor_role",
+            "cor_dataset_actor.organism",
+            "cor_dataset_actor.role",
+        ]
     if "create" in params:
         query = TDatasets.query.filter_by_creatable(params.pop("create"))
     else:
@@ -129,13 +140,6 @@ def get_datasets():
             joinedload("organism"),
         ),
     )
-    only = [
-        "+cruved",
-        "cor_dataset_actor",
-        "cor_dataset_actor.nomenclature_actor_role",
-        "cor_dataset_actor.organism",
-        "cor_dataset_actor.role",
-    ]
 
     if params.get("synthese_records_count", type=int, default=0):
         query = query.options(undefer(TDatasets.synthese_records_count))

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -82,12 +82,16 @@ export class DataFormService {
     });
   }
 
-  getDatasets(params?: ParamsDict, orderByName = true, fields = []) {
+  getDatasets(params?: ParamsDict, orderByName = true, fields = [], only: string[] = []) {
     let queryString: HttpParams = new HttpParams();
     queryString = this.addOrderBy(queryString, 'dataset_name');
     fields.forEach((f) => {
       queryString = queryString.append('fields', f);
     });
+    if (only.length !== 0) {
+      queryString = queryString.append('only', only.join(','));
+    }
+
     return this._http.post<any>(`${this.config.API_ENDPOINT}/meta/datasets`, params, {
       params: queryString,
     });

--- a/frontend/src/app/GN2CommonModule/form/datasets/datasets.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/datasets/datasets.component.ts
@@ -85,7 +85,8 @@ export class DatasetsComponent extends GenericFormComponent implements OnInit, O
     if (this.creatableInModule) {
       filter_param['create'] = this.creatableInModule;
     }
-    this._dfs.getDatasets((params = filter_param)).subscribe((res) => {
+    const onlyFields: string[] = ['id_dataset', 'dataset_name'];
+    this._dfs.getDatasets((params = filter_param), true, [], onlyFields).subscribe((res) => {
       this.datasetStore.filteredDataSets = res;
       this.datasetStore.datasets = res;
       this.valueLoaded.emit({ value: this.datasetStore.datasets });


### PR DESCRIPTION
Voir #2444 et https://github.com/PnX-SI/GeoNature/issues/2004

Implémente le point : 

> Éditer la route actuelle GET /meta/datasets en rendant disponible le paramètre only, permettant au front de spécifier uniquement les champs dont il a besoin.

La méthode `getDatasets` accepte un paramètre `only` qui est initialisé et rempli par le composant <pnx-datasets> avec les 2 propriétés requises pour ce composant : `id_dataset` et `dataset_name`.
Testé sur : 
- occhab
- occtax
- synthèse
- import
- monitoring