### PR TITLE
refix validation filtre avance ref #2470

### DIFF
--- a/contrib/gn_module_validation/frontend/app/components/validation.component.ts
+++ b/contrib/gn_module_validation/frontend/app/components/validation.component.ts
@@ -35,6 +35,7 @@ export class ValidationComponent implements OnInit {
     this._fs.selectedCdRefFromTree = [];
     this._fs.selectedTaxonFromRankInput = [];
     this._fs.selectedtaxonFromComponent = [];
+    this._fs.processedDefaultFilters = {};
     this.getStatusNames();
     this._commonService.translateToaster(
       'info',

--- a/frontend/src/app/GN2CommonModule/form/dynamic-form-generator/dynamic-form-generator.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/dynamic-form-generator/dynamic-form-generator.component.ts
@@ -152,7 +152,12 @@ export class GenericFormGeneratorComponent implements OnInit, OnChanges {
       this.setForms();
 
       // pour dire aux formulaires qu'il y a un changement;
-      this.update = true;
+
+      // fy ExpressionChangedAfterItHasBeenCheckedError
+      setTimeout(() => {
+        this.update = true;
+      });
+
       setTimeout(() => {
         this.update = false;
       }, 500);

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.component.html
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.component.html
@@ -344,6 +344,7 @@
     <legend>Filtres avancés</legend>
     <small> Ajouter un filtre </small>
     <pnx-dynamic-form-generator
+      *ngIf="formService.processedDefaultFilters"
       [myFormGroup]="formService.searchForm"
       [formsDefinition]="formService.dynamycFormDef"
       [defaults]="formService.processedDefaultFilters"

--- a/frontend/src/app/syntheseModule/synthese.component.ts
+++ b/frontend/src/app/syntheseModule/synthese.component.ts
@@ -71,14 +71,12 @@ export class SyntheseComponent implements OnInit {
       this._fs.selectedStatus = [];
       this._fs.selectedTaxRefAttributs = [];
 
-      // application des valeurs par defaut (input this.defaults)
-
-      // application des valeurs par defaut (input this.defaults)
+      // application des valeurs par defaut
       this._fs
         .processDefaultFilters(this.config.SYNTHESE.DEFAULT_FILTERS)
         .subscribe((processedDefaultFilters) => {
-          this._fs.processedDefaultFilters = processedDefaultFilters;
           this._fs.searchForm.patchValue(this._fs.processedDefaultFilters);
+          this._fs.processedDefaultFilters = processedDefaultFilters;
 
           this.loadAndStoreData(this._fs.formatParams());
         });


### PR DESCRIPTION
La dernière PR ne résolvait pas tout pour #2470
la je me suis assuré que cela fonctionnait pour la valisaiton (pas de filtre par defaut) et pour la synthese (possibilité de mettre des filtres par defaut)