### PR TITLE
fix(CA): added get to the route

### DIFF
--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -620,7 +620,9 @@ def get_acquisition_frameworks_list(scope):
     )
 
 
-@routes.route("/acquisition_frameworks/export_pdf/<id_acquisition_framework>", methods=["POST"])
+@routes.route(
+    "/acquisition_frameworks/export_pdf/<id_acquisition_framework>", methods=["POST", "GET"]
+)
 @permissions.check_cruved_scope("E", module_code="METADATA")
 def get_export_pdf_acquisition_frameworks(id_acquisition_framework):
     """

--- a/frontend/src/app/metadataModule/af/af-card.component.html
+++ b/frontend/src/app/metadataModule/af/af-card.component.html
@@ -41,12 +41,13 @@
             <mat-icon>file_download</mat-icon>
           </button>
           <br />
-          <span *ngIf="!af?.opened">
+          <span *ngIf="af && !af?.opened">
             <b> {{ config.METADATA.AF_SHEET_CLOSED_LINK_NAME }} </b> :
             <a
               href="{{ config.API_ENDPOINT }}/meta/acquisition_frameworks/export_pdf/{{
                 af?.id_acquisition_framework
               }}"
+              target="_blank"
             >
               {{ config.API_ENDPOINT }}/meta/acquisition_frameworks/export_pdf/{{
                 af?.id_acquisition_framework


### PR DESCRIPTION
also opened the file in a new tab and fixed the flashing link when the ca is not closed
### To Test

-     You need a CA (cadre d'aquisition) with a jdd (jeu de données) and an observation
-     Go to the CA information page in metadata
-     check that the link below the export button doesn't pop in and out
-     go back one page close the ca
-     go check that the link is there and that when you click it works and open on a new page
