### PR TITLE
fix(permissions): adding missing permission in metadata

### DIFF
--- a/backend/geonature/migrations/versions/f051b88a57fd_permissions_available.py
+++ b/backend/geonature/migrations/versions/f051b88a57fd_permissions_available.py
@@ -99,6 +99,7 @@ def upgrade():
                     ,('METADATA', 'ALL', 'C', False, 'Créer des métadonnées')
                     ,('METADATA', 'ALL', 'R', True, 'Voir les métadonnées')
                     ,('METADATA', 'ALL', 'U', True, 'Modifier les métadonnées')
+                    ,('METADATA', 'ALL', 'E', True, 'Exporter les métadonnées')
                     ,('METADATA', 'ALL', 'D', True, 'Supprimer des métadonnées')
                     ,('SYNTHESE', 'ALL', 'R', True, 'Voir les observations')
                     ,('SYNTHESE', 'ALL', 'E', True, 'Exporter les observations')


### PR DESCRIPTION
modified migrantion permission available to add the missing "E" permission used in the route ```/dataset/export_pdf/<id_dataset>```