### PR TITLE
Perf/taxhub api instead of synthese

### DIFF
--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -739,47 +739,6 @@ def get_taxon_tree():
     return [taxon_tree_table.as_dict(d) for d in data]
 
 
-@routes.route("/taxons_autocomplete", methods=["GET"])
-@login_required
-@json_resp
-def get_autocomplete_taxons_synthese():
-    """Autocomplete taxon for web search (based on all taxon in Synthese).
-
-    .. :quickref: Synthese;
-
-    The request use trigram algorithm to get relevent results
-
-    :query str search_name: the search name (use sql ilike statement and puts "%" for spaces)
-    :query str regne: filter with kingdom
-    :query str group2_inpn : filter with INPN group 2
-    """
-    search_name = request.args.get("search_name", "")
-    q = (
-        DB.session.query(
-            VMTaxrefListForautocomplete,
-            func.similarity(VMTaxrefListForautocomplete.search_name, search_name).label(
-                "idx_trgm"
-            ),
-        )
-        .distinct()
-        .join(Synthese, Synthese.cd_nom == VMTaxrefListForautocomplete.cd_nom)
-    )
-    search_name = search_name.replace(" ", "%")
-    q = q.filter(VMTaxrefListForautocomplete.search_name.ilike("%" + search_name + "%"))
-    regne = request.args.get("regne")
-    if regne:
-        q = q.filter(VMTaxrefListForautocomplete.regne == regne)
-
-    group2_inpn = request.args.get("group2_inpn")
-    if group2_inpn:
-        q = q.filter(VMTaxrefListForautocomplete.group2_inpn == group2_inpn)
-
-    q = q.order_by(desc(VMTaxrefListForautocomplete.cd_nom == VMTaxrefListForautocomplete.cd_ref))
-    limit = request.args.get("limit", 20)
-    data = q.order_by(desc("idx_trgm")).limit(20).all()
-    return [d[0].as_dict() for d in data]
-
-
 @routes.route("/sources", methods=["GET"])
 @login_required
 @json_resp

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.component.ts
@@ -47,7 +47,7 @@ export class SyntheseSearchComponent implements OnInit {
     this.route.queryParams.subscribe((params) => {
       this.params = params;
     });
-    this.taxonApiEndPoint = `${this.config.API_ENDPOINT}/synthese/taxons_autocomplete`;
+    this.taxonApiEndPoint = `${this.config.API_TAXHUB}/taxref/allnamebylist`;
   }
 
   ngOnInit() {


### PR DESCRIPTION
Bonjour,

Je me suis aperçu que dans la recherche simple de taxon (par nom), le module de synthèse et de validation faisaient appel à une route développée dans le module synthèse (`synthese/taxons_autocomplete`) qui semble faire la même chose que la route de taxhub (https://github.com/PnX-SI/TaxHub/blob/5c5354ffedc8b4242ae7d69d01bc3ba3ba19033a/apptax/taxonomie/routestaxref.py#L318)

Cette PR appelle plutôt la route de TaxHub, plus optimisée et plus rapide. Elle supprime également la route (`synthese/taxons_autocomplete`) qui n'est alors plus utilisée.

En espérant que cela vous convienne !