### PR TITLE
synthese: left outer join on aggregated areas

### DIFF
--- a/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
@@ -125,12 +125,19 @@ export class SyntheseCarteComponent implements OnInit, AfterViewInit, OnChanges,
     // On table click, change style layer and zoom
     this.mapListService.onTableClick$.subscribe((id) => {
       const selectedLayers = this.layersDict[id];
-      this.toggleStyleFromList(selectedLayers);
-      const tempFeatureGroup = new L.FeatureGroup();
-      selectedLayers.forEach((layer) => {
-        tempFeatureGroup.addLayer(layer);
-      });
-      this._ms.map.fitBounds(tempFeatureGroup.getBounds(), { maxZoom: 18 });
+      if (selectedLayers) {
+        this.toggleStyleFromList(selectedLayers);
+        const tempFeatureGroup = new L.FeatureGroup();
+        selectedLayers.forEach((layer) => {
+          tempFeatureGroup.addLayer(layer);
+        });
+        this._ms.map.fitBounds(tempFeatureGroup.getBounds(), { maxZoom: 18 });
+      } else {
+        this._commonService.regularToaster(
+          'warning',
+          "L'observation selectionnée n'est présente dans aucune maille - passez en mode 'point' pour la localiser"
+        );
+      }
     });
 
     // add the featureGroup to the map

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
@@ -320,6 +320,8 @@ export class SyntheseCarteComponent implements OnInit, AfterViewInit, OnChanges,
   }
 
   ngOnChanges(change) {
+    // clear layerDict cache
+    this.layersDict = {};
     // on change delete the previous layer and load the new ones from the geojson data send by the API
     // here we don't use geojson component for performance reasons
     if (this._ms.map) {

--- a/frontend/src/app/syntheseModule/synthese.component.ts
+++ b/frontend/src/app/syntheseModule/synthese.component.ts
@@ -195,7 +195,12 @@ export class SyntheseComponent implements OnInit {
   }
 
   private simplifyGeoJson(geojson) {
+    let noGeomMessage = false;
     for (let feature of geojson.features) {
+      if (!feature.geometry) {
+        noGeomMessage = true;
+      }
+
       let ids = [];
       for (let obs of Object.values(feature.properties.observations)) {
         if (obs['id']) {
@@ -203,6 +208,11 @@ export class SyntheseComponent implements OnInit {
         }
       }
       feature.properties.observations = { id: ids };
+    }
+    if (noGeomMessage) {
+      this._toasterService.warning(
+        "Certaine(s) observation(s) n'ont pas pu être affiché(es) sur la carte car leur maille d’aggrégation n'est pas disponible"
+      );
     }
     return geojson;
   }


### PR DESCRIPTION
Remonte les observations dont la géométries ne se trouve pas dans une maille du référentiel spécifié dans `AREA_AGGREGATION_TYPE`, mais la géométrie est alors `null`.

TODO (frontend) :
- Afficher un message s’il y a une feature avec une géométrie `null` « Attention, {n} observations ne sont pas affichées sur la carte », avec n = taille du tableau de `properties` de la feature
- Gérer le cas où la géométrie est nulle lorsque l’on clique sur un élément dans la liste

Le mécanisme de zoom sur la bounding box a l’air de fonctionner correctement malgré les géom nulles.

https://github.com/PnX-SI/GeoNature/issues/2495