### PR TITLE
meta: get read perms from METADATA module

### DIFF
--- a/backend/geonature/core/gn_meta/models.py
+++ b/backend/geonature/core/gn_meta/models.py
@@ -250,7 +250,7 @@ class TDatasetsQuery(Query):
     def _get_read_scope(self, user=None):
         if user is None:
             user = g.current_user
-        cruved = get_scopes_by_action(id_role=user.id_role, module_code="GEONATURE")
+        cruved = get_scopes_by_action(id_role=user.id_role, module_code="METADATA")
         return cruved["R"]
 
     def _get_create_scope(self, module_code, user=None):
@@ -560,7 +560,7 @@ class TAcquisitionFrameworkQuery(Query):
     def _get_read_scope(self, user=None):
         if user is None:
             user = g.current_user
-        cruved = get_scopes_by_action(id_role=user.id_role, module_code="GEONATURE")
+        cruved = get_scopes_by_action(id_role=user.id_role, module_code="METADATA")
         return cruved["R"]
 
     def filter_by_scope(self, scope, user=None):

--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -505,11 +505,8 @@ def get_export_pdf_dataset(id_dataset, scope):
 
 
 @routes.route("/acquisition_frameworks", methods=["GET", "POST"])
-@permissions.check_cruved_scope(
-    "R",
-    get_scope=True,
-)
-def get_acquisition_frameworks(scope):
+@login_required
+def get_acquisition_frameworks():
     """
     Get a simple list of AF without any nested relationships
     Use for AF select in form


### PR DESCRIPTION
Récupération des JDD et des DS en regardant le R METADATA plutôt que R GEONATURE.
Pas sûr que ça ne pose pas des soucis, par exemple, si on met un R METADATA à 0 pour interdire l’accès au module méta-données … Cela peut casser notamment les endroits où on utilise le composant `pnx-datasets` en mode pas `CREATE` (en mode `CREATE`, pas de soucis).
Autre utilisation : filtres de la synthèse