### PR TITLE
fix(synthese): modif d'un habitat dans occtax pas repercuté dans synthese

### DIFF
--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -490,6 +490,7 @@ class VSyntheseForWebApp(DB.Model):
     nom_valide = DB.Column(DB.Unicode)
     nom_vern = DB.Column(DB.Unicode)
     lb_nom = DB.Column(DB.Unicode)
+    cd_hab = DB.Column(DB.Integer)
     meta_v_taxref = DB.Column(DB.Unicode)
     sample_number_proof = DB.Column(DB.Unicode)
     digital_proof = DB.Column(DB.Unicode)

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -38,6 +38,7 @@ from apptax.taxonomie.models import (
     TaxrefBdcStatutText,
     TaxrefBdcStatutValues,
 )
+from pypn_habref_api.models import Habref
 from ref_geo.models import LAreas, BibAreasTypes
 
 
@@ -348,6 +349,13 @@ class SyntheseQuery:
                     ]
                 )
             )
+
+        if "lib_hab" in self.filters and self.filters["lib_hab"] != [""]:
+            cd_habs = DB.session.query(Habref.cd_hab).filter(
+                Habref.lb_hab_fr.ilike("%{}%".format(self.filters.pop("lib_hab")[0]))
+            )
+            formated_cd_habs = [cd[0] for cd in cd_habs]
+            self.query = self.query.where(self.model.cd_hab.in_(formated_cd_habs))
 
         if "id_organism" in self.filters:
             datasets = (

--- a/backend/geonature/migrations/versions/8620acb59204_fix_update_cd_hab_in_synthese.py
+++ b/backend/geonature/migrations/versions/8620acb59204_fix_update_cd_hab_in_synthese.py
@@ -1,0 +1,37 @@
+"""fix_update_cd_hab_in_synthese
+
+Revision ID: 8620acb59204
+Revises: e29af5549eac
+Create Date: 2023-04-05 15:31:49.623046
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8620acb59204"
+down_revision = "e29af5549eac"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE gn_synthese.synthese s
+        SET cd_hab =
+            (
+                SELECT cd_hab
+                FROM pr_occtax.t_releves_occtax tro
+                WHERE tro.unique_id_sinp_grp = s.unique_id_sinp_grp
+            )
+        FROM pr_occtax.t_releves_occtax tro
+        WHERE tro.unique_id_sinp_grp = s.unique_id_sinp_grp
+        AND tro.cd_hab IS DISTINCT FROM s.cd_hab 
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/backend/geonature/migrations/versions/e29af5549eac_add_cd_hab_in_v_synthese_for_web_app.py
+++ b/backend/geonature/migrations/versions/e29af5549eac_add_cd_hab_in_v_synthese_for_web_app.py
@@ -1,0 +1,171 @@
+"""add cd_hab in v_synthese_for_web_app
+
+Revision ID: e29af5549eac
+Revises: 9e9218653d6c
+Create Date: 2023-04-04 23:43:27.903445
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e29af5549eac"
+down_revision = "9e9218653d6c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE OR REPLACE VIEW gn_synthese.v_synthese_for_web_app
+        AS SELECT s.id_synthese,
+            s.unique_id_sinp,
+            s.unique_id_sinp_grp,
+            s.id_source,
+            s.entity_source_pk_value,
+            s.count_min,
+            s.count_max,
+            s.nom_cite,
+            s.meta_v_taxref,
+            s.sample_number_proof,
+            s.digital_proof,
+            s.non_digital_proof,
+            s.altitude_min,
+            s.altitude_max,
+            s.depth_min,
+            s.depth_max,
+            s.place_name,
+            s."precision",
+            s.the_geom_4326,
+            st_asgeojson(s.the_geom_4326) AS st_asgeojson,
+            s.date_min,
+            s.date_max,
+            s.validator,
+            s.validation_comment,
+            s.observers,
+            s.id_digitiser,
+            s.determiner,
+            s.comment_context,
+            s.comment_description,
+            s.meta_validation_date,
+            s.meta_create_date,
+            s.meta_update_date,
+            s.last_action,
+            d.id_dataset,
+            d.dataset_name,
+            d.id_acquisition_framework,
+            s.id_nomenclature_geo_object_nature,
+            s.id_nomenclature_info_geo_type,
+            s.id_nomenclature_grp_typ,
+            s.grp_method,
+            s.id_nomenclature_obs_technique,
+            s.id_nomenclature_bio_status,
+            s.id_nomenclature_bio_condition,
+            s.id_nomenclature_naturalness,
+            s.id_nomenclature_exist_proof,
+            s.id_nomenclature_valid_status,
+            s.id_nomenclature_diffusion_level,
+            s.id_nomenclature_life_stage,
+            s.id_nomenclature_sex,
+            s.id_nomenclature_obj_count,
+            s.id_nomenclature_type_count,
+            s.id_nomenclature_sensitivity,
+            s.id_nomenclature_observation_status,
+            s.id_nomenclature_blurring,
+            s.id_nomenclature_source_status,
+            s.id_nomenclature_determination_method,
+            s.id_nomenclature_behaviour,
+            s.reference_biblio,
+            sources.name_source,
+            sources.url_source,
+            t.cd_nom,
+            t.cd_ref,
+            t.nom_valide,
+            t.lb_nom,
+            t.nom_vern,
+            s.cd_hab
+        FROM gn_synthese.synthese s
+            JOIN taxonomie.taxref t ON t.cd_nom = s.cd_nom
+            JOIN gn_meta.t_datasets d ON d.id_dataset = s.id_dataset
+            JOIN gn_synthese.t_sources sources ON sources.id_source = s.id_source;
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        CREATE OR REPLACE VIEW gn_synthese.v_synthese_for_web_app
+        AS SELECT s.id_synthese,
+            s.unique_id_sinp,
+            s.unique_id_sinp_grp,
+            s.id_source,
+            s.entity_source_pk_value,
+            s.count_min,
+            s.count_max,
+            s.nom_cite,
+            s.meta_v_taxref,
+            s.sample_number_proof,
+            s.digital_proof,
+            s.non_digital_proof,
+            s.altitude_min,
+            s.altitude_max,
+            s.depth_min,
+            s.depth_max,
+            s.place_name,
+            s."precision",
+            s.the_geom_4326,
+            st_asgeojson(s.the_geom_4326) AS st_asgeojson,
+            s.date_min,
+            s.date_max,
+            s.validator,
+            s.validation_comment,
+            s.observers,
+            s.id_digitiser,
+            s.determiner,
+            s.comment_context,
+            s.comment_description,
+            s.meta_validation_date,
+            s.meta_create_date,
+            s.meta_update_date,
+            s.last_action,
+            d.id_dataset,
+            d.dataset_name,
+            d.id_acquisition_framework,
+            s.id_nomenclature_geo_object_nature,
+            s.id_nomenclature_info_geo_type,
+            s.id_nomenclature_grp_typ,
+            s.grp_method,
+            s.id_nomenclature_obs_technique,
+            s.id_nomenclature_bio_status,
+            s.id_nomenclature_bio_condition,
+            s.id_nomenclature_naturalness,
+            s.id_nomenclature_exist_proof,
+            s.id_nomenclature_valid_status,
+            s.id_nomenclature_diffusion_level,
+            s.id_nomenclature_life_stage,
+            s.id_nomenclature_sex,
+            s.id_nomenclature_obj_count,
+            s.id_nomenclature_type_count,
+            s.id_nomenclature_sensitivity,
+            s.id_nomenclature_observation_status,
+            s.id_nomenclature_blurring,
+            s.id_nomenclature_source_status,
+            s.id_nomenclature_determination_method,
+            s.id_nomenclature_behaviour,
+            s.reference_biblio,
+            sources.name_source,
+            sources.url_source,
+            t.cd_nom,
+            t.cd_ref,
+            t.nom_valide,
+            t.lb_nom,
+            t.nom_vern
+        FROM gn_synthese.synthese s
+            JOIN taxonomie.taxref t ON t.cd_nom = s.cd_nom
+            JOIN gn_meta.t_datasets d ON d.id_dataset = s.id_dataset
+            JOIN gn_synthese.t_sources sources ON sources.id_source = s.id_source;
+        """
+    )

--- a/contrib/occtax/backend/occtax/migrations/1b4f44762020_add_cd_hab_in_fct_tri_synthese_update_.py
+++ b/contrib/occtax/backend/occtax/migrations/1b4f44762020_add_cd_hab_in_fct_tri_synthese_update_.py
@@ -1,0 +1,114 @@
+"""add_cd_hab_in_fct_tri_synthese_update_releve
+
+Revision ID: 1b4f44762020
+Revises: 0ff94776a962
+Create Date: 2023-04-04 00:26:12.030884
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "1b4f44762020"
+down_revision = "0ff94776a962"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION pr_occtax.fct_tri_synthese_update_releve()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $function$
+        DECLARE
+        myobservers text;
+        BEGIN
+        --mise à jour en synthese des informations correspondant au relevé uniquement
+        UPDATE gn_synthese.synthese s SET
+        id_dataset = NEW.id_dataset,
+        observers = COALESCE(NEW.observers_txt, observers),
+        id_digitiser = NEW.id_digitiser,
+        id_module = NEW.id_module,
+        id_source = (SELECT id_source FROM gn_synthese.t_sources WHERE id_module = NEW.id_module),
+        grp_method = NEW.grp_method,
+        id_nomenclature_grp_typ = NEW.id_nomenclature_grp_typ,
+        date_min = date_trunc('day',NEW.date_min)+COALESCE(NEW.hour_min,'00:00:00'::time),
+        date_max = date_trunc('day',NEW.date_max)+COALESCE(NEW.hour_max,'00:00:00'::time),
+        altitude_min = NEW.altitude_min,
+        altitude_max = NEW.altitude_max,
+        depth_min = NEW.depth_min,
+        depth_max = NEW.depth_max,
+        place_name = NEW.place_name,
+        precision = NEW.precision,
+        the_geom_local = NEW.geom_local,
+        the_geom_4326 = NEW.geom_4326,
+        the_geom_point = ST_CENTROID(NEW.geom_4326),
+        id_nomenclature_geo_object_nature = NEW.id_nomenclature_geo_object_nature,
+        last_action = 'U',
+        comment_context = NEW.comment,
+        additional_data = COALESCE(NEW.additional_fields, '{}'::jsonb) || COALESCE(o.additional_fields, '{}'::jsonb) || COALESCE(c.additional_fields, '{}'::jsonb),
+        cd_hab = r.cd_hab
+        FROM pr_occtax.cor_counting_occtax c
+        INNER JOIN pr_occtax.t_occurrences_occtax o ON c.id_occurrence_occtax = o.id_occurrence_occtax
+        INNER JOIN pr_occtax.t_releves_occtax r ON r.id_releve_occtax = o.id_releve_occtax
+        WHERE c.unique_id_sinp_occtax = s.unique_id_sinp
+        AND o.id_releve_occtax = NEW.id_releve_occtax
+        AND s.unique_id_sinp IN (SELECT unnest(pr_occtax.get_unique_id_sinp_from_id_releve(NEW.id_releve_occtax::integer)));
+
+        RETURN NULL;
+        END;
+        $function$
+        ;
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION pr_occtax.fct_tri_synthese_update_releve()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $function$
+        DECLARE
+        myobservers text;
+        BEGIN
+
+        --mise à jour en synthese des informations correspondant au relevé uniquement
+        UPDATE gn_synthese.synthese s SET
+        id_dataset = NEW.id_dataset,
+        observers = COALESCE(NEW.observers_txt, observers),
+        id_digitiser = NEW.id_digitiser,
+        id_module = NEW.id_module,
+        id_source = (SELECT id_source FROM gn_synthese.t_sources WHERE id_module = NEW.id_module),
+        grp_method = NEW.grp_method,
+        id_nomenclature_grp_typ = NEW.id_nomenclature_grp_typ,
+        date_min = date_trunc('day',NEW.date_min)+COALESCE(NEW.hour_min,'00:00:00'::time),
+        date_max = date_trunc('day',NEW.date_max)+COALESCE(NEW.hour_max,'00:00:00'::time),
+        altitude_min = NEW.altitude_min,
+        altitude_max = NEW.altitude_max,
+        depth_min = NEW.depth_min,
+        depth_max = NEW.depth_max,
+        place_name = NEW.place_name,
+        precision = NEW.precision,
+        the_geom_local = NEW.geom_local,
+        the_geom_4326 = NEW.geom_4326,
+        the_geom_point = ST_CENTROID(NEW.geom_4326),
+        id_nomenclature_geo_object_nature = NEW.id_nomenclature_geo_object_nature,
+        last_action = 'U',
+        comment_context = NEW.comment,
+        additional_data = COALESCE(NEW.additional_fields, '{}'::jsonb) || COALESCE(o.additional_fields, '{}'::jsonb) || COALESCE(c.additional_fields, '{}'::jsonb)
+        FROM pr_occtax.cor_counting_occtax c
+        INNER JOIN pr_occtax.t_occurrences_occtax o ON c.id_occurrence_occtax = o.id_occurrence_occtax
+        WHERE c.unique_id_sinp_occtax = s.unique_id_sinp
+        AND s.unique_id_sinp IN (SELECT unnest(pr_occtax.get_unique_id_sinp_from_id_releve(NEW.id_releve_occtax::integer)));
+
+        RETURN NULL;
+        END;
+        $function$
+        ;
+        """
+    )

--- a/contrib/occtax/backend/occtax/migrations/8620acb59204_fix_update_cd_hab_in_synthese.py
+++ b/contrib/occtax/backend/occtax/migrations/8620acb59204_fix_update_cd_hab_in_synthese.py
@@ -1,7 +1,7 @@
 """fix_update_cd_hab_in_synthese
 
 Revision ID: 8620acb59204
-Revises: e29af5549eac
+Revises: 1b4f44762020
 Create Date: 2023-04-05 15:31:49.623046
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "8620acb59204"
-down_revision = "e29af5549eac"
+down_revision = "1b4f44762020"
 branch_labels = None
 depends_on = None
 

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/dynamicFormConfig.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/dynamicFormConfig.ts
@@ -263,4 +263,10 @@ export const DYNAMIC_FORM_DEF = [
     attribut_name: 'unique_id_sinp',
     required: false,
   },
+  {
+    type_widget: 'text',
+    attribut_label: 'Habitat',
+    attribut_name: 'lib_hab',
+    required: false,
+  },
 ];


### PR DESCRIPTION
- Reprise de la fonction `pr_occtax.fct_tri_synthese_update_releve` pour qu'elle prenne en compte les modifications de l'habitat d'un relevé
- Ajout habitat dans vue `gn_synthese.v_synthese_for_web_app`
- Ajout du filtre "Habitat" dans les filtres avancés de la Synthèse
- Migration proposé pour corriger les éventuels habitats qui ont été modifiés dans des relevés Occtax

Closes #2384 