### PR TITLE
Fix/dynamic formm number default val

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/dynamic-form-generator/dynamic-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/dynamic-form-generator/dynamic-form.service.ts
@@ -128,10 +128,10 @@ export class DynamicFormService {
   createControl(formDef): AbstractControl {
     const formControl = new UntypedFormControl();
     const value = formDef.value || null;
-    this.setControl(formControl, formDef, value);
+    const defaultValue = parseFloat(value) ? parseFloat(value) : value;
+    this.setControl(formControl, formDef, defaultValue);
     return formControl;
   }
-
   addNewControl(formDef, formGroup: UntypedFormGroup) {
     //Mise en fonction des valeurs des dynamic-form ex: "hidden: "({value}) => value.monChamps != 'maValeur'""
     for (const keyParam of Object.keys(formDef)) {


### PR DESCRIPTION
Dans les formulaires dynamiques, les valeurs par défaut de type "number" n'étaient pas automatiquement sélectionnées dans les formulaires de type select, car considérées comme des "string".

https://github.com/PnX-SI/GeoNature/issues/2540