### PR TITLE
feat(api): add notification for comment on obs

### DIFF
--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -1101,11 +1101,11 @@ def create_report(scope):
         id_type=type_exists.id_type,
     )
     session.add(new_entry)
-    notify_new_report_change(synthese=synthese, content=content)
+    notify_new_report_change(synthese=synthese, user=g.current_user, content=content)
     session.commit()
 
 
-def notify_new_report_change(synthese, content):
+def notify_new_report_change(synthese, user, content):
     if not synthese.id_digitiser:
         return
     dispatch_notifications(
@@ -1117,7 +1117,7 @@ def notify_new_report_change(synthese, content):
             + "/#/synthese/occurrence/"
             + str(synthese.id_synthese)
         ),
-        context={"synthese": synthese, "content": content},
+        context={"synthese": synthese, "user": user, "content": content},
     )
 
 

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -1109,7 +1109,7 @@ def notify_new_report_change(synthese, user, content):
     if not synthese.id_digitiser:
         return
     dispatch_notifications(
-        code_categories=["VALIDATION-NEW-COMMENT"],
+        code_categories=["OBSERVATION-COMMENT"],
         id_roles=[synthese.id_digitiser],
         title="Nouveau commentaire sur une observation",
         url=(

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -1120,7 +1120,7 @@ def create_report(scope):
             ).distinct(TReport.id_role)
         }
         # The id_roles are the Union between observers and commenters
-        id_roles = observers | commenters | { synthese.id_digitiser }
+        id_roles = observers | commenters | {synthese.id_digitiser}
         # Remove the user that just commented the obs not to notify him/her
         id_roles.discard(g.current_user.id_role)
         notify_new_report_change(

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -32,6 +32,7 @@ from geonature.utils.errors import GeonatureApiError
 from geonature.utils.utilsgeometrytools import export_as_geo_file
 
 from geonature.core.gn_meta.models import TDatasets
+from geonature.core.notifications.utils import dispatch_notifications
 
 from geonature.core.gn_synthese.models import (
     BibReportsTypes,
@@ -1100,7 +1101,24 @@ def create_report(scope):
         id_type=type_exists.id_type,
     )
     session.add(new_entry)
+    notify_new_report_change(synthese=synthese, content=content)
     session.commit()
+
+
+def notify_new_report_change(synthese, content):
+    if not synthese.id_digitiser:
+        return
+    dispatch_notifications(
+        code_categories=["VALIDATION-NEW-COMMENT"],
+        id_roles=[synthese.id_digitiser],
+        title="Nouveau commentaire sur une observation",
+        url=(
+            current_app.config["URL_APPLICATION"]
+            + "/#/validation/occurrence/"
+            + str(synthese.id_synthese)
+        ),
+        context={"synthese": synthese, "content": content},
+    )
 
 
 @routes.route("/reports/<int:id_report>", methods=["PUT"])

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -1116,13 +1116,13 @@ def create_report(scope):
         commenters = {
             report.id_role
             for report in report_query.filter(
-                TReport.id_role not in {synthese.id_digitiser} | observers
+                TReport.id_role.notin_({synthese.id_digitiser} | observers)
             ).distinct(TReport.id_role)
         }
         # The id_roles are the Union between observers and commenters
-        id_roles = observers | commenters
+        id_roles = observers | commenters | { synthese.id_digitiser }
         # Remove the user that just commented the obs not to notify him/her
-        id_roles.remove(g.current_user.id_role)
+        id_roles.discard(g.current_user.id_role)
         notify_new_report_change(
             synthese=synthese, user=g.current_user, id_roles=id_roles, content=content
         )

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -1114,7 +1114,7 @@ def notify_new_report_change(synthese, content):
         title="Nouveau commentaire sur une observation",
         url=(
             current_app.config["URL_APPLICATION"]
-            + "/#/validation/occurrence/"
+            + "/#/synthese/occurrence/"
             + str(synthese.id_synthese)
         ),
         context={"synthese": synthese, "content": content},

--- a/backend/geonature/migrations/versions/95acee9f0452_add_comment_notification.py
+++ b/backend/geonature/migrations/versions/95acee9f0452_add_comment_notification.py
@@ -23,9 +23,9 @@ depends_on = None
 CATEGORY_CODE = "OBSERVATION-COMMENT"
 EMAIL_CONTENT = (
     "<p>Bonjour <i>{{ role.nom_complet }}</i> !</p>"
-    "<p>{{ user.nom_complet }} a commenté l'observation de {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }}" 
+    "<p>{{ user.nom_complet }} a commenté l'observation de {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }}"
     "que vous avez créée ou commentée</p>"
-    "<p>Vous pouvez y accéder directement <a href=\"{{ url }}\">ici</a></p>"
+    '<p>Vous pouvez y accéder directement <a href="{{ url }}">ici</a></p>'
     "<p><i>Vous recevez cet email automatiquement via le service de notification de GeoNature.</i></p>"
 )
 DB_CONTENT = (
@@ -43,7 +43,7 @@ def upgrade():
         code=CATEGORY_CODE,
         label="Nouveau commentaire sur une observation",
         description=(
-            "Se déclenche lorsqu'un nouveau commentaire est ajouté à une de vos observations"
+            "Se déclenche lorsqu'un nouveau commentaire est ajouté à une de vos observations, ou une observation que vous avez commenté"
         ),
     )
 

--- a/backend/geonature/migrations/versions/95acee9f0452_add_comment_notification.py
+++ b/backend/geonature/migrations/versions/95acee9f0452_add_comment_notification.py
@@ -1,4 +1,4 @@
-"""add_validation_comment_notification
+"""add_comment_notification
 
 Revision ID: 95acee9f0452
 Revises: 9e9218653d6c
@@ -21,6 +21,17 @@ branch_labels = None
 depends_on = None
 
 CATEGORY_CODE = "OBSERVATION-COMMENT"
+EMAIL_CONTENT = (
+    "<p>Bonjour <i>{{ role.nom_complet }}</i> !</p>"
+    "<p>{{ user.nom_complet }} a commenté l'observation de {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }}" 
+    "que vous avez créée ou commentée</p>"
+    "<p>Vous pouvez y accéder directement <a href=\"{{ url }}\">ici</a></p>"
+    "<p><i>Vous recevez cet email automatiquement via le service de notification de GeoNature.</i></p>"
+)
+DB_CONTENT = (
+    "{{ user.nom_complet }} a commenté l'observation de {{ synthese.nom_cite }} du "
+    "{{ synthese.meta_create_date.strftime('%d-%m-%Y') }} que vous avez créée ou commentée"
+)
 
 
 def upgrade():
@@ -38,17 +49,7 @@ def upgrade():
 
     session.add(category)
 
-    # Add template
-    email_content = """ <p>Bonjour <i>{{ role.nom_complet }}</i> !</p> 
-    <p>{{ user.nom_complet }} a commenté votre observation de {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }}</p>
-    <p>Vous pouvez y accéder directement <a href="{{ url }}">ici</a></p>
-    <p><i>Vous recevez cet email automatiquement via le service de notification de GeoNature.</i></p>
-    """
-    db_content = """ {{ user.nom_complet }} a commenté votre observation 
-    de {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }}
-    """
-
-    for method, content in (("EMAIL", email_content), ("DB", db_content)):
+    for method, content in (("EMAIL", EMAIL_CONTENT), ("DB", DB_CONTENT)):
         template = NotificationTemplate(category=category, code_method=method, content=content)
         session.add(template)
 

--- a/backend/geonature/migrations/versions/95acee9f0452_add_comment_notification.py
+++ b/backend/geonature/migrations/versions/95acee9f0452_add_comment_notification.py
@@ -1,4 +1,4 @@
-"""add_comment_notification
+"""add comment notification
 
 Revision ID: 95acee9f0452
 Revises: 9e9218653d6c
@@ -16,7 +16,7 @@ from geonature.core.notifications.models import (
 
 # revision identifiers, used by Alembic.
 revision = "95acee9f0452"
-down_revision = "9e9218653d6c"
+down_revision = "e2a94808cf76"
 branch_labels = None
 depends_on = None
 

--- a/backend/geonature/migrations/versions/95acee9f0452_add_validation_comment_notification.py
+++ b/backend/geonature/migrations/versions/95acee9f0452_add_validation_comment_notification.py
@@ -32,7 +32,7 @@ def upgrade():
         code=CATEGORY_CODE,
         label="Nouveau commentaire sur une observation",
         description=(
-            "Se déclenche lorsqu'un nouveau commentaire " "est ajouté à une de vos observations"
+            "Se déclenche lorsqu'un nouveau commentaire est ajouté à une de vos observations"
         ),
     )
 

--- a/backend/geonature/migrations/versions/95acee9f0452_add_validation_comment_notification.py
+++ b/backend/geonature/migrations/versions/95acee9f0452_add_validation_comment_notification.py
@@ -20,7 +20,7 @@ down_revision = "9e9218653d6c"
 branch_labels = None
 depends_on = None
 
-CATEGORY_CODE = "VALIDATION-NEW-COMMENT"
+CATEGORY_CODE = "OBSERVATION-COMMENT"
 
 
 def upgrade():
@@ -30,10 +30,9 @@ def upgrade():
     # Add category
     category = NotificationCategory(
         code=CATEGORY_CODE,
-        label="Nouveau commentaire dans une discussion sur une observation",
+        label="Nouveau commentaire sur une observation",
         description=(
-            "Se déclenche lorsqu'un nouveau commentaire "
-            "est ajouté dans une discussion de validation"
+            "Se déclenche lorsqu'un nouveau commentaire " "est ajouté à une de vos observations"
         ),
     )
 
@@ -63,10 +62,10 @@ def downgrade():
     category = (
         session.query(NotificationCategory)
         .filter(NotificationCategory.code == CATEGORY_CODE)
-        .one()
+        .one_or_none()
     )
 
-    if category:
+    if category is not None:
         session.query(NotificationRule).filter(
             NotificationRule.code_category == category.code
         ).delete()

--- a/backend/geonature/migrations/versions/95acee9f0452_add_validation_comment_notification.py
+++ b/backend/geonature/migrations/versions/95acee9f0452_add_validation_comment_notification.py
@@ -1,0 +1,79 @@
+"""add_validation_comment_notification
+
+Revision ID: 95acee9f0452
+Revises: 9e9218653d6c
+Create Date: 2023-04-06 19:02:39.863972
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from geonature.core.notifications.models import (
+    NotificationCategory,
+    NotificationRule,
+    NotificationTemplate,
+)
+
+# revision identifiers, used by Alembic.
+revision = "95acee9f0452"
+down_revision = "9e9218653d6c"
+branch_labels = None
+depends_on = None
+
+CATEGORY_CODE = "VALIDATION-NEW-COMMENT"
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+
+    # Add category
+    category = NotificationCategory(
+        code=CATEGORY_CODE,
+        label="Nouveau commentaire dans une discussion sur une observation",
+        description=(
+            "Se déclenche lorsqu'un nouveau commentaire "
+            "est ajouté dans une discussion de validation"
+        ),
+    )
+
+    session.add(category)
+
+    # Add template
+    email_content = """ <p>Bonjour <i>{{ role.nom_complet }}</i> !</p> 
+    <p>Votre observation de l'espèce : {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }} a reçu un commentaire</p>
+    <p>Vous pouvez y accéder directement <a href="{{ url }}">ici</a></p>
+    <p><i>Vous recevez cet email automatiquement via le service de notification de GeoNature.</i></p>
+    """
+    db_content = """ Vous avez reçu un nouveau commentaire sur votre observation 
+    de {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }}
+    """
+
+    for method, content in (("EMAIL", email_content), ("DB", db_content)):
+        template = NotificationTemplate(category=category, code_method=method, content=content)
+        session.add(template)
+
+    session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+    # Do not use NotificationCategory.query as it is not the same session!
+    category = (
+        session.query(NotificationCategory)
+        .filter(NotificationCategory.code == CATEGORY_CODE)
+        .one()
+    )
+
+    if category:
+        session.query(NotificationRule).filter(
+            NotificationRule.code_category == category.code
+        ).delete()
+        # Since there is no cascade, need to delete template manually
+        session.query(NotificationTemplate).filter(
+            NotificationTemplate.code_category == category.code
+        ).delete()
+
+        session.delete(category)
+        session.commit()

--- a/backend/geonature/migrations/versions/95acee9f0452_add_validation_comment_notification.py
+++ b/backend/geonature/migrations/versions/95acee9f0452_add_validation_comment_notification.py
@@ -41,11 +41,11 @@ def upgrade():
 
     # Add template
     email_content = """ <p>Bonjour <i>{{ role.nom_complet }}</i> !</p> 
-    <p>Votre observation de l'espèce : {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }} a reçu un commentaire</p>
+    <p>{{ user.nom_complet }} a commenté votre observation de {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }}</p>
     <p>Vous pouvez y accéder directement <a href="{{ url }}">ici</a></p>
     <p><i>Vous recevez cet email automatiquement via le service de notification de GeoNature.</i></p>
     """
-    db_content = """ Vous avez reçu un nouveau commentaire sur votre observation 
+    db_content = """ {{ user.nom_complet }} a commenté votre observation 
     de {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }}
     """
 

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -318,7 +318,15 @@ def synthese_data(app, users, datasets, source):
             )
             geom = from_shape(point, srid=4326)
             taxon = Taxref.query.filter_by(cd_nom=cd_nom).one()
-            s = create_synthese(geom, taxon, users["self_user"], ds, source, unique_id_sinp, [users["admin_user"], users["user"]])
+            s = create_synthese(
+                geom,
+                taxon,
+                users["self_user"],
+                ds,
+                source,
+                unique_id_sinp,
+                [users["admin_user"], users["user"]],
+            )
             db.session.add(s)
             data[name] = s
     return data

--- a/backend/geonature/tests/test_notifications.py
+++ b/backend/geonature/tests/test_notifications.py
@@ -4,7 +4,7 @@ import json
 import datetime
 from unittest.mock import patch
 
-from flask import url_for, jsonify, current_app
+from flask import url_for
 from werkzeug.exceptions import Forbidden, Unauthorized, BadRequest
 
 from geonature.utils.env import db
@@ -16,16 +16,11 @@ from geonature.core.notifications.models import (
     NotificationTemplate,
 )
 from geonature.core.notifications import utils
-from geonature.tests.fixtures import celery_eager
+from geonature.tests.fixtures import celery_eager, notifications_enabled
 
 from .utils import set_logged_user_cookie
 
 log = logging.getLogger()
-
-
-@pytest.fixture()
-def notifications_enabled(monkeypatch):
-    monkeypatch.setitem(current_app.config, "NOTIFICATIONS_ENABLED", True)
 
 
 @pytest.fixture(scope="class")

--- a/backend/geonature/tests/test_reports.py
+++ b/backend/geonature/tests/test_reports.py
@@ -13,56 +13,36 @@ from .fixtures import *
 from .utils import logged_user_headers, set_logged_user_cookie
 
 
-@pytest.fixture()
-def admin_notification_rule(users):
+def add_notification_rule(user):
     with db.session.begin_nested():
         new_notification_rule = NotificationRule(
-            id_role=users["admin_user"].id_role,
+            id_role=user.id_role,
             code_method="DB",
             code_category="OBSERVATION-COMMENT",
             subscribed=True,
         )
         db.session.add(new_notification_rule)
     return new_notification_rule
+
+
+@pytest.fixture()
+def admin_notification_rule(users):
+    return add_notification_rule(users["admin_user"])
 
 
 @pytest.fixture()
 def associate_user_notification_rule(users):
-    with db.session.begin_nested():
-        new_notification_rule = NotificationRule(
-            id_role=users["associate_user"].id_role,
-            code_method="DB",
-            code_category="OBSERVATION-COMMENT",
-            subscribed=True,
-        )
-        db.session.add(new_notification_rule)
-    return new_notification_rule
+    return add_notification_rule(users["associate_user"])
 
 
 @pytest.fixture()
 def user_notification_rule(users):
-    with db.session.begin_nested():
-        new_notification_rule = NotificationRule(
-            id_role=users["user"].id_role,
-            code_method="DB",
-            code_category="OBSERVATION-COMMENT",
-            subscribed=True,
-        )
-        db.session.add(new_notification_rule)
-    return new_notification_rule
+    return add_notification_rule(users["user"])
 
 
 @pytest.fixture()
 def self_user_notification_rule(users):
-    with db.session.begin_nested():
-        new_notification_rule = NotificationRule(
-            id_role=users["self_user"].id_role,
-            code_method="DB",
-            code_category="OBSERVATION-COMMENT",
-            subscribed=True,
-        )
-        db.session.add(new_notification_rule)
-    return new_notification_rule
+    return add_notification_rule(users["self_user"])
 
 
 @pytest.mark.usefixtures("client_class", "temporary_transaction")


### PR DESCRIPTION
Dans le cadre d'une prestation pour l'Agence Régionale de la Biodiversité Ile De France : ajout d'une notification lorsqu'un commentaire est ajouté sur l'observation d'un utilisateur.
La notification n'est pas envoyé aux utilisateurs commentant une observation qui n'ont pas faite.

**Code de la notification :** VALIDATION-NEW-COMMENT
**Template de mail :**
```html
<p>Bonjour <i>{{ role.nom_complet }}</i> !</p> 
<p>Votre observation de l'espèce : {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }} a reçu un commentaire</p>
<p>Vous pouvez y accéder directement <a href="{{ url }}">ici</a></p>
<p><i>Vous recevez cet email automatiquement via le service de notification de GeoNature.</i></p>
```

**Template de notification :** 
```html
Vous avez reçu un nouveau commentaire sur votre observation de {{ synthese.nom_cite }} du {{ synthese.meta_create_date.strftime('%d-%m-%Y') }}
```

Closes #2460 