### PR TITLE
feat(front): utiliser le localStorage pour stocker le fond cartographique actuel

### DIFF
--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -207,6 +207,15 @@ export class MapComponent implements OnInit {
       this.mapService.loadOverlay(overlay);
     });
 
+    map.on('baselayerchange', (layer) => {
+      localStorage.setItem('MapLayer', layer.name);
+    });
+
+    const userMapLayer = localStorage.getItem('MapLayer');
+    if (userMapLayer !== null && baseControl[userMapLayer] !== undefined) {
+      map.addLayer(baseControl[userMapLayer]);
+    }
+
     setTimeout(() => {
       this.map.invalidateSize();
     }, 50);


### PR DESCRIPTION
Ce qui a été fait :

- Stockage seulement du nom du fond de carte dans le `localStorage` car la couche peut-être retrouvée grâce à la variable `baseControl`
- A la création de la carte : prend la couche contenue dans le `localStorage`. La directive `map.addLayer` n'ajoute pas la couche si elle existe déjà (voir : https://stackoverflow.com/a/33762133) mais la met à jour
- Ajout de conditions pour traiter les erreurs suivantes : `localStorage` vide, nom de la couche introuvable

Attention : cette PR ne traite pas du stockage des `REF_LAYERS` (ZNIEFF, communes etc), car lourd à afficher et n'a pas vocation, selon moi, à apparaitre constamment sur la carte.


Closes #2619 