### PR TITLE
feat(metadata): add custo label button and remove link, export PDF closed AF

### DIFF
--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -152,7 +152,6 @@ class HomeConfig(Schema):
 class MetadataConfig(Schema):
     NB_AF_DISPLAYED = fields.Integer(load_default=50, validate=OneOf([10, 25, 50, 100]))
     ENABLE_CLOSE_AF = fields.Boolean(load_default=False)
-    AF_SHEET_CLOSED_LINK_NAME = fields.String(load_default="Lien du certificat de dépôt")
     CLOSED_AF_TITLE = fields.String(load_default="")
     AF_PDF_TITLE = fields.String(load_default="Cadre d'acquisition: ")
     DS_PDF_TITLE = fields.String(load_default="")

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -152,6 +152,7 @@ class HomeConfig(Schema):
 class MetadataConfig(Schema):
     NB_AF_DISPLAYED = fields.Integer(load_default=50, validate=OneOf([10, 25, 50, 100]))
     ENABLE_CLOSE_AF = fields.Boolean(load_default=False)
+    LABEL_BUTTON_EXPORT_PDF_CLOSED_AF = fields.String(load_default="Export PDF")
     CLOSED_AF_TITLE = fields.String(load_default="")
     AF_PDF_TITLE = fields.String(load_default="Cadre d'acquisition: ")
     DS_PDF_TITLE = fields.String(load_default="")

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -560,6 +560,8 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
     NB_AF_DISPLAYED = 100
     # activer la fonctionalité de dépot/publication
     ENABLE_CLOSE_AF = false
+    # Paramétrer le label du bouton d'export PDF pour un CA clôturé
++   LABEL_BUTTON_EXPORT_PDF_CLOSED_AF = "Export PDF"
 
     AF_PDF_TITLE = ""
     DS_PDF_TITLE = ""

--- a/frontend/cypress/fixtures/config.json
+++ b/frontend/cypress/fixtures/config.json
@@ -171,7 +171,6 @@
     "DS_PDF_TITLE": "",
     "AF_PDF_TITLE": "Cadre d'acquisition: ",
     "MAIL_CONTENT_AF_CLOSED_GREETINGS": "",
-    "AF_SHEET_CLOSED_LINK_NAME": "Lien du certificat de d\u00e9p\u00f4t",
     "NB_AF_DISPLAYED": 50,
     "MAIL_CONTENT_AF_CLOSED_URL": ""
   },

--- a/frontend/src/app/metadataModule/af/af-card.component.html
+++ b/frontend/src/app/metadataModule/af/af-card.component.html
@@ -36,8 +36,8 @@
     <div class="col-4">
       <div class="card">
         <div class="card-body">
-          <button mat-raised-button color="primary" (click)="getPdf()">
-            Export PDF
+          <button mat-raised-button color="primary" (click)="getPdf()" *ngIf="af != null">
+            {{ af.opened ? 'Export PDF' : config.METADATA.LABEL_BUTTON_EXPORT_PDF_CLOSED_AF }}
             <mat-icon>file_download</mat-icon>
           </button>
           <br />

--- a/frontend/src/app/metadataModule/af/af-card.component.html
+++ b/frontend/src/app/metadataModule/af/af-card.component.html
@@ -41,18 +41,6 @@
             <mat-icon>file_download</mat-icon>
           </button>
           <br />
-          <span *ngIf="!af?.opened">
-            <b> {{ config.METADATA.AF_SHEET_CLOSED_LINK_NAME }} </b> :
-            <a
-              href="{{ config.API_ENDPOINT }}/meta/acquisition_frameworks/export_pdf/{{
-                af?.id_acquisition_framework
-              }}"
-            >
-              {{ config.API_ENDPOINT }}/meta/acquisition_frameworks/export_pdf/{{
-                af?.id_acquisition_framework
-              }}</a
-            >
-          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# ⚠️ Développement non retenu, car besoin de garder un lien visible pour l'export PDF du CA ▶️ Correction du lien plutôt, avec PR suivante : #2616 

### Permissions manquantes pour fermer un CA

⚠️ Actuellement, sur `develop` au niveau du commit [`f89c72ac93e1c2cedf2e099f3b5d96529017d3bc`](https://github.com/PnX-SI/GeoNature/commit/f89c72ac93e1c2cedf2e099f3b5d96529017d3bc), la route appelée pour fermer un CA nécessite que l'utilisateur aie un scope E>1 pour ("METADATA", "ALL"). Toutefois, suite à l'évolution récente des permissions (https://github.com/PnX-SI/GeoNature/pull/2487#issuecomment-1517899647), il n'y a pas de permission disponible déclarée (dans le cadre de la migration suivante : https://github.com/PnX-SI/GeoNature/commit/969a1a0a0792bfbfc729b81b03c955308a79a749#diff-08f76b4f22a15c6a1b07ca3965fb1b5d46ebf7772409ab0225bb9bcb4da59f82) pour le tuple (module_code="METADATA", object_code="ALL", action_code="E"). Toute permission pour ce tuple (METADATA, ALL, E) est, de plus, supprimée avec cette migration. 

[➡️](https://emojiterra.com/fr/fleche-droite/) Contournement ponctuel : Ajouter directement, en base de données, la permission nécessaire, dans la table `gn_permissions.t_permissions`

[➡️](https://emojiterra.com/fr/fleche-droite/) Perspective : Reprendre la cohérence entre les routes API du module METADATA et les permissions disponibles déclarées : revoir les permissions utilisées pour chaque route (notamment pour les routes qui utilisent l'action E) / compléter la table `t_permissions_available` / utiliser le décorateur `@permissions.permissions_required`, plutôt que `@permissions.check_cruved_scope`.

----

### Tests frontend cassés

⚠️ Les tests frontend qui sont en fail le sont depuis ce commit sur la branche develop : https://github.com/PnX-SI/GeoNature/commit/c460c1f5760d116be3c59140c346f42385a88c70. 

[➡️](https://emojiterra.com/fr/fleche-droite/) Perspective : corriger les tests frontend

## Description

Two evolutions, for the "Export PDF" section in the detail card of an AF (Acquisition Framework) :
- [x] Remove the broken link used to export PDF for closed acquisition framework sheet report : the link was no longer working in 2.12
- [x] Add a config parameter to customize the label of the button "Export PDF" for a closed AF

## Comment tester

Avec GeoNature en 2.12.3+

1. Avoir un CA, avec au moins 1 JDD associé, et au moins 1 observation dans ce JDD.
2. Accéder à la page de détail du CA, et constater qu'il n'y pas de lien visible en dessous du bouton "Export PDF"
3. Clôturer le CA, et constater que le label du bouton est toujours à "Export PDF", valeur par défaut pour un CA clôturé
4. Ajouter la configuration suivante dans le fichier de configuration `geonature/config/geonature_config.toml` : 
```
# Configuration Métadonnées
[METADATA]
    ENABLE_CLOSE_AF = true
    CLOSED_AF_TITLE = "Certificat de dépôt"
    LABEL_BUTTON_EXPORT_PDF_CLOSED_AF = "Certificat de dépôt"
```
5. Accéder à la page de détail du CA, et constater que le label du bouton vaut désormais "Certificat de dépôt"

## TODO

- [ ] Ajouter des tests frontend pour l'export PDF d'un CA : en complétant le fichier de test `metadata-spec.js` 

- [ ] Définir les permissions disponibles nécessaires pour la route implémentant la fermeture d'un CA + pour les routes avec action 'E' dans le module METADATA

