### PR TITLE
test/fix fixture sensitive synthese

### DIFF
--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -850,6 +850,7 @@ def export_status(permissions):
 
     protection_status = []
     data = DB.session.execute(query)
+
     for d in data:
         d = d._mapping
         row = OrderedDict(

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -240,14 +240,8 @@ def get_observations_for_web(permissions):
 
         agg_areas = (
             select(CorAreaSynthese.id_synthese, LAreas.id_area)
-            .select_from(
-                CorAreaSynthese.__table__.join(
-                    LAreas, LAreas.id_area == CorAreaSynthese.id_area
-                ).join(
-                    BibAreasTypes,
-                    BibAreasTypes.id_type == LAreas.id_type,
-                ),
-            )
+            .join(CorAreaSynthese, CorAreaSynthese.id_area == LAreas.id_area)
+            .join(BibAreasTypes, BibAreasTypes.id_type == LAreas.id_type)
             .where(CorAreaSynthese.id_synthese == obs_query.c.id_synthese)
             .where(
                 BibAreasTypes.type_code == current_app.config["SYNTHESE"]["AREA_AGGREGATION_TYPE"]

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -660,10 +660,6 @@ def synthese_sensitive_data(app, users, datasets, source):
         .filter(TNomenclatures.cd_nomenclature == "0")
         .one()
     )
-    assert (
-        nomenclature_not_sensitive.mnemonique == "Non sensible - Diffusion précise",
-        nomenclature_not_sensitive.mnemonique,
-    )
     id_nomenclature_not_sensitive = nomenclature_not_sensitive.id_nomenclature
 
     synthese_to_assert = Synthese.query.filter(
@@ -675,13 +671,10 @@ def synthese_sensitive_data(app, users, datasets, source):
         )
     ).first()
 
-    assert (
-        synthese_to_assert.id_nomenclature_sensitivity != id_nomenclature_not_sensitive,
-        (
-            f"cd_nom: {synthese_to_assert.cd_nom}, id_nomenclature_bio_status: {synthese_to_assert.id_nomenclature_bio_status}, "
-            f"id_nomenclature_behaviour: {synthese_to_assert}.id_nomenclature_behaviour, "
-            f"geojson: {synthese_to_assert.the_geom_4326_geojson}"
-        ),
+    assert synthese_to_assert.id_nomenclature_sensitivity != id_nomenclature_not_sensitive, (
+        f"cd_nom: {synthese_to_assert.cd_nom}, id_nomenclature_bio_status: {synthese_to_assert.id_nomenclature_bio_status}, "
+        f"id_nomenclature_behaviour: {synthese_to_assert}.id_nomenclature_behaviour, "
+        f"geojson: {synthese_to_assert.the_geom_4326_geojson}"
     )
 
     # Assert that obs_protected_not_sensitive is not a sensitive observation

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -684,7 +684,7 @@ def synthese_with_protected_status(users, datasets, source):
     pytest.Fixture
         fixture with synthese observations
     """
-    synthese_element = {}
+    synthese_element = []
 
     # Retrieve protected taxon from the bdc_statut_taxons table
     protected_taxon = db.session.scalars(
@@ -711,7 +711,7 @@ def synthese_with_protected_status(users, datasets, source):
                 cor_observers=[users["self_user"]],
             )
             db.session.add(synthese)
-            synthese_element[taxon.cd_nom] = synthese
+            synthese_element.append(synthese)
 
     return synthese_element
 

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -633,7 +633,14 @@ def synthese_sensitive_data(app, users, datasets, source):
         .one()
     ).id_nomenclature
     assert (
-        Synthese.query.filter(Synthese.cd_nom == sensitive_protected_cd_nom)
+        Synthese.query.filter(
+            Synthese.id_synthese.in_(
+                (
+                    data[key].id_synthese
+                    for key in ["obs_sensitive_protected", "obs_sensitive_protected_2"]
+                )
+            )
+        )
         .first()
         .id_nomenclature_sensitivity
         != id_nomenclature_not_sensitive
@@ -641,7 +648,9 @@ def synthese_sensitive_data(app, users, datasets, source):
 
     # Assert that obs_protected_not_sensitive is not a sensitive observation
     assert (
-        Synthese.query.filter(Synthese.cd_nom == protected_not_sensitive_cd_nom)
+        Synthese.query.filter(
+            Synthese.id_synthese == data["obs_protected_not_sensitive"].id_synthese
+        )
         .first()
         .id_nomenclature_sensitivity
         == id_nomenclature_not_sensitive

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -646,11 +646,11 @@ def synthese_sensitive_data(app, users, datasets, source):
             LAreas.area_code == "01",
         )  # Ain
     ).one()
-    
+
     unsensitive_protected_taxon = db.session.execute(
-            select(Taxref).filter_by(cd_nom=64357)
-        ).scalar_one().cd_nom
-    
+        select(Taxref.cd_nom).filter_by(cd_nom=64357)
+    ).scalar_one()
+
     with db.session.begin_nested():
         for name, cd_nom, point, ds, comment_description, id_nomenclature_sensitivity in [
             (

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -629,13 +629,23 @@ def synthese_sensitive_data(app, users, datasets, source):
             source,
             comment_description=name,
         )
-        db.session.add(s)
-        data[name] = s
+        .filter(TNomenclatures.cd_nomenclature == "0")
+        .one()
+    ).id_nomenclature
+    assert (
+        Synthese.query.filter(Synthese.cd_nom == sensitive_protected_cd_nom)
+        .first()
+        .id_nomenclature_sensitivity
+        != id_nomenclature_not_sensitive
+    )
 
-    # retrieves sensitive nomenclatures computed by trigger
-    db.session.flush()
-    for s in data.values():
-        db.session.refresh(s)
+    # Assert that obs_protected_not_sensitive is not a sensitive observation
+    assert (
+        Synthese.query.filter(Synthese.cd_nom == protected_not_sensitive_cd_nom)
+        .first()
+        .id_nomenclature_sensitivity
+        == id_nomenclature_not_sensitive
+    )
 
     assert data["obs_sensitive_protected"].nomenclature_sensitivity.cd_nomenclature == "2"
     assert data["obs_sensitive_protected_2"].nomenclature_sensitivity.cd_nomenclature == "2"

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -597,7 +597,19 @@ def synthese_sensitive_data(app, users, datasets, source):
             SensitivityRule.cd_nom == sensitive_protected_taxon.cd_nom,
             SensitivityRule.areas.any(LAreas.id_area == unsensitive_area.id_area),
         )
-        .limit(1)
+        .join(
+            cte_taxa_area_with_sensitivity,
+            sa.and_(
+                cte_taxa_area_with_status.c.cd_nom == cte_taxa_area_with_sensitivity.c.cd_nom,
+                cte_taxa_area_with_status.c.id_area == cte_taxa_area_with_sensitivity.c.id_area,
+            ),
+        )
+        .order_by(cte_taxa_area_with_status.c.cd_nom)
+        .first()
+    )
+    sensitivity_rule = SensitivityRule.query.filter(
+        SensitivityRule.cd_nom == sensitive_protected_cd_nom,
+        SensitivityRule.areas.any(LAreas.id_area == sensitive_protected_id_area),
     ).first()
     assert sensitivity_rule is None, "Le référentiel de sensibilité ne convient pas aux tests"
 

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -697,14 +697,13 @@ def synthese_sensitive_data(app, users, datasets, source):
             data[name] = s
 
     # Assert that obs_sensitive_protected is a sensitive observation
-    nomenclature_not_sensitive = (
+    id_nomenclature_not_sensitive = (
         TNomenclatures.query.filter(
             TNomenclatures.nomenclature_type.has(BibNomenclaturesTypes.mnemonique == "SENSIBILITE")
         )
         .filter(TNomenclatures.cd_nomenclature == "0")
         .one()
-    )
-    id_nomenclature_not_sensitive = nomenclature_not_sensitive.id_nomenclature
+    ).id_nomenclature
 
     synthese_to_assert = Synthese.query.filter(
         Synthese.id_synthese.in_(

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -7,6 +7,7 @@ from collections import Counter
 import pytest
 from flask import url_for, current_app
 import sqlalchemy as sa
+import pandas as pd
 from sqlalchemy import func, select
 from werkzeug.exceptions import Forbidden, BadRequest, Unauthorized
 from jsonschema import validate as validate_json
@@ -21,7 +22,7 @@ from geonature.core.gn_synthese.utils.blurring import split_blurring_precise_per
 from geonature.core.gn_synthese.utils.query_select_sqla import remove_accents
 from geonature.core.sensitivity.models import cor_sensitivity_area_type
 from geonature.core.gn_meta.models import TDatasets
-from geonature.core.gn_synthese.models import Synthese, TSources
+from geonature.core.gn_synthese.models import Synthese, TSources, VSyntheseForWebApp
 from geonature.core.gn_synthese.schemas import SyntheseSchema
 from geonature.core.gn_permissions.models import PermAction, Permission
 from geonature.core.gn_commons.models.base import TModules

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -905,8 +905,11 @@ class TestSynthese:
 
         user = users["user"]
         set_expected_cd_ref = set(
-            db.session.scalars(select(Taxref.cd_ref).where(Taxref.cd_nom == obs.cd_nom)).one()
-            for obs in synthese_with_protected_status.values()
+            db.session.scalars(
+                select(Taxref.cd_ref).where(
+                    Taxref.cd_nom.in_([el.cd_nom for el in synthese_with_protected_status])
+                )
+            ).all()
         )
         assert_export_status_results(user, set_expected_cd_ref)
 

--- a/backend/geonature/tests/utils.py
+++ b/backend/geonature/tests/utils.py
@@ -1,5 +1,7 @@
 from flask import url_for
-
+from pypnnomenclature.models import BibNomenclaturesTypes, TNomenclatures
+import sqlalchemy as sa
+from geonature.utils.env import db
 from pypnusershub.tests.utils import (
     set_logged_user,
     unset_logged_user,
@@ -15,6 +17,18 @@ def login(client, username="admin", password=None):
     }
     response = client.post(url_for("auth.login"), json=data)
     assert response.status_code == 200
+
+
+def get_id_nomenclature(nomenclature_type_mnemonique, cd_nomenclature):
+    return db.session.scalar(
+        sa.select(TNomenclatures.id_nomenclature)
+        .where(TNomenclatures.cd_nomenclature == cd_nomenclature)
+        .where(
+            TNomenclatures.nomenclature_type.has(
+                BibNomenclaturesTypes.mnemonique == nomenclature_type_mnemonique
+            )
+        )
+    )
 
 
 jsonschema_definitions = {


### PR DESCRIPTION
Ajout d'`assert` pour effectivement tester si les 2 données insérées en synthèse sont bien respectivement sensible et non sensible.
Modification du `cd_nomenclature` à 0 correspondant à la nomenclature "Non sensible - Diffusion précise". 4 étant "Sensible - Aucune diffusion".