### PR TITLE
[Metadonnées] Perf/exclude dataset fields by default

### DIFF
--- a/backend/requirements-dependencies.in
+++ b/backend/requirements-dependencies.in
@@ -2,6 +2,6 @@ pypnusershub>=1.6.5,<2
 pypnnomenclature>=1.5.4,<2
 pypn_habref_api>=0.3.2,<1
 utils-flask-sqlalchemy-geo>=0.2.7,<1
-utils-flask-sqlalchemy>=0.3.2,<1
+utils-flask-sqlalchemy>=0.3.3,<1
 taxhub>=1.11.1,<2
 pypn-ref-geo>=1.3.0,<2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -317,7 +317,7 @@ urllib3==1.26.12
     #   botocore
     #   requests
     #   taxhub
-utils-flask-sqlalchemy==0.3.2
+utils-flask-sqlalchemy==0.3.3
     # via
     #   -r requirements-dependencies.in
     #   pypn-habref-api

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -13,7 +13,7 @@ import { map } from 'rxjs/operators';
 import { ConfigService } from '@geonature/services/config.service';
 
 /** Interface for queryString parameters*/
-interface ParamsDict {
+export interface ParamsDict {
   [key: string]: any;
 }
 
@@ -82,9 +82,12 @@ export class DataFormService {
     });
   }
 
-  getDatasets(params?: ParamsDict, orderByName = true, fields = []) {
+  getDatasets(params?: ParamsDict, queryStrings: ParamsDict = {}, fields = []) {
     let queryString: HttpParams = new HttpParams();
     queryString = this.addOrderBy(queryString, 'dataset_name');
+    Object.keys(queryStrings).forEach((key) => {
+      queryString = queryString.append(key, queryStrings[key]);
+    });
     fields.forEach((f) => {
       queryString = queryString.append('fields', f);
     });

--- a/frontend/src/app/metadataModule/metadata.component.ts
+++ b/frontend/src/app/metadataModule/metadata.component.ts
@@ -7,7 +7,7 @@ import { Observable, combineLatest } from 'rxjs';
 import { map, distinctUntilChanged, debounceTime } from 'rxjs/operators';
 import { omitBy } from 'lodash';
 
-import { DataFormService } from '@geonature_common/form/data-form.service';
+import { DataFormService, ParamsDict } from '@geonature_common/form/data-form.service';
 import { CommonService } from '@geonature_common/service/common.service';
 import { MetadataService } from './services/metadata.service';
 import { ConfigService } from '@geonature/services/config.service';
@@ -150,13 +150,14 @@ export class MetadataComponent implements OnInit {
   onOpenExpansionPanel(af: any) {
     if (af.t_datasets === undefined) {
       let params = {};
+      const queryStrings: ParamsDict = { synthese_records_count: 1 };
       if (this.searchTerms.selector === 'ds') {
         params = this.searchTerms;
       }
       if (this.rapidSearchControl.value) {
         params = { ...params, search: this.rapidSearchControl.value };
       }
-      this.metadataService.addDatasetToAcquisitionFramework(af, params);
+      this.metadataService.addDatasetToAcquisitionFramework(af, params, queryStrings);
     }
   }
 

--- a/frontend/src/app/metadataModule/services/metadata.service.ts
+++ b/frontend/src/app/metadataModule/services/metadata.service.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
 import { SyntheseDataService } from '@geonature_common/form/synthese-form/synthese-data.service';
-import { DataFormService } from '@geonature_common/form/data-form.service';
+import { DataFormService, ParamsDict } from '@geonature_common/form/data-form.service';
 import { ConfigService } from '@geonature/services/config.service';
 
 const SELECTORS = { datasets: 0, creator: 1, actors: 1 };
@@ -84,15 +84,18 @@ export class MetadataService {
     );
   }
 
-  addDatasetToAcquisitionFramework(af, params) {
+  addDatasetToAcquisitionFramework(af, params, queryString: ParamsDict = {}) {
     //TODO: keep in mind that acquisistionframeworks is
     // a behaviour subject and so filter it with rxjs and
     // pipe the getDatasets then subscribe at the end
     this.dataFormService
-      .getDatasets({
-        id_acquisition_frameworks: [af.id_acquisition_framework],
-        ...params,
-      })
+      .getDatasets(
+        {
+          id_acquisition_frameworks: [af.id_acquisition_framework],
+          ...params,
+        },
+        queryString
+      )
       .subscribe((datasets) => {
         af.t_datasets = datasets;
       });


### PR DESCRIPTION
Par défaut, le schema Marshmallow suivant : https://github.com/PnX-SI/GeoNature/blob/5999efb11113081f1f9e8c65d44130318069c7b6/backend/geonature/core/gn_meta/schemas.py#L41

Chargeait le champs `synthese_records_count` qui effectuait un `select` pour chaque jeu de données de la requête.

Cette PR l'exclue par défaut et ajoute la possibilité au composant `metadata.component` de demander le calcul de `synthese_records_count`

Closes #2444 