### PR TITLE
Header auth

### DIFF
--- a/backend/geonature/core/gn_permissions/decorators.py
+++ b/backend/geonature/core/gn_permissions/decorators.py
@@ -10,6 +10,10 @@ from werkzeug.exceptions import Unauthorized, Forbidden
 from geonature.core.gn_permissions.tools import get_permissions, get_scopes_by_action
 
 
+# use login_required from flask_login
+from flask_login import login_required
+
+
 def _forbidden_message(action, module_code, object_code):
     message = f"User {g.current_user.id_role} has no permissions to {action}"
     if module_code:
@@ -17,16 +21,6 @@ def _forbidden_message(action, module_code, object_code):
     if object_code:
         message += f" on {object_code}"
     return message
-
-
-def login_required(view_func):
-    @wraps(view_func)
-    def decorated_view(*args, **kwargs):
-        if g.current_user is None:
-            raise Unauthorized
-        return view_func(*args, **kwargs)
-
-    return decorated_view
 
 
 def check_cruved_scope(

--- a/backend/geonature/core/gn_permissions/decorators.py
+++ b/backend/geonature/core/gn_permissions/decorators.py
@@ -46,7 +46,7 @@ def check_cruved_scope(
     def _check_cruved_scope(view_func):
         @wraps(view_func)
         def decorated_view(*args, **kwargs):
-            if g.current_user is None:
+            if not g.current_user.is_authenticated:
                 raise Unauthorized
             scope = get_scopes_by_action(module_code=module_code, object_code=object_code)[action]
             if not scope:
@@ -68,7 +68,7 @@ def permissions_required(
     def _permission_required(view_func):
         @wraps(view_func)
         def decorated_view(*args, **kwargs):
-            if g.current_user is None:
+            if not g.current_user.is_authenticated:
                 raise Unauthorized
             permissions = get_permissions(action, module_code=module_code, object_code=object_code)
             if not permissions:

--- a/backend/geonature/core/users/routes.py
+++ b/backend/geonature/core/users/routes.py
@@ -26,7 +26,6 @@ from pypnusershub.env import REGISTER_POST_ACTION_FCT
 from pypnusershub.db.models import User, Application
 from pypnusershub.db.models_register import TempUser
 from pypnusershub.routes_register import bp as user_api
-from pypnusershub.routes import check_auth
 from utils_flask_sqla.response import json_resp
 
 

--- a/backend/geonature/tests/conftest.py
+++ b/backend/geonature/tests/conftest.py
@@ -1,3 +1,3 @@
 # force discovery of some fixtures
 from .fixtures import app, users, _session
-from pypnusershub.tests.fixtures import _logout_user
+from pypnusershub.tests.fixtures import teardown_logout_user

--- a/backend/geonature/tests/conftest.py
+++ b/backend/geonature/tests/conftest.py
@@ -1,2 +1,3 @@
 # force discovery of some fixtures
 from .fixtures import app, users, _session
+from pypnusershub.tests.fixtures import _logout_user

--- a/backend/geonature/tests/test_gn_commons.py
+++ b/backend/geonature/tests/test_gn_commons.py
@@ -20,7 +20,7 @@ from geonature.utils.env import db
 from geonature.utils.errors import GeoNatureError
 
 from .fixtures import *
-from .utils import set_logged_user_cookie
+from .utils import set_logged_user
 
 
 @pytest.fixture(scope="function")
@@ -321,12 +321,12 @@ class TestCommons:
         response = self.client.get(url_for("gn_commons.list_modules", exclude="GEONATURE"))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
         response = self.client.get(url_for("gn_commons.list_modules", exclude="GEONATURE"))
         assert response.status_code == 200
         assert len(response.json) == 0
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.get(url_for("gn_commons.list_modules", exclude="GEONATURE"))
         assert response.status_code == 200
         assert len(response.json) > 0
@@ -334,7 +334,7 @@ class TestCommons:
     def test_list_module_exclude(self, users):
         excluded_module = "GEONATURE"
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(
             url_for("gn_commons.list_modules"), query_string={"exclude": [excluded_module]}
@@ -370,12 +370,12 @@ class TestCommons:
         response = self.client.get(url_for("gn_commons.list_places"))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url_for("gn_commons.list_places"))
         assert response.status_code == 200
         assert place.id_place in [p["properties"]["id_place"] for p in response.json]
 
-        set_logged_user_cookie(self.client, users["associate_user"])
+        set_logged_user(self.client, users["associate_user"])
         response = self.client.get(url_for("gn_commons.list_places"))
         assert response.status_code == 200
         assert place.id_place not in [p["properties"]["id_place"] for p in response.json]
@@ -390,7 +390,7 @@ class TestCommons:
         response = self.client.post(url_for("gn_commons.add_place"))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.post(url_for("gn_commons.add_place"), data=geofeature)
         assert response.status_code == 200
         assert db.session.query(
@@ -399,7 +399,7 @@ class TestCommons:
             ).exists()
         ).scalar()
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.post(url_for("gn_commons.add_place"), data=geofeature)
         assert response.status_code == Conflict.code
 
@@ -408,14 +408,14 @@ class TestCommons:
         response = self.client.delete(url_for("gn_commons.delete_place", id_place=unexisting_id))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["associate_user"])
+        set_logged_user(self.client, users["associate_user"])
         response = self.client.delete(url_for("gn_commons.delete_place", id_place=unexisting_id))
         assert response.status_code == NotFound.code
 
         response = self.client.delete(url_for("gn_commons.delete_place", id_place=place.id_place))
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.delete(url_for("gn_commons.delete_place", id_place=place.id_place))
         assert response.status_code == 204
         assert not db.session.query(
@@ -463,7 +463,7 @@ class TestCommons:
         assert len(data) == 0
 
     def test_additional_field_admin(self, app, users, module, perm_object):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         app.config["ADDITIONAL_FIELDS"]["IMPLEMENTED_MODULES"] = [module.module_code]
         app.config["ADDITIONAL_FIELDS"]["IMPLEMENTED_OBJECTS"] = [perm_object.code_object]
         form_values = {

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -680,7 +680,7 @@ class TestGNMeta:
         assert datasets["own_dataset"].id_dataset not in filtered_ds
 
     def test_get_dataset_filter_create(self, users, datasets, module):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(
             url_for("gn_meta.get_datasets"),

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -25,7 +25,7 @@ from geonature.core.gn_synthese.models import Synthese
 from geonature.utils.env import db
 
 from .fixtures import *
-from .utils import logged_user_headers, set_logged_user_cookie
+from .utils import logged_user_headers, set_logged_user
 
 
 @pytest.fixture(scope="function")
@@ -166,7 +166,7 @@ class TestGNMeta:
         )  # DS are attached to this AF
 
     def test_create_acquisition_framework(self, users):
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         # Post with only required attributes
         response = self.client.post(
@@ -180,7 +180,7 @@ class TestGNMeta:
         assert response.status_code == 200
 
     def test_create_acquisition_framework_forbidden(self, users):
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
 
         response = self.client.post(url_for("gn_meta.create_acquisition_framework"), data={})
 
@@ -192,27 +192,27 @@ class TestGNMeta:
         response = self.client.delete(url_for("gn_meta.delete_acquisition_framework", af_id=af_id))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
 
         # The user has no rights on METADATA module
         response = self.client.delete(url_for("gn_meta.delete_acquisition_framework", af_id=af_id))
         assert response.status_code == Forbidden.code
         assert "METADATA" in response.json["description"]
 
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         # The user has right on METADATA module, but not on this specific AF
         response = self.client.delete(url_for("gn_meta.delete_acquisition_framework", af_id=af_id))
         assert response.status_code == Forbidden.code
         assert "METADATA" not in response.json["description"]
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         # The AF can not be deleted due to attached DS
         response = self.client.delete(url_for("gn_meta.delete_acquisition_framework", af_id=af_id))
         assert response.status_code == Conflict.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         af_id = acquisition_frameworks["own_af"].id_acquisition_framework
 
         response = self.client.delete(url_for("gn_meta.delete_acquisition_framework", af_id=af_id))
@@ -221,7 +221,7 @@ class TestGNMeta:
     def test_update_acquisition_framework(self, users, acquisition_frameworks):
         new_name = "thenewname"
         af = acquisition_frameworks["own_af"]
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         response = self.client.post(
             url_for(
@@ -236,7 +236,7 @@ class TestGNMeta:
 
     def test_update_acquisition_framework_forbidden(self, users, acquisition_frameworks):
         stranger_user = users["stranger_user"]
-        set_logged_user_cookie(self.client, stranger_user)
+        set_logged_user(self.client, stranger_user)
         af = acquisition_frameworks["own_af"]
 
         response = self.client.post(
@@ -255,7 +255,7 @@ class TestGNMeta:
 
     def test_update_acquisition_framework_forbidden_af(self, users, acquisition_frameworks):
         self_user = users["self_user"]
-        set_logged_user_cookie(self.client, self_user)
+        set_logged_user(self.client, self_user)
         af = acquisition_frameworks["own_af"]
 
         response = self.client.post(
@@ -276,7 +276,7 @@ class TestGNMeta:
         response = self.client.get(url_for("gn_meta.get_acquisition_frameworks"))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(url_for("gn_meta.get_acquisition_frameworks"))
         response = self.client.get(
@@ -293,14 +293,14 @@ class TestGNMeta:
         response = self.client.get(url_for("gn_meta.get_acquisition_frameworks_list"))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(url_for("gn_meta.get_acquisition_frameworks_list"))
         assert response.status_code == 200
 
     def test_filter_acquisition_by_geo(self, synthese_data, users, commune_without_obs):
         # security test already passed in previous tests
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         # get 2 synthese observations in two differents AF and two differents communes
         s1, s2 = synthese_data["p1_af1"], synthese_data["p3_af3"]
@@ -342,7 +342,7 @@ class TestGNMeta:
 
     def test_get_acquisition_frameworks_list_excluded_fields(self, users):
         excluded = ["id_acquisition_framework", "id_digitizer"]
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(
             url_for("gn_meta.get_acquisition_frameworks_list"),
@@ -355,7 +355,7 @@ class TestGNMeta:
     def test_get_acquisition_frameworks_list_excluded_fields_not_nested(self, users):
         excluded = ["id_acquisition_framework", "id_digitizer"]
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(
             url_for("gn_meta.get_acquisition_frameworks_list"),
@@ -372,18 +372,18 @@ class TestGNMeta:
         response = self.client.get(get_af_url)
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
         response = self.client.get(get_af_url)
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.get(get_af_url)
         assert response.status_code == 200
 
     def test_get_acquisition_frameworks_search_af_name(
         self, users, acquisition_frameworks, datasets
     ):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         af1 = acquisition_frameworks["af_1"]
         af2 = acquisition_frameworks["af_2"]
         get_af_url = url_for("gn_meta.get_acquisition_frameworks")
@@ -397,7 +397,7 @@ class TestGNMeta:
     def test_get_acquisition_frameworks_search_ds_name(
         self, users, acquisition_frameworks, datasets
     ):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         ds = datasets["belong_af_1"]
         af1 = acquisition_frameworks["af_1"]
         af2 = acquisition_frameworks["af_2"]
@@ -411,7 +411,7 @@ class TestGNMeta:
         assert af2.id_acquisition_framework not in af_list
 
     def test_get_acquisition_frameworks_search_af_uuid(self, users, acquisition_frameworks):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         af1 = acquisition_frameworks["af_1"]
 
@@ -425,7 +425,7 @@ class TestGNMeta:
         }
 
     def test_get_acquisition_frameworks_search_af_date(self, users, acquisition_frameworks):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         af1 = acquisition_frameworks["af_1"]
 
@@ -441,7 +441,7 @@ class TestGNMeta:
     def test_get_export_pdf_acquisition_frameworks(self, users, acquisition_frameworks):
         af_id = acquisition_frameworks["own_af"].id_acquisition_framework
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         response = self.client.post(
             url_for(
@@ -466,7 +466,7 @@ class TestGNMeta:
         self, users, acquisition_frameworks, datasets, synthese_data
     ):
         af = synthese_data["obs1"].dataset.acquisition_framework
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         response = self.client.get(
             url_for(
@@ -492,7 +492,7 @@ class TestGNMeta:
         # this AF contains at least 2 obs at different locations
         af = synthese_data["p1_af1"].dataset.acquisition_framework
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         response = self.client.get(
             url_for(
@@ -559,27 +559,27 @@ class TestGNMeta:
         response = self.client.delete(url_for("gn_meta.delete_dataset", ds_id=ds_id))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
 
         # The user has no rights on METADATA module
         response = self.client.delete(url_for("gn_meta.delete_dataset", ds_id=ds_id))
         assert response.status_code == Forbidden.code
         assert "METADATA" in response.json["description"]
 
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         # The user has right on METADATA module, but not on this specific DS
         response = self.client.delete(url_for("gn_meta.delete_dataset", ds_id=ds_id))
         assert response.status_code == Forbidden.code
         assert "METADATA" not in response.json["description"]
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         # The DS can not be deleted due to attached rows in synthese
         response = self.client.delete(url_for("gn_meta.delete_dataset", ds_id=ds_id))
         assert response.status_code == Conflict.code
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         ds_id = datasets["orphan_dataset"].id_dataset
 
         response = self.client.delete(url_for("gn_meta.delete_dataset", ds_id=ds_id))
@@ -589,7 +589,7 @@ class TestGNMeta:
         response = self.client.get(url_for("gn_meta.get_datasets"))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(url_for("gn_meta.get_datasets"))
         assert response.status_code == 200
@@ -618,7 +618,7 @@ class TestGNMeta:
         )
 
     def test_list_datasets_mobile(self, users, datasets, acquisition_frameworks):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         headers = Headers()
         headers.add("User-Agent", "okhttp/")
 
@@ -630,7 +630,7 @@ class TestGNMeta:
         response = self.client.post(url_for("gn_meta.create_dataset"))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.post(url_for("gn_meta.create_dataset"))
         assert response.status_code == BadRequest.code
@@ -642,7 +642,7 @@ class TestGNMeta:
         assert response.status_code == Unauthorized.code
 
         stranger_user = users["stranger_user"]
-        set_logged_user_cookie(self.client, stranger_user)
+        set_logged_user(self.client, stranger_user)
         response = self.client.get(url_for("gn_meta.get_dataset", id_dataset=ds.id_dataset))
         assert response.status_code == Forbidden.code
         assert (
@@ -650,12 +650,12 @@ class TestGNMeta:
             == f"User {stranger_user.identifiant} cannot read dataset {ds.id_dataset}"
         )
 
-        set_logged_user_cookie(self.client, users["associate_user"])
+        set_logged_user(self.client, users["associate_user"])
         response = self.client.get(url_for("gn_meta.get_dataset", id_dataset=ds.id_dataset))
         assert response.status_code == 200
 
     def test_get_dataset_filter_active(self, users, datasets, module):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(
             url_for("gn_meta.get_datasets"),
@@ -667,7 +667,7 @@ class TestGNMeta:
         assert expected_ds.issubset(filtered_ds)
 
     def test_get_dataset_filter_module_code(self, users, datasets, module):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(
             url_for("gn_meta.get_datasets"),
@@ -699,7 +699,7 @@ class TestGNMeta:
         assert datasets["own_dataset"].id_dataset not in filtered_ds
 
     def test_get_dataset_search(self, users, datasets, module):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         ds = datasets["with_module_1"]
 
         response = self.client.get(
@@ -714,7 +714,7 @@ class TestGNMeta:
 
     def test_get_dataset_search_uuid(self, users, datasets):
         ds = datasets["own_dataset"]
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(
             url_for("gn_meta.get_datasets"),
@@ -727,7 +727,7 @@ class TestGNMeta:
 
     def test_get_dataset_search_date(self, users, datasets):
         ds = datasets["own_dataset"]
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(
             url_for("gn_meta.get_datasets"),
@@ -746,7 +746,7 @@ class TestGNMeta:
             for af in acquisition_frameworks.values()
             if af.id_acquisition_framework == dataset.id_acquisition_framework
         ][0]
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         # If Acquisition Framework matches, returns all datasets
         response = self.client.get(
@@ -763,7 +763,7 @@ class TestGNMeta:
 
     def test_get_dataset_search_ds_matches(self, users, datasets, acquisition_frameworks):
         dataset = datasets["belong_af_1"]
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         # If Acquisition Framework matches, returns all datasets
         response = self.client.get(
@@ -784,7 +784,7 @@ class TestGNMeta:
             for af in acquisition_frameworks.values()
             if af.id_acquisition_framework == dataset.id_acquisition_framework
         ][0]
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         # If Acquisition Framework matches, returns all datasets
         response = self.client.get(
@@ -802,7 +802,7 @@ class TestGNMeta:
     def test_get_dataset_forbidden_ds(self, users, datasets):
         ds = datasets["own_dataset"]
         self_user = users["self_user"]
-        set_logged_user_cookie(self.client, self_user)
+        set_logged_user(self.client, self_user)
 
         response = self.client.get(url_for("gn_meta.get_dataset", id_dataset=ds.id_dataset))
 
@@ -815,7 +815,7 @@ class TestGNMeta:
     def test_update_dataset(self, users, datasets):
         new_name = "thenewname"
         ds = datasets["own_dataset"]
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         response = self.client.patch(
             url_for("gn_meta.update_dataset", id_dataset=ds.id_dataset),
@@ -826,7 +826,7 @@ class TestGNMeta:
         assert response.json.get("dataset_name") == new_name
 
     def test_update_dataset_not_found(self, users, datasets, unexisted_id):
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         response = self.client.patch(url_for("gn_meta.update_dataset", id_dataset=unexisted_id))
 
@@ -834,7 +834,7 @@ class TestGNMeta:
 
     def test_update_dataset_forbidden(self, users, datasets):
         ds = datasets["own_dataset"]
-        set_logged_user_cookie(self.client, users["stranger_user"])
+        set_logged_user(self.client, users["stranger_user"])
 
         response = self.client.patch(url_for("gn_meta.update_dataset", id_dataset=ds.id_dataset))
 
@@ -849,7 +849,7 @@ class TestGNMeta:
         )
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.post(
             url_for("gn_meta.get_export_pdf_dataset", id_dataset=unexisting_id)
@@ -861,7 +861,7 @@ class TestGNMeta:
         )
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.post(
             url_for("gn_meta.get_export_pdf_dataset", id_dataset=ds.id_dataset)
         )
@@ -875,7 +875,7 @@ class TestGNMeta:
         response = self.client.get(url_for("gn_meta.uuid_report"))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url_for("gn_meta.uuid_report"))
         assert response.status_code == 200
 
@@ -885,7 +885,7 @@ class TestGNMeta:
     ):
         dataset_id = datasets["own_dataset"].id_dataset
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         response = self.client.get(
             url_for("gn_meta.uuid_report"), query_string={"id_dataset": dataset_id}
@@ -910,7 +910,7 @@ class TestGNMeta:
         )
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         response = self.client.get(
             url_for("gn_meta.sensi_report"), query_string={"id_dataset": dataset_id}
@@ -918,7 +918,7 @@ class TestGNMeta:
         assert response.status_code == 200
 
     def test_sensi_report_fail(self, users):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(url_for("gn_meta.sensi_report"))
         # BadRequest because for now id_dataset query is required
@@ -1033,7 +1033,7 @@ class TestGNMeta:
     def test_publish_acquisition_framework_no_data(
         self, mocked_publish_mail, users, acquisition_frameworks
     ):
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         af = acquisition_frameworks["own_af"]
         response = self.client.get(
@@ -1058,7 +1058,7 @@ class TestGNMeta:
     def test_publish_acquisition_framework_with_data(
         self, mocked_publish_mail, users, acquisition_frameworks, synthese_data
     ):
-        set_logged_user_cookie(self.client, users["stranger_user"])
+        set_logged_user(self.client, users["stranger_user"])
         af = acquisition_frameworks["af_1"]
         response = self.client.get(
             url_for(

--- a/backend/geonature/tests/test_notifications.py
+++ b/backend/geonature/tests/test_notifications.py
@@ -18,7 +18,7 @@ from geonature.core.notifications.models import (
 from geonature.core.notifications import utils
 from geonature.tests.fixtures import celery_eager, notifications_enabled
 
-from .utils import set_logged_user_cookie
+from .utils import set_logged_user
 
 log = logging.getLogger()
 
@@ -126,14 +126,14 @@ class TestNotification:
         assert response.status_code == Unauthorized.code
 
         # TEST CONNECTED USER WITHOUT NOTIFICATION
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
         assert len(data) == 0
 
         # TEST CONNECTED USER WITH NOTIFICATION
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.get(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
@@ -149,14 +149,14 @@ class TestNotification:
         assert response.status_code == Unauthorized.code
 
         # TEST CONNECTED USER NO DATA
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
         assert data == 0
 
         # TEST CONNECTED USER
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.get(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
@@ -175,14 +175,14 @@ class TestNotification:
         assert response.status_code == Unauthorized.code
 
         # TEST CONNECTED USER BUT NOTIFICATION DOES NOT EXIST FOR THIS USER
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.post(
             url_for(url, id_notification=notification_data.id_notification)
         )
         assert response.status_code == Forbidden.code
 
         # TEST CONNECTED USER WITH NOTIFICATION
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.post(
             url_for(url, id_notification=notification_data.id_notification)
         )
@@ -198,7 +198,7 @@ class TestNotification:
         assert response.status_code == Unauthorized.code
 
         # TEST CONNECTED USER WITHOUT NOTIFICATION
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.delete(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
@@ -210,7 +210,7 @@ class TestNotification:
         ).scalar()
 
         # TEST CONNECTED USER WITH NOTIFICATION
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.delete(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
@@ -231,13 +231,13 @@ class TestNotification:
         assert response.status_code == Unauthorized.code
 
         # TEST CONNECTED USER
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
         assert len(data) == 0
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.get(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
@@ -269,7 +269,7 @@ class TestNotification:
         response = self.client.post(subscribe_url)
         assert response.status_code == Unauthorized.code, response.data
 
-        set_logged_user_cookie(self.client, role)
+        set_logged_user(self.client, role)
 
         response = self.client.post(subscribe_url)
         assert response.status_code == 200, response.data
@@ -301,7 +301,7 @@ class TestNotification:
         assert response.status_code == Unauthorized.code
 
         # TEST CONNECTED USER WITHOUT RULE
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.delete(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
@@ -313,7 +313,7 @@ class TestNotification:
         ).scalar()
 
         # TEST CONNECTED USER WITH RULE
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.delete(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
@@ -334,7 +334,7 @@ class TestNotification:
         assert response.status_code == Unauthorized.code
 
         # TEST CONNECTED USER
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.get(url_for(url))
         assert response.status_code == 200
         data = response.get_json()
@@ -350,7 +350,7 @@ class TestNotification:
         assert response.status_code == Unauthorized.code
 
         # TEST CONNECTED USER
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.get(url_for(url))
         assert response.status_code == 200
         data = response.get_json()

--- a/backend/geonature/tests/test_pr_occhab.py
+++ b/backend/geonature/tests/test_pr_occhab.py
@@ -16,7 +16,7 @@ from pypn_habref_api.models import Habref
 from pypnnomenclature.models import TNomenclatures
 from utils_flask_sqla_geo.schema import FeatureSchema, FeatureCollectionSchema
 
-from .utils import set_logged_user_cookie
+from .utils import set_logged_user
 from .fixtures import *
 
 occhab = pytest.importorskip("gn_module_occhab")
@@ -117,16 +117,16 @@ class TestOcchab:
         response = self.client.get(url)
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
         response = self.client.get(url)
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url)
         assert response.status_code == 200
         StationSchema(many=True).validate(response.json)
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url, query_string={"format": "geojson"})
         assert response.status_code == 200
         StationSchema(as_geojson=True, many=True).validate(response.json)
@@ -145,15 +145,15 @@ class TestOcchab:
         response = self.client.get(url)
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
         response = self.client.get(url)
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["stranger_user"])
+        set_logged_user(self.client, users["stranger_user"])
         response = self.client.delete(url)
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url)
         assert response.status_code == 200
         response_station = StationSchema(
@@ -205,11 +205,11 @@ class TestOcchab:
         response = self.client.post(url, data=feature)
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
         response = self.client.post(url, data=feature)
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         response = self.client.post(url, data=feature)
         assert response.status_code == 200, response.json
@@ -266,15 +266,15 @@ class TestOcchab:
         response = self.client.post(url, data=feature)
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
         response = self.client.post(url, data=feature)
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["stranger_user"])
+        set_logged_user(self.client, users["stranger_user"])
         response = self.client.post(url, data=feature)
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
 
         # Try modifying id_station
         id_station = station.id_station
@@ -361,15 +361,15 @@ class TestOcchab:
         response = self.client.delete(url)
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
         response = self.client.delete(url)
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["stranger_user"])
+        set_logged_user(self.client, users["stranger_user"])
         response = self.client.delete(url)
         assert response.status_code == Forbidden.code
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.delete(url)
         assert response.status_code == 204
         assert not db.session.query(
@@ -379,6 +379,6 @@ class TestOcchab:
     def test_get_default_nomenclatures(self, users):
         response = self.client.get(url_for("occhab.get_default_nomenclatures"))
         assert response.status_code == Unauthorized.code
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url_for("occhab.get_default_nomenclatures"))
         assert response.status_code == 200

--- a/backend/geonature/tests/test_reports.py
+++ b/backend/geonature/tests/test_reports.py
@@ -10,7 +10,7 @@ from geonature.core.notifications.models import Notification, NotificationRule
 from geonature.utils.env import db
 
 from .fixtures import *
-from .utils import logged_user_headers, set_logged_user_cookie
+from .utils import logged_user_headers, set_logged_user
 
 
 def add_notification_rule(user):
@@ -55,7 +55,7 @@ class TestReports:
         response = self.client.post(url_for(url), data=data)
         assert response.status_code == 401
         # TEST NO DATA
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.post(url_for(url))
         assert response.status_code == BadRequest.code
         # TEST VALID - ADD DISCUSSION
@@ -108,7 +108,7 @@ class TestReports:
         response = self.client.delete(url_for(url, id_report=discussionReportId))
         assert response.status_code == 401
         # NOT FOUND
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.delete(url_for(url, id_report=id_report_ko))
         assert response.status_code == NotFound.code
         # SUCCESS - NOT DELETE WITH DISCUSSION
@@ -126,7 +126,7 @@ class TestReports:
     def test_list_reports(self, reports_data, synthese_data, users):
         url = "gn_synthese.list_reports"
         # TEST GET WITHOUT REQUIRED ID SYNTHESE
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.get(url_for(url))
         assert response.status_code == NotFound.code
         ids = [s.id_synthese for s in synthese_data.values()]
@@ -154,7 +154,7 @@ class TestReports:
 class TestReportsNotifications:
     def post_comment(self, synthese, user):
         """Post a comment on a synthese row as a user"""
-        set_logged_user_cookie(self.client, user)
+        set_logged_user(self.client, user)
         url = "gn_synthese.create_report"
         id_synthese = synthese.id_synthese
         data = {"item": id_synthese, "content": "comment 4", "type": "discussion"}

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -349,7 +349,7 @@ class TestSynthese:
         module_label_to_filter,
         expected_length,
     ):
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         id_modules_selected = []
         for module in modules:

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -15,7 +15,7 @@ from geonature.utils.env import db
 from geonature.core.gn_meta.models import TDatasets
 from geonature.core.gn_synthese.models import Synthese, TSources, VSyntheseForWebApp
 
-from pypnusershub.tests.utils import logged_user_headers, set_logged_user_cookie
+from pypnusershub.tests.utils import logged_user_headers, set_logged_user
 from ref_geo.models import BibAreasTypes, LAreas
 from apptax.tests.fixtures import noms_example, attribut_example
 from apptax.taxonomie.models import Taxref
@@ -154,14 +154,14 @@ class TestSynthese:
             assert sq.filter_by_scope(0).all() == []
 
     def test_list_sources(self, source, users):
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
         response = self.client.get(url_for("gn_synthese.get_sources"))
         assert response.status_code == 200
         data = response.get_json()
         assert len(data) > 0
 
     def test_get_defaut_nomenclatures(self, users):
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
         response = self.client.get(url_for("gn_synthese.getDefaultsNomenclatures"))
         assert response.status_code == 200
 
@@ -176,7 +176,7 @@ class TestSynthese:
         r = self.client.get(url)
         assert r.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         r = self.client.get(url)
         assert r.status_code == 200
@@ -303,7 +303,7 @@ class TestSynthese:
         assert r.status_code == 200
 
     def test_get_observations_for_web_filter_comment(self, users, synthese_data, taxon_attribut):
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         # Post a comment
         url = "gn_synthese.create_report"
@@ -321,7 +321,7 @@ class TestSynthese:
         assert id_synthese in (feature["properties"]["id"] for feature in r.json["features"])
 
     def test_get_observations_for_web_filter_id_source(self, users, synthese_data, source):
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
         id_source = source.id_source
 
         url = url_for("gn_synthese.get_observations_for_web")
@@ -377,7 +377,7 @@ class TestSynthese:
     def test_get_observations_for_web_filter_observers(
         self, users, synthese_for_observers, observer_input, expected_length_synthese
     ):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         filters = {"observers": observer_input}
         r = self.client.get(url_for("gn_synthese.get_observations_for_web"), json=filters)
@@ -386,7 +386,7 @@ class TestSynthese:
         assert len(r.json["features"]) == expected_length_synthese
 
     def test_get_synthese_data_cruved(self, app, users, synthese_data, datasets):
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(
             url_for("gn_synthese.get_observations_for_web"), query_string={"limit": 100}
@@ -403,7 +403,7 @@ class TestSynthese:
 
     def test_get_synthese_data_aggregate(self, users, datasets, synthese_data):
         # Test geometry aggregation
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.post(
             url_for("gn_synthese.get_observations_for_web"),
             query_string={
@@ -422,7 +422,7 @@ class TestSynthese:
 
     def test_get_synthese_data_aggregate_by_areas(self, users, datasets, synthese_data):
         # Test geometry aggregation
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.get(
             url_for("gn_synthese.get_observations_for_web"),
             query_string={
@@ -443,7 +443,7 @@ class TestSynthese:
         """
         Test avec un cruved R2 qui join sur cor_synthese_observers
         """
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(url_for("gn_synthese.get_observations_for_web"))
         data = response.get_json()
@@ -454,7 +454,7 @@ class TestSynthese:
         assert response.status_code == 200
 
     def test_export(self, users):
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         # csv
         response = self.client.post(
@@ -567,7 +567,7 @@ class TestSynthese:
         ]
 
         def assert_export_results(user, expected_id_synthese_list):
-            set_logged_user_cookie(self.client, user)
+            set_logged_user(self.client, user)
             response = self.client.post(
                 url_for("gn_synthese.export_observations_web"),
                 json=list_id_synthese,
@@ -690,7 +690,7 @@ class TestSynthese:
         index_colummn_cd_ref = expected_columns_exports.index('"cd_ref"')
 
         def assert_export_taxons_results(user, set_expected_cd_ref):
-            set_logged_user_cookie(self.client, user)
+            set_logged_user(self.client, user)
 
             response = self.client.post(
                 url_for("gn_synthese.export_taxon_web"),
@@ -780,7 +780,7 @@ class TestSynthese:
         index_column_cd_nom = expected_columns_exports.index('"cd_nom"')
 
         def assert_export_status_results(user, set_expected_cd_ref):
-            set_logged_user_cookie(self.client, user)
+            set_logged_user(self.client, user)
 
             response = self.client.post(
                 url_for("gn_synthese.export_status"),
@@ -851,7 +851,7 @@ class TestSynthese:
 
         # TODO: assert that some data is excluded from the response
         def assert_export_metadata_results(user, dict_expected_datasets):
-            set_logged_user_cookie(self.client, user)
+            set_logged_user(self.client, user)
 
             response = self.client.post(
                 url_for("gn_synthese.export_metadata"),
@@ -964,7 +964,7 @@ class TestSynthese:
         assert_export_metadata_results(user, dict_expected_datasets)
 
     def test_general_stat(self, users):
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(url_for("gn_synthese.general_stats"))
 
@@ -976,44 +976,44 @@ class TestSynthese:
         )
         assert response.status_code == 401
 
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
         response = self.client.get(
             url_for("gn_synthese.get_one_synthese", id_synthese=synthese_data["obs1"].id_synthese)
         )
         assert response.status_code == 403
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         not_existing = db.session.query(func.max(Synthese.id_synthese)).scalar() + 1
         response = self.client.get(
             url_for("gn_synthese.get_one_synthese", id_synthese=not_existing)
         )
         assert response.status_code == 404
 
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         response = self.client.get(
             url_for("gn_synthese.get_one_synthese", id_synthese=synthese_data["obs1"].id_synthese)
         )
         assert response.status_code == 200
 
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
         response = self.client.get(
             url_for("gn_synthese.get_one_synthese", id_synthese=synthese_data["obs1"].id_synthese)
         )
         assert response.status_code == 200
 
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(
             url_for("gn_synthese.get_one_synthese", id_synthese=synthese_data["obs1"].id_synthese)
         )
         assert response.status_code == 200
 
-        set_logged_user_cookie(self.client, users["associate_user"])
+        set_logged_user(self.client, users["associate_user"])
         response = self.client.get(
             url_for("gn_synthese.get_one_synthese", id_synthese=synthese_data["obs1"].id_synthese)
         )
         assert response.status_code == 200
 
-        set_logged_user_cookie(self.client, users["stranger_user"])
+        set_logged_user(self.client, users["stranger_user"])
         response = self.client.get(
             url_for("gn_synthese.get_one_synthese", id_synthese=synthese_data["obs1"].id_synthese)
         )
@@ -1021,7 +1021,7 @@ class TestSynthese:
 
     def test_color_taxon(self, synthese_data, users):
         # Note: require grids 5×5!
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
         response = self.client.get(url_for("gn_synthese.get_color_taxon"))
         assert response.status_code == 200
 
@@ -1062,7 +1062,7 @@ class TestSynthese:
         response = self.client.get(url_for("gn_synthese.get_taxa_distribution"))
         assert response.status_code == Unauthorized.code
 
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
         response = self.client.get(url_for("gn_synthese.get_taxa_distribution"))
         assert response.status_code == 200
         assert len(response.json)
@@ -1095,7 +1095,7 @@ class TestSynthese:
         assert len(response.json)
 
     def test_get_taxa_count(self, synthese_data, users):
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(url_for("gn_synthese.get_taxa_count"))
 
@@ -1104,7 +1104,7 @@ class TestSynthese:
     def test_get_taxa_count_id_dataset(self, synthese_data, users, datasets, unexisted_id):
         id_dataset = datasets["own_dataset"].id_dataset
         url = "gn_synthese.get_taxa_count"
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(url_for(url), query_string={"id_dataset": id_dataset})
         response_empty = self.client.get(url_for(url), query_string={"id_dataset": unexisted_id})
@@ -1114,7 +1114,7 @@ class TestSynthese:
 
     def test_get_observation_count(self, synthese_data, users):
         nb_observations = len(synthese_data)
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(url_for("gn_synthese.get_observation_count"))
 
@@ -1124,7 +1124,7 @@ class TestSynthese:
         id_dataset = datasets["own_dataset"].id_dataset
         nb_observations = len([s for s in synthese_data.values() if s.id_dataset == id_dataset])
         url = "gn_synthese.get_observation_count"
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(url_for(url), query_string={"id_dataset": id_dataset})
         response_empty = self.client.get(url_for(url), query_string={"id_dataset": unexisted_id})
@@ -1133,7 +1133,7 @@ class TestSynthese:
         assert response_empty.json == 0
 
     def test_get_bbox(self, synthese_data, users):
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(url_for("gn_synthese.get_bbox"))
 
@@ -1143,7 +1143,7 @@ class TestSynthese:
     def test_get_bbox_id_dataset(self, synthese_data, users, datasets, unexisted_id):
         id_dataset = datasets["own_dataset"].id_dataset
         url = "gn_synthese.get_bbox"
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(url_for(url), query_string={"id_dataset": id_dataset})
         assert response.status_code == 200
@@ -1156,7 +1156,7 @@ class TestSynthese:
     def test_get_bbox_id_source(self, synthese_data, users, source):
         id_source = source.id_source
         url = "gn_synthese.get_bbox"
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(url_for(url), query_string={"id_source": id_source})
 
@@ -1165,7 +1165,7 @@ class TestSynthese:
 
     def test_get_bbox_id_source_empty(self, users, unexisted_id_source):
         url = "gn_synthese.get_bbox"
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(url_for(url), query_string={"id_source": unexisted_id_source})
 
@@ -1175,7 +1175,7 @@ class TestSynthese:
     def test_observation_count_per_column(self, users, synthese_data):
         column_name_dataset = "id_dataset"
         column_name_cd_nom = "cd_nom"
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response_dataset = self.client.get(
             url_for("gn_synthese.observation_count_per_column", column=column_name_dataset)
@@ -1225,7 +1225,7 @@ class TestSynthese:
     def test_get_autocomplete_taxons_synthese(self, synthese_data, users):
         seach_name = synthese_data["obs1"].nom_cite
 
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(
             url_for("gn_synthese.get_autocomplete_taxons_synthese"),

--- a/backend/geonature/tests/test_synthese_logs.py
+++ b/backend/geonature/tests/test_synthese_logs.py
@@ -11,7 +11,7 @@ from werkzeug.datastructures import MultiDict
 from geonature.utils.env import db
 from geonature.core.gn_synthese.models import SyntheseLogEntry
 
-from pypnusershub.tests.utils import set_logged_user_cookie
+from pypnusershub.tests.utils import set_logged_user
 
 from .fixtures import *
 
@@ -49,7 +49,7 @@ class TestSyntheseLogs:
 
     def test_list_synthese_log_entries(self, users, synthese_data):
         url = url_for("gn_synthese.list_synthese_log_entries")
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         created_obs = synthese_data["obs1"]
         updated_obs = synthese_data["obs2"]
@@ -74,7 +74,7 @@ class TestSyntheseLogs:
 
     def test_list_synthese_log_entries_sort(self, users, synthese_data):
         url = url_for("gn_synthese.list_synthese_log_entries")
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         response = self.client.get(url, query_string={"sort": "invalid"})
         assert response.status_code == BadRequest.code, response.json
@@ -90,7 +90,7 @@ class TestSyntheseLogs:
 
     def test_list_synthese_log_entries_filter_last_action(self, users, synthese_data):
         url = url_for("gn_synthese.list_synthese_log_entries")
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
 
         created_obs = synthese_data["obs1"]
         updated_obs = synthese_data["obs2"]

--- a/backend/geonature/tests/test_users.py
+++ b/backend/geonature/tests/test_users.py
@@ -6,7 +6,7 @@ from pypnusershub.db.models import Organisme
 
 # Apparently: need to import both?
 from geonature.tests.fixtures import acquisition_frameworks, datasets, module
-from geonature.tests.utils import set_logged_user_cookie
+from geonature.tests.utils import set_logged_user
 from geonature.utils.env import db
 
 
@@ -21,7 +21,7 @@ def organisms():
 @pytest.mark.usefixtures("client_class", "temporary_transaction")
 class TestUsers:
     def test_get_organismes(self, users, organisms):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(url_for("users.get_organismes"))
 
@@ -32,14 +32,14 @@ class TestUsers:
 
     @pytest.mark.skip()
     def test_get_organismes_no_right(self, users):
-        set_logged_user_cookie(self.client, users["noright_user"])
+        set_logged_user(self.client, users["noright_user"])
 
         response = self.client.get(url_for("users.get_organismes"))
 
         assert response.status_code == 403
 
     def test_get_organisme_order_by(self, users, organisms):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
         order_by_column = "nom_organisme"
 
         response = self.client.get(
@@ -55,7 +55,7 @@ class TestUsers:
 
     def test_get_role(self, users):
         self_user = users["self_user"]
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(url_for("users.get_role", id_role=self_user.id_role))
 
@@ -64,7 +64,7 @@ class TestUsers:
 
     def test_get_roles(self, users):
         noright_user = users["noright_user"]
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(url_for("users.get_roles"))
 
@@ -75,7 +75,7 @@ class TestUsers:
         pass
 
     def test_get_roles_order_by(self, users):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(
             url_for("users.get_roles"), query_string={"orderby": "identifiant"}
@@ -94,7 +94,7 @@ class TestUsers:
 
     def test_get_organismes_jdd(self, users, datasets):
         # Need to have a dataset to have the organism...
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(url_for("users.get_organismes_jdd"))
         for org in response.json:
@@ -104,7 +104,7 @@ class TestUsers:
         ]
 
     def test_get_organismes_jdd_no_dataset(self, users):
-        set_logged_user_cookie(self.client, users["admin_user"])
+        set_logged_user(self.client, users["admin_user"])
 
         response = self.client.get(url_for("users.get_organismes_jdd"))
 

--- a/backend/geonature/tests/test_validation.py
+++ b/backend/geonature/tests/test_validation.py
@@ -11,7 +11,7 @@ from geonature.utils.config import config
 from pypnnomenclature.models import TNomenclatures
 
 from .fixtures import *
-from .utils import set_logged_user_cookie
+from .utils import set_logged_user
 
 
 gn_module_validation = pytest.importorskip("gn_module_validation")
@@ -25,7 +25,7 @@ class TestValidation:
     def test_get_synthese_data(self, users, synthese_data):
         response = self.client.get(url_for("validation.get_synthese_data"))
         assert response.status_code == Unauthorized.code
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
         response = self.client.get(url_for("validation.get_synthese_data"))
         assert response.status_code == 200
         assert len(response.json["features"]) >= len(synthese_data)
@@ -33,12 +33,12 @@ class TestValidation:
     def test_get_status_names(self, users, synthese_data):
         response = self.client.get(url_for("validation.get_statusNames"))
         assert response.status_code == Unauthorized.code
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url_for("validation.get_statusNames"))
         assert response.status_code == 200
 
     def test_add_validation_status(self, users, synthese_data):
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         synthese = synthese_data["obs1"]
         id_nomenclature_valid_status = TNomenclatures.query.filter(
             sa.and_(
@@ -69,7 +69,7 @@ class TestValidation:
         assert abs(datetime.fromisoformat(response.json) - validation_date) < timedelta(seconds=2)
 
     def test_get_validation_history(self, users, synthese_data):
-        set_logged_user_cookie(self.client, users["user"])
+        set_logged_user(self.client, users["user"])
         response = self.client.get(url_for("gn_commons.get_hist", uuid_attached_row="invalid"))
         assert response.status_code == BadRequest.code
         s = next(filter(lambda s: s.unique_id_sinp, synthese_data.values()))

--- a/backend/geonature/tests/utils.py
+++ b/backend/geonature/tests/utils.py
@@ -1,8 +1,8 @@
 from flask import url_for
 
 from pypnusershub.tests.utils import (
-    set_logged_user_cookie,
-    unset_logged_user_cookie,
+    set_logged_user,
+    unset_logged_user,
     logged_user_headers,
 )
 

--- a/backend/geonature/utils/config.py
+++ b/backend/geonature/utils/config.py
@@ -46,6 +46,6 @@ config = ChainMap({}, config_programmatic, config_backend, config_frontend, conf
 
 api_uri = urlsplit(config["API_ENDPOINT"])
 if "APPLICATION_ROOT" not in config:
-    config["APPLICATION_ROOT"] = api_uri.path
+    config["APPLICATION_ROOT"] = api_uri.path or "/"
 if "PREFERRED_URL_SCHEME" not in config:
     config["PREFERRED_URL_SCHEME"] = api_uri.scheme

--- a/backend/requirements-dependencies.in
+++ b/backend/requirements-dependencies.in
@@ -1,4 +1,4 @@
-pypnusershub>=1.6.11,<2
+pypnusershub>=1.6.11
 pypnnomenclature>=1.5.4,<2
 pypn_habref_api>=0.3.2,<1
 utils-flask-sqlalchemy-geo>=0.2.8,<1

--- a/backend/requirements-dependencies.in
+++ b/backend/requirements-dependencies.in
@@ -1,4 +1,4 @@
-pypnusershub>=1.6.11
+pypnusershub>=2.0.0,<3
 pypnnomenclature>=1.5.4,<2
 pypn_habref_api>=0.3.2,<1
 utils-flask-sqlalchemy-geo>=0.2.8,<1

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -17,13 +17,10 @@
     #   -r requirements-submodules.in
     #   pypnnomenclature
     #   taxhub
-    #   usershub
 -e file:dependencies/TaxHub#egg=taxhub
     # via
     #   -r requirements-submodules.in
     #   pypnnomenclature
--e file:dependencies/UsersHub#egg=usershub
-    # via -r requirements-submodules.in
 -e file:dependencies/Utils-Flask-SQLAlchemy#egg=utils-flask-sqlalchemy
     # via
     #   -r requirements-submodules.in
@@ -54,11 +51,11 @@ bcrypt==4.0.1
     # via pypnusershub
 billiard==3.6.4.0
     # via celery
-blinker==1.6.2
+blinker==1.6.3
     # via flask-mail
-boto3==1.28.57
+boto3==1.28.70
     # via taxhub
-botocore==1.31.57
+botocore==1.31.70
     # via
     #   boto3
     #   s3transfer
@@ -81,7 +78,7 @@ cffi==1.15.1
     #   cairocffi
     #   cryptography
     #   weasyprint
-charset-normalizer==3.2.0
+charset-normalizer==3.3.1
     # via requests
 click==8.1.7
     # via
@@ -104,20 +101,14 @@ click-repl==0.3.0
     # via celery
 cligj==0.7.2
     # via fiona
-cryptography==41.0.4
+cryptography==41.0.5
     # via authlib
 cssselect2==0.7.0
     # via
     #   cairosvg
     #   weasyprint
-decorator==5.1.1
-    # via validators
 defusedxml==0.7.1
     # via cairosvg
-dnspython==2.3.0
-    # via email-validator
-email-validator==2.0.0.post2
-    # via wtforms-components
 fiona==1.8.22
     # via
     #   -r requirements-common.in
@@ -127,6 +118,7 @@ flask==2.2.5
     #   -r requirements-common.in
     #   flask-admin
     #   flask-cors
+    #   flask-login
     #   flask-mail
     #   flask-marshmallow
     #   flask-migrate
@@ -138,7 +130,6 @@ flask==2.2.5
     #   pypnnomenclature
     #   pypnusershub
     #   taxhub
-    #   usershub
     #   utils-flask-sqlalchemy
 flask-admin==1.6.1
     # via
@@ -148,6 +139,8 @@ flask-cors==4.0.0
     # via
     #   -r requirements-common.in
     #   taxhub
+flask-login==0.6.2
+    # via pypnusershub
 flask-mail==0.9.1
     # via -r requirements-common.in
 flask-marshmallow==0.14.0
@@ -162,7 +155,6 @@ flask-migrate==4.0.5
     #   pypn-habref-api
     #   pypnnomenclature
     #   taxhub
-    #   usershub
     #   utils-flask-sqlalchemy
 flask-sqlalchemy==2.5.1
     # via
@@ -173,14 +165,11 @@ flask-sqlalchemy==2.5.1
     #   pypnnomenclature
     #   pypnusershub
     #   taxhub
-    #   usershub
     #   utils-flask-sqlalchemy
 flask-weasyprint==1.0.0
     # via -r requirements-common.in
 flask-wtf==1.1.1
-    # via
-    #   -r requirements-common.in
-    #   usershub
+    # via -r requirements-common.in
 geoalchemy2==0.11.1
     # via utils-flask-sqlalchemy-geo
 geojson==3.0.1
@@ -191,13 +180,10 @@ gunicorn==21.2.0
     # via
     #   -r requirements-common.in
     #   taxhub
-    #   usershub
 html5lib==1.1
     # via weasyprint
 idna==3.4
-    # via
-    #   email-validator
-    #   requests
+    # via requests
 importlib-metadata==4.13.0 ; python_version < "3.10"
     # via
     #   -r requirements-common.in
@@ -213,10 +199,6 @@ importlib-metadata==4.13.0 ; python_version < "3.10"
     #   redis
 importlib-resources==5.12.0
     # via alembic
-infinity==1.5
-    # via intervals
-intervals==0.9.2
-    # via wtforms-components
 itsdangerous==2.1.2
     # via
     #   flask
@@ -239,7 +221,6 @@ markupsafe==2.1.3
     #   mako
     #   werkzeug
     #   wtforms
-    #   wtforms-components
 marshmallow==3.19.0
     # via
     #   -r requirements-common.in
@@ -257,11 +238,10 @@ marshmallow-sqlalchemy==0.28.2
     #   pypnnomenclature
     #   pypnusershub
     #   taxhub
-    #   usershub
     #   utils-flask-sqlalchemy-geo
 munch==4.0.0
     # via fiona
-packaging==23.1
+packaging==23.2
     # via
     #   -r requirements-common.in
     #   geoalchemy2
@@ -276,7 +256,7 @@ pillow==9.5.0
     #   weasyprint
 prompt-toolkit==3.0.39
     # via click-repl
-psycopg2==2.9.8
+psycopg2==2.9.9
     # via
     #   -r requirements-common.in
     #   pypn-habref-api
@@ -284,7 +264,6 @@ psycopg2==2.9.8
     #   pypnnomenclature
     #   pypnusershub
     #   taxhub
-    #   usershub
 pycparser==2.21
     # via cffi
 pyphen==0.14.0
@@ -293,7 +272,6 @@ python-dateutil==2.8.2
     # via
     #   -r requirements-common.in
     #   botocore
-    #   usershub
     #   utils-flask-sqlalchemy
 python-dotenv==0.21.1
     # via
@@ -301,7 +279,6 @@ python-dotenv==0.21.1
     #   pypn-ref-geo
     #   pypnnomenclature
     #   taxhub
-    #   usershub
 pytz==2023.3.post1
     # via celery
 redis==5.0.1
@@ -323,7 +300,6 @@ six==1.16.0
     #   flask-marshmallow
     #   html5lib
     #   python-dateutil
-    #   wtforms-components
 sqlalchemy==1.3.24
     # via
     #   -r requirements-common.in
@@ -352,19 +328,17 @@ typing-extensions==4.7.1
     #   async-timeout
     #   importlib-metadata
     #   redis
-urllib3==1.26.16
+urllib3==1.26.18
     # via
     #   botocore
     #   requests
     #   taxhub
-validators==0.20.0
-    # via wtforms-components
 vine==5.0.0
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.7
+wcwidth==0.2.8
     # via prompt-toolkit
 weasyprint==52.5
     # via
@@ -376,17 +350,16 @@ webencodings==0.5.1
     #   html5lib
     #   tinycss2
 werkzeug==2.2.3
-    # via flask
+    # via
+    #   flask
+    #   flask-login
+    #   pypnusershub
 wtforms==3.0.1
     # via
     #   -r requirements-common.in
     #   flask-admin
     #   flask-wtf
-    #   usershub
-    #   wtforms-components
     #   wtforms-sqlalchemy
-wtforms-components==0.10.5
-    # via usershub
 wtforms-sqlalchemy==0.3
     # via -r requirements-common.in
 xmltodict==0.13.0

--- a/backend/requirements-submodules.in
+++ b/backend/requirements-submodules.in
@@ -5,4 +5,3 @@
 -e file:dependencies/Utils-Flask-SQLAlchemy#egg=utils-flask-sqlalchemy
 -e file:dependencies/Utils-Flask-SQLAlchemy-Geo#egg=utils-flask-sqlalchemy-geo
 -e file:dependencies/RefGeo#egg=pypn-ref-geo
--e file:dependencies/UsersHub#egg=usershub

--- a/frontend/src/app/routing/auth-guard.service.ts
+++ b/frontend/src/app/routing/auth-guard.service.ts
@@ -21,7 +21,7 @@ export class AuthGuard implements CanActivate, CanActivateChild {
     const configService = this._injector.get(ConfigService);
     const routingService = this._injector.get(RoutingService);
 
-    if (authService.getToken() === null) {
+    if (!authService.isLoggedIn()) {
       if (
         route.queryParams.access &&
         route.queryParams.access === 'public' &&

--- a/frontend/src/app/services/http.interceptor.ts
+++ b/frontend/src/app/services/http.interceptor.ts
@@ -68,6 +68,13 @@ export class MyCustomInterceptor implements HttpInterceptor {
         withCredentials: true,
       });
     }
+    // Pass JWT in header for each request
+    const idToken = localStorage.getItem('gn_id_token');
+    if (idToken) {
+      request = request.clone({
+        headers: request.headers.set('Authorization', 'Bearer ' + idToken),
+      });
+    }
 
     // pass on the modified request object
     // and intercept error


### PR DESCRIPTION
Abandon du système d'authentification par cookie. Le token d'authentification (JWT) est maintenant passé dans chaque appel à l'API dans le header HTTP "Authorization Bearer". Il est aussi fourni par la route de `login` du sous module d'authentification et stocké dans le localStorage (voir : https://github.com/PnX-SI/UsersHub-authentification-module/pull/64)
Fix : #2161 #490 #2574