### PR TITLE
fix(install): add gettext linux package for envsubst command

### DIFF
--- a/install/install_all/install_all.sh
+++ b/install/install_all/install_all.sh
@@ -57,7 +57,7 @@ echo "############### Installation des paquets systèmes ###############"
 
 # Installing required environment for GeoNature and TaxHub
 echo "Installation de l'environnement logiciel..."
-sudo apt-get install -y unzip git postgresql-postgis postgis python3-pip python3-venv python3-dev libpq-dev libgdal-dev libffi-dev libpangocairo-1.0-0 apache2 redis || exit 1
+sudo apt-get install -y unzip git postgresql-postgis postgis python3-pip python3-venv python3-dev libpq-dev libgdal-dev libffi-dev libpangocairo-1.0-0 apache2 redis gettext-base || exit 1
 
 if [ "${mode}" = "dev" ]; then
     sudo apt-get install -y xvfb || exit 1


### PR DESCRIPTION
Fixes an issue occurring during installation of GeoNature : `envsubst: command not found`.