### PR TITLE
Feat/synthese search group3 inpn

### DIFF
--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -255,16 +255,6 @@ class SyntheseQuery:
         if len(cd_ref_childs) > 0:
             self.add_join(Taxref, Taxref.cd_nom, self.model.cd_nom)
             self.query = self.query.where(Taxref.cd_ref.in_(cd_ref_childs))
-        if "taxonomy_group2_inpn" in self.filters:
-            self.add_join(Taxref, Taxref.cd_nom, self.model.cd_nom)
-            self.query = self.query.where(
-                Taxref.group2_inpn.in_(self.filters.pop("taxonomy_group2_inpn"))
-            )
-        if "taxonomy_group3_inpn" in self.filters:
-            self.add_join(Taxref, Taxref.cd_nom, self.model.cd_nom)
-            self.query = self.query.where(
-                Taxref.group3_inpn.in_(self.filters.pop("taxonomy_group3_inpn"))
-            )
         if "taxonomy_id_hab" in self.filters:
             self.add_join(Taxref, Taxref.cd_nom, self.model.cd_nom)
             self.query = self.query.where(
@@ -276,6 +266,13 @@ class SyntheseQuery:
         red_list_filters = {}
 
         for colname, value in self.filters.items():
+            if colname.startswith("taxonomy_group"):
+                # colname = group type (group2 or group3 inpn)
+                # value = list of group values
+                colname = colname.split("taxonomy_")[-1]
+                self.add_join(Taxref, Taxref.cd_nom, self.model.cd_nom)
+                self.query = self.query.where(getattr(Taxref, colname).in_(value))
+
             if colname.startswith("taxhub_attribut"):
                 self.add_join(Taxref, Taxref.cd_nom, self.model.cd_nom)
                 taxhub_id_attr = colname[16:]

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -260,7 +260,11 @@ class SyntheseQuery:
             self.query = self.query.where(
                 Taxref.group2_inpn.in_(self.filters.pop("taxonomy_group2_inpn"))
             )
-
+        if "taxonomy_group3_inpn" in self.filters:
+            self.add_join(Taxref, Taxref.cd_nom, self.model.cd_nom)
+            self.query = self.query.where(
+                Taxref.group3_inpn.in_(self.filters.pop("taxonomy_group3_inpn"))
+            )
         if "taxonomy_id_hab" in self.filters:
             self.add_join(Taxref, Taxref.cd_nom, self.model.cd_nom)
             self.query = self.query.where(

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -496,7 +496,7 @@ class TestSynthese:
         group_from_taxref = getattr(taxref_from_cd_nom, group_inpn)
         filter_name = "taxonomie_" + group_inpn
 
-        set_logged_user_cookie(self.client, users["self_user"])
+        set_logged_user(self.client, users["self_user"])
         response = self.client.get(
             url_for("gn_synthese.get_observations_for_web"),
             json={
@@ -732,6 +732,7 @@ class TestSynthese:
             '"nom_vern"',
             '"group1_inpn"',
             '"group2_inpn"',
+            '"group3_inpn"',
             '"regne"',
             '"phylum"',
             '"classe"',
@@ -757,7 +758,7 @@ class TestSynthese:
             rows_data_response = response.data.decode("utf-8").split("\r\n")[0:-1]
             row_header = rows_data_response[0]
             rows_taxons_data_response = rows_data_response[1:]
-
+            print(row_header.split(";"), expected_columns_exports)
             assert row_header.split(";") == expected_columns_exports
 
             nb_expected_cd_noms = len(set_expected_cd_ref)

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -227,6 +227,10 @@ export class DataFormService {
     return this._http.get<any>(`${this.config.API_TAXHUB}/taxref/regnewithgroupe2`);
   }
 
+  getRegneAndGroup3Inpn() {
+    return this._http.get<any>(`${this.config.API_TAXHUB}/taxref/regnewithgroupe3`);
+  }
+
   getTaxhubBibAttributes() {
     return this._http.get<any>(`${this.config.API_TAXHUB}/bibattributs/`);
   }

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -227,8 +227,8 @@ export class DataFormService {
     return this._http.get<any>(`${this.config.API_TAXHUB}/taxref/regnewithgroupe2`);
   }
 
-  getRegneAndGroup3Inpn() {
-    return this._http.get<any>(`${this.config.API_TAXHUB}/taxref/regnewithgroupe3`);
+  getGroup3Inpn() {
+    return this._http.get<any>(`${this.config.API_TAXHUB}/taxref/groupe3_inpn`);
   }
 
   getTaxhubBibAttributes() {

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form-store.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form-store.service.ts
@@ -90,18 +90,8 @@ export class TaxonAdvancedStoreService {
       this.taxonomyGroup2Inpn = all_groups;
     });
 
-    all_groups = [];
-    this._dataService.getRegneAndGroup3Inpn().subscribe((data) => {
-      this.taxonomyGroup3Inpn = data;
-      // eslint-disable-next-line guard-for-in
-      for (let regne in data) {
-        data[regne].forEach((group) => {
-          if (group.length > 0) {
-            all_groups.push({ value: group });
-          }
-        });
-      }
-      this.taxonomyGroup3Inpn = all_groups;
+    this._dataService.getGroup3Inpn().subscribe((data) => {
+      this.taxonomyGroup3Inpn = data.map((item) => ({ value: item }));
     });
   }
 }

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form-store.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form-store.service.ts
@@ -76,7 +76,7 @@ export class TaxonAdvancedStoreService {
       this.taxonomyHab = data;
     });
 
-    let all_groups = [];
+    const all_groups = [];
     this._dataService.getRegneAndGroup2Inpn().subscribe((data) => {
       this.taxonomyGroup2Inpn = data;
       // eslint-disable-next-line guard-for-in

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form-store.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form-store.service.ts
@@ -76,7 +76,7 @@ export class TaxonAdvancedStoreService {
       this.taxonomyHab = data;
     });
 
-    const all_groups = [];
+    let all_groups = [];
     this._dataService.getRegneAndGroup2Inpn().subscribe((data) => {
       this.taxonomyGroup2Inpn = data;
       // eslint-disable-next-line guard-for-in
@@ -89,6 +89,8 @@ export class TaxonAdvancedStoreService {
       }
       this.taxonomyGroup2Inpn = all_groups;
     });
+
+    all_groups = [];
     this._dataService.getRegneAndGroup3Inpn().subscribe((data) => {
       this.taxonomyGroup3Inpn = data;
       // eslint-disable-next-line guard-for-in

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form-store.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form-store.service.ts
@@ -19,6 +19,7 @@ export class TaxonAdvancedStoreService {
   public formBuilded: boolean;
   public taxonomyHab: Array<any>;
   public taxonomyGroup2Inpn: Array<any>;
+  public taxonomyGroup3Inpn: Array<any>;
   public redListsValues: any = {};
 
   constructor(
@@ -87,6 +88,18 @@ export class TaxonAdvancedStoreService {
         });
       }
       this.taxonomyGroup2Inpn = all_groups;
+    });
+    this._dataService.getRegneAndGroup3Inpn().subscribe((data) => {
+      this.taxonomyGroup3Inpn = data;
+      // eslint-disable-next-line guard-for-in
+      for (let regne in data) {
+        data[regne].forEach((group) => {
+          if (group.length > 0) {
+            all_groups.push({ value: group });
+          }
+        });
+      }
+      this.taxonomyGroup3Inpn = all_groups;
     });
   }
 }

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form.component.html
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form.component.html
@@ -164,6 +164,18 @@
         >
         </pnx-multiselect>
       </div>
+      <div class="form-group">
+        <pnx-multiselect
+          [values]="storeService.taxonomyGroup3Inpn"
+          [parentFormControl]="formService.searchForm.controls.taxonomy_group3_inpn"
+          keyLabel="value"
+          keyValue="value"
+          label="Groupe 3 INPN"
+          (onChange)="onTaxRefAttributsSelected($event.value)"
+          (onDelete)="onTaxRefAttributsDeleted($event.value.value)"
+        >
+        </pnx-multiselect>
+      </div>
     </div>
 
     <div *ngIf="storeService.formBuilded && storeService.taxhubAttributes.length > 0">

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.service.ts
@@ -88,6 +88,7 @@ export class SyntheseFormService {
       taxonomy_lr: null,
       taxonomy_id_hab: null,
       taxonomy_group2_inpn: null,
+      taxonomy_group3_inpn: null,
       taxon_rank: null,
     });
 


### PR DESCRIPTION
Bonjour,

Dans le cadre d'une prestation pour l'Agence Régionale de la Biodiversité en île de France, une demande a été faite pour intégrer le groupe3_inpn dans GeoNature.

L'objectif est tout d'abord de l'intégrer dans la recherche avancée de la taxonomie dans la synthèse.

Attention cette PR part du principe qu'une nouvelle route vers Taxhub est disponible ainsi que le modèle ORM de Taxref dispose de l'attribut `group3_inpn`. Cette PR incluant cette route est disponible ici : https://github.com/PnX-SI/TaxHub/pull/409