### PR TITLE
Synthese form - filtre insensible aux accents sur les observateurs + recherche pour plusieurs observateurs

### DIFF
--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -284,7 +284,7 @@ class SyntheseQuery:
             # découpe des éléments saisies par les espaces
             observers = self.filters.pop("observers").split()
             self.query = self.query.where(
-                and_(*[self.model.observers.ilike("%" + observer + "%") for observer in observers])
+                and_(*[func.unaccent(self.model.observers).ilike("%" + func.unaccent(observer) + "%") for observer in observers])
             )
 
         if "observers_list" in self.filters:

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -284,7 +284,14 @@ class SyntheseQuery:
             # découpe des éléments saisies par les espaces
             observers = self.filters.pop("observers").split(";")
             self.query = self.query.where(
-                or_(*[func.unaccent(self.model.observers).ilike("%" + func.unaccent(observer) + "%") for observer in observers])
+                or_(
+                    *[
+                        func.unaccent(self.model.observers).ilike(
+                            "%" + func.unaccent(observer) + "%"
+                        )
+                        for observer in observers
+                    ]
+                )
             )
 
         if "observers_list" in self.filters:

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -286,7 +286,7 @@ class SyntheseQuery:
             )
         if "observers" in self.filters:
             # découpe des éléments saisies par des ","
-            observers = self.filters.pop("observers").split(",")
+            observers = self.filters.pop("observers")[0].split(",")
             self.query = self.query.where(
                 or_(
                     *[

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -282,9 +282,9 @@ class SyntheseQuery:
             )
         if "observers" in self.filters:
             # découpe des éléments saisies par les espaces
-            observers = self.filters.pop("observers").split()
+            observers = self.filters.pop("observers").split(";")
             self.query = self.query.where(
-                and_(*[func.unaccent(self.model.observers).ilike("%" + func.unaccent(observer) + "%") for observer in observers])
+                or_(*[func.unaccent(self.model.observers).ilike("%" + func.unaccent(observer) + "%") for observer in observers])
             )
 
         if "observers_list" in self.filters:

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -281,8 +281,8 @@ class SyntheseQuery:
                 self.model.id_dataset.in_(self.filters.pop("id_dataset"))
             )
         if "observers" in self.filters:
-            # découpe des éléments saisies par les espaces
-            observers = self.filters.pop("observers").split(";")
+            # découpe des éléments saisies par des ","
+            observers = self.filters.pop("observers").split(",")
             self.query = self.query.where(
                 or_(
                     *[

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -9,7 +9,7 @@ import datetime
 import uuid
 
 from flask import current_app
-
+import unicodedata
 from sqlalchemy import func, or_, and_, select, distinct
 from sqlalchemy.sql import text
 from sqlalchemy.orm import aliased
@@ -94,6 +94,10 @@ class SyntheseQuery:
                     e=e, model=model
                 )
             )
+
+    # def remove_accents(input_str):
+    #     nfkd_form = unicodedata.normalize('NFKD', input_str)
+    #     return u"".join([c for c in nfkd_form if not unicodedata.combining(c)])
 
     def add_join(self, right_table, right_column, left_column, join_type="right"):
         if self.first:
@@ -287,7 +291,7 @@ class SyntheseQuery:
                 or_(
                     *[
                         func.unaccent(self.model.observers).ilike(
-                            "%" + func.unaccent(observer) + "%"
+                            "%" + remove_accents(observer) + "%"
                         )
                         for observer in observers
                     ]
@@ -536,3 +540,8 @@ class SyntheseQuery:
                 == (len(protection_status_value) + len(red_list_filters)),
             ],
         )
+
+
+def remove_accents(input_str):
+    nfkd_form = unicodedata.normalize("NFKD", input_str)
+    return "".join([c for c in nfkd_form if not unicodedata.combining(c)])

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -152,10 +152,6 @@ def users(app):
         ("self_user", organisme, scope_filters[1]),
         ("user", organisme, scope_filters[2]),
         ("admin_user", organisme, scope_filters[3]),
-        ("Léa Dupont", organisme, scope_filters[2]),
-        ("Test user", organisme, scope_filters[2]),
-        ("claude éluard", organisme, scope_filters[2]),
-        ("Thomas Badu", organisme, scope_filters[2]),
     ]
 
     for username, *args in users_to_create:
@@ -307,30 +303,16 @@ def synthese_data(app, users, datasets, source):
     point3 = Point(-3.486786, 48.832182)
     data = {}
     with db.session.begin_nested():
-        for name, cd_nom, point, ds, user_name, observer in [
-            ("obs1", 713776, point1, datasets["own_dataset"], users["Léa Dupont"], "Léa Dupont"),
-            ("obs2", 212, point2, datasets["own_dataset"], users["Thomas Badu"], "Thomas Badu"),
-            ("obs3", 2497, point3, datasets["own_dataset"], users["Test user"], "Test user"),
-            ("p1_af1", 713776, point1, datasets["belong_af_1"], users["Test user"], "Test user"),
-            (
-                "p1_af1_2",
-                212,
-                point1,
-                datasets["belong_af_1"],
-                users["claude éluard"],
-                "claude éluard",
-            ),
-            ("p1_af2", 212, point1, datasets["belong_af_2"], users["Léa Dupont"], "Léa Dupont"),
-            (
-                "p2_af2",
-                2497,
-                point2,
-                datasets["belong_af_2"],
-                users["claude éluard"],
-                "claude éluard",
-            ),
-            ("p2_af1", 2497, point2, datasets["belong_af_1"], users["Test user"], "Test user"),
-            ("p3_af3", 2497, point3, datasets["belong_af_3"], users["Test user"], "Test user"),
+        for name, cd_nom, point, ds in [
+            ("obs1", 713776, point1, datasets["own_dataset"]),
+            ("obs2", 212, point2, datasets["own_dataset"]),
+            ("obs3", 2497, point3, datasets["own_dataset"]),
+            ("p1_af1", 713776, point1, datasets["belong_af_1"]),
+            ("p1_af1_2", 212, point1, datasets["belong_af_1"]),
+            ("p1_af2", 212, point1, datasets["belong_af_2"]),
+            ("p2_af2", 2497, point2, datasets["belong_af_2"]),
+            ("p2_af1", 2497, point2, datasets["belong_af_1"]),
+            ("p3_af3", 2497, point3, datasets["belong_af_3"]),
         ]:
             unique_id_sinp = (
                 "f4428222-d038-40bc-bc5c-6e977bbbc92b" if not data else func.uuid_generate_v4()
@@ -340,12 +322,12 @@ def synthese_data(app, users, datasets, source):
             s = create_synthese(
                 geom,
                 taxon,
-                user_name,
+                users["self_user"],
                 ds,
                 source,
                 unique_id_sinp,
-                [users["admin_user"], user_name],
-                observer,
+                [users["admin_user"], users["user"]],
+                "user"
             )
             db.session.add(s)
             data[name] = s

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -233,8 +233,8 @@ class TestSynthese:
         validate_json(instance=r.json, schema=schema)
         assert len(r.json["features"]) >= 2  # FIXME
 
-        filters = {"observers": "Léa, Eluard"}
-        r = self.client.get(url)
+        filters = {"observers": ["user, self_user"]}
+        r = self.client.get(url, json=filters)
         validate_json(instance=r.json, schema=schema)
         assert len(r.json["features"]) > 0
 
@@ -305,10 +305,7 @@ class TestSynthese:
     @pytest.mark.parametrize(
         "test_input,expected_length_observer",
         [
-            ("Leaa, Robert", 0),
-            ("Léa, éluard", 4),
-            ("lea, eluard", 4),
-            ("lea", 2),
+            ("user, self_user", 1)
         ],
     )
     def test_get_observations_for_web_filter_observers(
@@ -317,7 +314,7 @@ class TestSynthese:
         set_logged_user_cookie(self.client, users["self_user"])
 
         url = url_for("gn_synthese.get_observations_for_web")
-        filters = {"observers": test_input}
+        filters = {"observers": [test_input]}
         r = self.client.get(url, json=filters)
 
         response_data = {feature["properties"] for feature in r.json["features"]}

--- a/frontend/src/app/GN2CommonModule/form/observers-text/observers-text.component.html
+++ b/frontend/src/app/GN2CommonModule/form/observers-text/observers-text.component.html
@@ -1,5 +1,5 @@
 <small> {{ 'Releve.Observers' | translate }} </small>
-<i class="fa fa-question-circle" title="Renseignez plusieurs observateurs séparés par des ';' "></i>
+<i class="fa fa-question-circle" title="Renseignez plusieurs observateurs séparés par des ',' "></i>
 <div class="input-group">
   <input
     [ngClass]="{ 'is-invalid': parentFormControl.invalid }"

--- a/frontend/src/app/GN2CommonModule/form/observers-text/observers-text.component.html
+++ b/frontend/src/app/GN2CommonModule/form/observers-text/observers-text.component.html
@@ -1,4 +1,5 @@
 <small> {{ 'Releve.Observers' | translate }} </small>
+<i class="fa fa-question-circle" title="Renseignez plusieurs observateurs séparés par des ';' "></i>
 <div class="input-group">
   <input
     [ngClass]="{ 'is-invalid': parentFormControl.invalid }"


### PR DESCRIPTION
Modifcations suggérées : 

- Recherche insensible aux accent avec `func.unaccent` sur le filtre des observateurs 
- Recherche pour plusieurs observateurs en indiquant dans une info bulle comment pouvoir effectuer cette recherche (coté front) et changeant le "split" coté back et l'opérateur "and" en "or" pour la requête SQL

Closes #2568