### PR TITLE
Intégration de TaxHub

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -114,12 +114,6 @@ jobs:
         run: geonature dev_back &
         env:
           GEONATURE_CONFIG_FILE: config/test_config.toml
-      - name: Run TaxHub backend
-        run: flask run --host=0.0.0.0 &
-        working-directory: ./backend/dependencies/TaxHub/
-        env:
-          TAXHUB_SETTINGS: test_config.py
-          TAXHUB_SQLALCHEMY_DATABASE_URI: "postgresql://geonatadmin:geonatpasswd@127.0.0.1:5432/geonature2db"
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:

--- a/backend/geonature/core/admin/admin.py
+++ b/backend/geonature/core/admin/admin.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import g
 from werkzeug.exceptions import Unauthorized
 from flask_admin import Admin, AdminIndexView, expose
@@ -151,5 +153,6 @@ admin.add_view(
         category="Autres",
     )
 )
+
 
 flask_admin = admin  # for retro-compatibility, usefull for export module for instance

--- a/backend/geonature/core/command/main.py
+++ b/backend/geonature/core/command/main.py
@@ -115,7 +115,6 @@ def default_config():
     required_fields = (
         "URL_APPLICATION",
         "API_ENDPOINT",
-        "API_TAXHUB",
         "SECRET_KEY",
         "SQLALCHEMY_DATABASE_URI",
     )

--- a/backend/geonature/core/taxonomie/admin.py
+++ b/backend/geonature/core/taxonomie/admin.py
@@ -1,0 +1,92 @@
+import os
+from apptax.admin.admin_view import (
+    BibListesView,
+    TaxrefView,
+    TMediasView,
+    BibAttributsView,
+    BibThemesView,
+)
+from geonature.utils.env import db
+
+from apptax.admin.admin import adresses
+from apptax.taxonomie.models import Taxref, BibListes, TMedias, BibAttributs, BibThemes
+from geonature.core.admin.utils import CruvedProtectedMixin
+
+
+class CruvedProtectedBibListesView(CruvedProtectedMixin, BibListesView):
+    module_code = "TAXHUB"
+    object_code = "LISTE"
+    extra_actions_perm = {".import_cd_nom_view": "C"}
+
+
+class CruvedProtectedTaxrefView(CruvedProtectedMixin, TaxrefView):
+    module_code = "TAXHUB"
+    object_code = "TAXON"
+
+
+class CruvedProtectedTMediasView(CruvedProtectedMixin, TMediasView):
+    module_code = "TAXHUB"
+    object_code = "TAXON"
+
+
+class CruvedProtectedBibAttributsView(CruvedProtectedMixin, BibAttributsView):
+    module_code = "TAXHUB"
+    object_code = "ATTRIBUT"
+
+
+class CruvedProtectedBibThemes(CruvedProtectedMixin, BibThemesView):
+    module_code = "TAXHUB"
+    object_code = "THEME"
+
+
+def load_admin_views(app, admin):
+    static_folder = os.path.join(adresses.root_path, "static")
+
+    admin.add_view(
+        CruvedProtectedTaxrefView(
+            Taxref,
+            db.session,
+            name="Taxref",
+            endpoint="taxons",
+            category="TaxHub",
+            static_folder=static_folder,
+        )
+    )
+    admin.add_view(
+        CruvedProtectedBibListesView(
+            BibListes,
+            db.session,
+            name="Listes",
+            category="TaxHub",
+            static_folder=static_folder,
+        )
+    )
+
+    admin.add_view(
+        CruvedProtectedBibAttributsView(
+            BibAttributs,
+            db.session,
+            name="Attributs",
+            category="TaxHub",
+            static_folder=static_folder,
+        )
+    )
+    admin.add_view(
+        CruvedProtectedBibThemes(
+            BibThemes,
+            db.session,
+            name="Thèmes",
+            category="TaxHub",
+            static_folder=static_folder,
+        )
+    )
+
+    admin.add_view(
+        CruvedProtectedTMediasView(
+            TMedias,
+            db.session,
+            name="Médias",
+            category="TaxHub",
+            static_folder=static_folder,
+        )
+    )

--- a/backend/geonature/migrations/versions/ebbe0f7ed866_declare_taxhub_admin.py
+++ b/backend/geonature/migrations/versions/ebbe0f7ed866_declare_taxhub_admin.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "ebbe0f7ed866"
-down_revision = "f1dd984bff97"
+down_revision = "446e902a14e7"
 branch_labels = None
 depends_on = None
 

--- a/backend/geonature/migrations/versions/ebbe0f7ed866_declare_taxhub_admin.py
+++ b/backend/geonature/migrations/versions/ebbe0f7ed866_declare_taxhub_admin.py
@@ -1,0 +1,120 @@
+"""declare module TAXHUB
+
+Revision ID: ebbe0f7ed866
+Revises: f1dd984bff97
+Create Date: 2023-08-02 13:15:38.542530
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ebbe0f7ed866"
+down_revision = "f1dd984bff97"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO gn_commons.t_modules
+        (module_code, module_label, module_picto, module_desc, module_target, active_frontend, active_backend)
+        VALUES('TAXHUB', 'Taxhub', 'fa-leaf', 'Module TaxHub', '_blank', false, false);
+
+        INSERT INTO gn_permissions.t_objects
+        (code_object, description_object)
+        VALUES
+        ('TAXON', 'Gestion des taxons dans TaxHub'),
+        ('THEME', 'Gestion des thêmes d''attribut dans TaxHub'),
+        ('LISTE', 'Gestion des listes dans TaxHub'),
+        ('ATTRIBUT', 'Gestion des types d''attributs dans TaxHub')
+        ;
+
+
+        INSERT INTO
+            gn_permissions.t_permissions_available (
+                id_module,
+                id_object,
+                id_action,
+                scope_filter,
+                label
+            )
+        SELECT
+            m.id_module,
+            o.id_object,
+            a.id_action,
+            v.scope_filter,
+            v.label
+        FROM (
+                VALUES
+                 ('TAXHUB', 'TAXON', 'R', False, 'Voir les taxons')
+                ,('TAXHUB', 'TAXON', 'U', False, 'Modifier les taxons (médias - liste - attributs)')
+                ,('TAXHUB', 'THEME', 'C', False, 'Créer des thêmes')
+                ,('TAXHUB', 'THEME', 'R', False, 'Voir les thêmes')
+                ,('TAXHUB', 'THEME', 'U', False, 'Modifier les thêmes')
+                ,('TAXHUB', 'THEME', 'D', False, 'Supprimer des thêmes')
+                ,('TAXHUB', 'LISTE', 'C', False, 'Creer des listes')
+                ,('TAXHUB', 'LISTE', 'R', False, 'Voir les listes')
+                ,('TAXHUB', 'LISTE', 'U', False, 'Modifier les listes')
+                ,('TAXHUB', 'LISTE', 'D', False, 'Supprimer des listes')
+                ,('TAXHUB', 'ATTRIBUT', 'C', False, 'Créer des types d''attribut')
+                ,('TAXHUB', 'ATTRIBUT', 'R', False, 'Voir les types d''attribut')
+                ,('TAXHUB', 'ATTRIBUT', 'U', False, 'Modfier les types d''attribut')
+                ,('TAXHUB', 'ATTRIBUT', 'D', False, 'Supprimer les types d''attribut')
+            ) AS v (module_code, object_code, action_code, scope_filter, label)
+        JOIN
+            gn_commons.t_modules m ON m.module_code = v.module_code
+        JOIN
+            gn_permissions.t_objects o ON o.code_object = v.object_code
+        JOIN
+            gn_permissions.bib_actions a ON a.code_action = v.action_code
+        WHERE m.module_code = 'TAXHUB'
+    """
+    )
+    # rappatriement des permissions de l'application TaxHub
+
+    op.execute(
+        """
+        INSERT INTO gn_permissions.t_permissions
+        (id_role, id_action, id_module, id_object)
+        select crap.id_role, t.id_action, t.id_module, t.id_object
+        from ( values ('TH', 'TAXHUB')) as v (code_appli, code_module)
+        join gn_commons.t_modules m ON m.module_code  = v.code_module 
+        join gn_permissions.t_permissions_available t on t.id_module = m.id_module 
+        join utilisateurs.t_applications app on app.code_application = v.code_appli
+        join utilisateurs.cor_role_app_profil crap on crap.id_application = app.id_application 
+        where m.module_code = 'TAXHUB' and app.code_application = 'TH' and crap.id_profil = 6;
+
+        INSERT INTO gn_permissions.t_permissions
+        (id_role, id_action, id_module, id_object)
+        select crap.id_role, t.id_action, t.id_module, t.id_object
+        from ( values ('TH', 'TAXHUB')) as v (code_appli, code_module)
+        join gn_commons.t_modules m ON m.module_code  = v.code_module 
+        join gn_permissions.t_permissions_available t on t.id_module = m.id_module 
+        join gn_permissions.t_objects obj on t.id_object = obj.id_object 
+        join utilisateurs.t_applications app on app.code_application = v.code_appli
+        join utilisateurs.cor_role_app_profil crap on crap.id_application = app.id_application 
+        where m.module_code = 'TAXHUB' and app.code_application = 'TH' and crap.id_profil in (1,2,3,4,5) and obj.code_object = 'TAXON';
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM utilisateurs.cor_role_app_profil  where id_application = (select id_application from utilisateurs.t_applications  t where t.code_application = 'TH' );
+        DELETE FROM utilisateurs.cor_profil_for_app  where id_application = (select id_application from utilisateurs.t_applications  t where t.code_application = 'TH' );
+        DELETE FROM utilisateurs.t_applications where code_application = 'TH';
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        DELETE FROM gn_permissions.t_permissions  WHERE id_module  = (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'TAXHUB');
+        DELETE FROM gn_permissions.t_permissions_available WHERE id_module = (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'TAXHUB');
+        DELETE FROM gn_commons.t_modules where module_code = 'TAXHUB';
+        DELETE FROM gn_permissions.t_objects where code_object in ('TAXON', 'ATTRIBUT', 'THEME', 'LISTE');
+        """
+    )

--- a/backend/geonature/migrations/versions/ebbe0f7ed866_declare_taxhub_admin.py
+++ b/backend/geonature/migrations/versions/ebbe0f7ed866_declare_taxhub_admin.py
@@ -15,63 +15,81 @@ down_revision = "446e902a14e7"
 branch_labels = None
 depends_on = None
 
+from geonature.utils.config import config
+
 
 def upgrade():
-    op.execute(
+    op.get_bind().execute(
+        sa.text(
+            """
+            INSERT INTO gn_commons.t_modules
+            (module_code, module_label, module_picto, module_desc, module_target, module_external_url, active_frontend, active_backend)
+            VALUES('TAXHUB', 'Taxhub', 'fa-leaf', 'Module TaxHub', '_blank', :module_url, false, false);
+
+            INSERT INTO gn_permissions.t_objects
+            (code_object, description_object)
+            VALUES
+            ('TAXON', 'Gestion des taxons dans TaxHub'),
+            ('THEME', 'Gestion des thêmes d''attribut dans TaxHub'),
+            ('LISTE', 'Gestion des listes dans TaxHub'),
+            ('ATTRIBUT', 'Gestion des types d''attributs dans TaxHub')
+            ;
+
+            INSERT INTO gn_permissions.cor_object_module
+            (id_object, id_module)
+            SELECT _to.id_object, (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'TAXHUB')
+            FROM (
+                VALUES 
+                    ('TAXON'), 
+                    ('THEME'), 
+                    ('LISTE'), 
+                    ('ATTRIBUT')
+                ) AS o (object_code)
+            JOIN gn_permissions.t_objects _to ON _to.code_object = o.object_code;
+            
+
+
+            INSERT INTO
+                gn_permissions.t_permissions_available (
+                    id_module,
+                    id_object,
+                    id_action,
+                    scope_filter,
+                    label
+                )
+            SELECT
+                m.id_module,
+                o.id_object,
+                a.id_action,
+                v.scope_filter,
+                v.label
+            FROM (
+                    VALUES
+                    ('TAXHUB', 'TAXON', 'R', False, 'Voir les taxons')
+                    ,('TAXHUB', 'TAXON', 'U', False, 'Modifier les taxons (médias - liste - attributs)')
+                    ,('TAXHUB', 'THEME', 'C', False, 'Créer des thêmes')
+                    ,('TAXHUB', 'THEME', 'R', False, 'Voir les thêmes')
+                    ,('TAXHUB', 'THEME', 'U', False, 'Modifier les thêmes')
+                    ,('TAXHUB', 'THEME', 'D', False, 'Supprimer des thêmes')
+                    ,('TAXHUB', 'LISTE', 'C', False, 'Creer des listes')
+                    ,('TAXHUB', 'LISTE', 'R', False, 'Voir les listes')
+                    ,('TAXHUB', 'LISTE', 'U', False, 'Modifier les listes')
+                    ,('TAXHUB', 'LISTE', 'D', False, 'Supprimer des listes')
+                    ,('TAXHUB', 'ATTRIBUT', 'C', False, 'Créer des types d''attribut')
+                    ,('TAXHUB', 'ATTRIBUT', 'R', False, 'Voir les types d''attribut')
+                    ,('TAXHUB', 'ATTRIBUT', 'U', False, 'Modfier les types d''attribut')
+                    ,('TAXHUB', 'ATTRIBUT', 'D', False, 'Supprimer les types d''attribut')
+                ) AS v (module_code, object_code, action_code, scope_filter, label)
+            JOIN
+                gn_commons.t_modules m ON m.module_code = v.module_code
+            JOIN
+                gn_permissions.t_objects o ON o.code_object = v.object_code
+            JOIN
+                gn_permissions.bib_actions a ON a.code_action = v.action_code
+            WHERE m.module_code = 'TAXHUB'
         """
-        INSERT INTO gn_commons.t_modules
-        (module_code, module_label, module_picto, module_desc, module_target, active_frontend, active_backend)
-        VALUES('TAXHUB', 'Taxhub', 'fa-leaf', 'Module TaxHub', '_blank', false, false);
-
-        INSERT INTO gn_permissions.t_objects
-        (code_object, description_object)
-        VALUES
-        ('TAXON', 'Gestion des taxons dans TaxHub'),
-        ('THEME', 'Gestion des thêmes d''attribut dans TaxHub'),
-        ('LISTE', 'Gestion des listes dans TaxHub'),
-        ('ATTRIBUT', 'Gestion des types d''attributs dans TaxHub')
-        ;
-
-
-        INSERT INTO
-            gn_permissions.t_permissions_available (
-                id_module,
-                id_object,
-                id_action,
-                scope_filter,
-                label
-            )
-        SELECT
-            m.id_module,
-            o.id_object,
-            a.id_action,
-            v.scope_filter,
-            v.label
-        FROM (
-                VALUES
-                 ('TAXHUB', 'TAXON', 'R', False, 'Voir les taxons')
-                ,('TAXHUB', 'TAXON', 'U', False, 'Modifier les taxons (médias - liste - attributs)')
-                ,('TAXHUB', 'THEME', 'C', False, 'Créer des thêmes')
-                ,('TAXHUB', 'THEME', 'R', False, 'Voir les thêmes')
-                ,('TAXHUB', 'THEME', 'U', False, 'Modifier les thêmes')
-                ,('TAXHUB', 'THEME', 'D', False, 'Supprimer des thêmes')
-                ,('TAXHUB', 'LISTE', 'C', False, 'Creer des listes')
-                ,('TAXHUB', 'LISTE', 'R', False, 'Voir les listes')
-                ,('TAXHUB', 'LISTE', 'U', False, 'Modifier les listes')
-                ,('TAXHUB', 'LISTE', 'D', False, 'Supprimer des listes')
-                ,('TAXHUB', 'ATTRIBUT', 'C', False, 'Créer des types d''attribut')
-                ,('TAXHUB', 'ATTRIBUT', 'R', False, 'Voir les types d''attribut')
-                ,('TAXHUB', 'ATTRIBUT', 'U', False, 'Modfier les types d''attribut')
-                ,('TAXHUB', 'ATTRIBUT', 'D', False, 'Supprimer les types d''attribut')
-            ) AS v (module_code, object_code, action_code, scope_filter, label)
-        JOIN
-            gn_commons.t_modules m ON m.module_code = v.module_code
-        JOIN
-            gn_permissions.t_objects o ON o.code_object = v.object_code
-        JOIN
-            gn_permissions.bib_actions a ON a.code_action = v.action_code
-        WHERE m.module_code = 'TAXHUB'
-    """
+        ),
+        module_url=f"{config['API_ENDPOINT']}/admin/taxons",
     )
     # rappatriement des permissions de l'application TaxHub
 
@@ -79,24 +97,30 @@ def upgrade():
         """
         INSERT INTO gn_permissions.t_permissions
         (id_role, id_action, id_module, id_object)
-        select crap.id_role, t.id_action, t.id_module, t.id_object
-        from ( values ('TH', 'TAXHUB')) as v (code_appli, code_module)
-        join gn_commons.t_modules m ON m.module_code  = v.code_module 
-        join gn_permissions.t_permissions_available t on t.id_module = m.id_module 
-        join utilisateurs.t_applications app on app.code_application = v.code_appli
-        join utilisateurs.cor_role_app_profil crap on crap.id_application = app.id_application 
-        where m.module_code = 'TAXHUB' and app.code_application = 'TH' and crap.id_profil = 6;
+        SELECT crap.id_role, t.id_action, t.id_module, t.id_object
+        FROM 
+            ( values ('TH', 'TAXHUB')) as v (code_appli, code_module)
+        JOIN gn_commons.t_modules m ON m.module_code  = v.code_module 
+        JOIN gn_permissions.t_permissions_available t on t.id_module = m.id_module 
+        JOIN utilisateurs.t_applications app on app.code_application = v.code_appli
+        JOIN utilisateurs.cor_role_app_profil crap on crap.id_application = app.id_application 
+        WHERE m.module_code = 'TAXHUB' and app.code_application = 'TH' and crap.id_profil = 6;
 
         INSERT INTO gn_permissions.t_permissions
         (id_role, id_action, id_module, id_object)
-        select crap.id_role, t.id_action, t.id_module, t.id_object
-        from ( values ('TH', 'TAXHUB')) as v (code_appli, code_module)
-        join gn_commons.t_modules m ON m.module_code  = v.code_module 
-        join gn_permissions.t_permissions_available t on t.id_module = m.id_module 
-        join gn_permissions.t_objects obj on t.id_object = obj.id_object 
-        join utilisateurs.t_applications app on app.code_application = v.code_appli
-        join utilisateurs.cor_role_app_profil crap on crap.id_application = app.id_application 
-        where m.module_code = 'TAXHUB' and app.code_application = 'TH' and crap.id_profil in (1,2,3,4,5) and obj.code_object = 'TAXON';
+        SELECT crap.id_role, t.id_action, t.id_module, t.id_object
+        FROM 
+            ( values ('TH', 'TAXHUB')) as v (code_appli, code_module)
+        JOIN gn_commons.t_modules m ON m.module_code  = v.code_module 
+        JOIN gn_permissions.t_permissions_available t on t.id_module = m.id_module 
+        JOIN gn_permissions.t_objects obj on t.id_object = obj.id_object 
+        JOIN utilisateurs.t_applications app on app.code_application = v.code_appli
+        JOIN utilisateurs.cor_role_app_profil crap on crap.id_application = app.id_application 
+        WHERE 
+            m.module_code = 'TAXHUB'
+            AND  app.code_application = 'TH'
+            AND crap.id_profil in (1,2,3,4,5) 
+            AND obj.code_object = 'TAXON';
         """
     )
 

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -3,14 +3,9 @@
 """
 
 import os
+import warnings
 
-from marshmallow import (
-    Schema,
-    fields,
-    validates_schema,
-    ValidationError,
-    post_load,
-)
+from marshmallow import Schema, fields, validates_schema, ValidationError, post_load, pre_load
 from marshmallow.validate import OneOf, Regexp, Email, Length
 
 from geonature.core.gn_synthese.synthese_config import (
@@ -529,7 +524,7 @@ class GnGeneralSchemaConf(Schema):
     DEBUG = fields.Boolean(load_default=False)
     URL_APPLICATION = fields.Url(required=True)
     API_ENDPOINT = fields.Url(required=True)
-    API_TAXHUB = fields.Url(required=True)
+    API_TAXHUB = fields.Url()
     CODE_APPLICATION = fields.String(load_default="GN")
     XML_NAMESPACE = fields.String(load_default="{http://inpn.mnhn.fr/mtd}")
     MTD_API_ENDPOINT = fields.Url(load_default="https://preprod-inpn.mnhn.fr/mtd")
@@ -583,6 +578,16 @@ class GnGeneralSchemaConf(Schema):
                 "Si AUTO_ACCOUNT_CREATION = False, veuillez remplir le paramètre VALIDATOR_EMAIL",
                 "AUTO_ACCOUNT_CREATION, VALIDATOR_EMAIL",
             )
+
+    @pre_load
+    def _pre_load(self, data, **kwargs):
+        if "API_TAXHUB" in data:
+            warnings.warn(
+                "Le paramètre API_TAXHUB est déprécié, il sera automatiquement déduit API_ENDPOINT et supprimé dans la version 2.14",
+                Warning,
+            )
+        data["API_TAXHUB"] = f"{data['API_ENDPOINT']}/taxhub/api"
+        return data
 
     @post_load
     def insert_module_config(self, data, **kwargs):

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -586,7 +586,7 @@ class GnGeneralSchemaConf(Schema):
                 "Le paramètre API_TAXHUB est déprécié, il sera automatiquement déduit API_ENDPOINT et supprimé dans la version 2.14",
                 Warning,
             )
-        data["API_TAXHUB"] = f"{data['API_ENDPOINT']}/taxhub/api"
+        data["API_TAXHUB"] = f"{data['API_ENDPOINT']}/taxhub"
         return data
 
     @post_load

--- a/backend/requirements-common.in
+++ b/backend/requirements-common.in
@@ -3,6 +3,7 @@ click>=7.0
 fiona>=1.8.22,<1.9
 flask
 flask-admin
+flask-babelex
 flask-cors
 flask-mail
 flask-marshmallow<0.15.0

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -41,8 +41,6 @@ URL_APPLICATION = "http://url.com/geonature"
 # URL de l'API de GeoNature. Remplacer "url.com" par votre domaine ou IP
 API_ENDPOINT = "http://url.com/geonature/api"
 
-# URL de l'API de Taxhub
-API_TAXHUB = "http://127.0.0.1:5000/api/"
 
 # Type de session
 SESSION_TYPE = "filesystem"

--- a/config/geonature_config.toml.sample
+++ b/config/geonature_config.toml.sample
@@ -6,7 +6,6 @@
 SQLALCHEMY_DATABASE_URI = "postgresql://monuser:monpassachanger@localhost:5432/mabase"
 URL_APPLICATION = 'http://url.com/geonature'
 API_ENDPOINT = 'http://url.com/geonature/api'
-API_TAXHUB = 'http://url.com/taxhub/api'
 
 # Remplacer par une clé alétoire complexe
 SECRET_KEY = 'super secret key'

--- a/config/test_config.toml
+++ b/config/test_config.toml
@@ -1,7 +1,6 @@
 SQLALCHEMY_DATABASE_URI = "postgresql://geonatadmin:geonatpasswd@127.0.0.1:5432/geonature2db"
 URL_APPLICATION = 'http://127.0.0.1:4200'
 API_ENDPOINT = 'http://127.0.0.1:8000'
-API_TAXHUB = 'http://127.0.0.1:5000/api'
 SECRET_KEY = '5fdc2c8fb46f44033144d07396ba082a95b8b3cc827b611a7aaaefbef414f13b'
 DEFAULT_LANGUAGE='fr'
 [MAPCONFIG]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,23 @@
 CHANGELOG
 =========
 
+
+2.14.0 (unreleased)
+-------------------
+
+**🚀 Nouveautés**
+
+- Intégration de TaxHub dans GeoNature. L'interface est dispobible dans le "backoffice"
+
+**💻 Développement**
+
+- L'API de TaxHub est désormais disponible à l'URL `<URL_GEONATURE>/api/taxhub`.
+
+Note de version:
+
+- L'intégration de TaxHub dans GeoNature entraine la suppression du service systemd et la conf apache spécifique à TaxHub. Les logs sont également centralisés dans le fichier de log de GeoNature
+- Les médias de TaxHub sont copiés dans le repertoire `<GEONATURE_DIR>/medias/taxhub` lors de l'execution du script `migrate.sh`. Vous pouvez vérifier dans ce dossier que vos médias sont bien présents. Vous pouvez par la suite supprimer complétement le dossier de l'application TaxHub
+
 2.13.3 (2023-10-17)
 -------------------
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ CHANGELOG
 Note de version:
 
 - L'intégration de TaxHub dans GeoNature entraine la suppression du service systemd et la conf apache spécifique à TaxHub. Les logs sont également centralisés dans le fichier de log de GeoNature
-- Les médias de TaxHub sont copiés dans le repertoire `<GEONATURE_DIR>/medias/taxhub` lors de l'execution du script `migrate.sh`. Vous pouvez vérifier dans ce dossier que vos médias sont bien présents. Vous pouvez par la suite supprimer complétement le dossier de l'application TaxHub
+- Les permissions de TaxHub comme "module" de GeoNature ont été modifié. Voir la section "module TaxHub" de la doc administrateur de GeoNature. Les anciennes permissions de l'application TaxHub on été rappatriées dans ce nouveau modèle. Les utilisateurs avec un profil "6" ont tous les droits sur le modules, les personnes ayant des profils 1,3,4 ou 5 ont des droits sur les objets uniquement sur l'objet 'TAXON'.
 
 2.13.3 (2023-10-17)
 -------------------

--- a/docs/admin-manual.rst
+++ b/docs/admin-manual.rst
@@ -1883,6 +1883,12 @@ Le champs "Attribut additionnels" permet d'ajouter des éléments de configurati
 - Ajouter un sous-titre descriptif : `{"help" : "mon sous titre"}`
 - Ajouter des valeurs min/max pour un input `number` : `{"min": 1, "max": 10}`
 
+TaxHub
+""""""
+
+Backoffice de gestion des taxons (basé sur TaxHub) permettant de faire des liste de taxons ainsi que d'ajouter des attributs etdes médias aux taxons.
+Voir la documentation de TaxHub : https://taxhub.readthedocs.io/fr/latest/
+
 Module OCCHAB
 -------------
 

--- a/docs/admin-manual.rst
+++ b/docs/admin-manual.rst
@@ -2272,3 +2272,23 @@ Liste des propriétés disponibles :
 - data_link : lien vers l'observation dans son module de saisie
 - tous les champs de la synthèse (acquisition_framework, altitude_max, altitude_min, bio_status, blurring, cd_hab, cd_nom, comment_context, comment_description, date_min, depth_max, depth_min, determiner, diffusion_level, digital_proof, entity_source_pk_value, exist_proof, grp_method, grp_typ, last_action, life_stage, meta_create_date, meta_update_date, meta_v_taxref, meta_validation_date, nat_obj_geo, naturalness, nom_cite, non_digital_proof, obj_count, obs_technique, observation_status, observers, occ_behaviour, occ_stat_biogeo, place_name, precision, sample_number_proof, sensitivity, sex, source, type_count, unique_id_sinp, unique_id_sinp_grp, valid_status, validation_comment)
 - tous les champs du taxon (cd_nom, cd_ref, cd_sup, cd_taxsup, regne, ordre, classe, famille, group1_inpn, group2_inpn, id_rang, nom_complet, nom_habitat, nom_rang, nom_statut, nom_valide, nom_vern)
+
+
+
+Module TaxHub
+-------------
+
+Depuis la version 2.14 de GeoNature, TaxHub est integré comme un module de GeoNature. Il est disponible depuis le backoffice de GeoNature.
+
+L'emplacement de stockage des médias est contrôlé par le paramètre `MEDIA_FOLDER`. Les médias de TaxHub seront à l'emplacement `<MEDIA_FOLDER>/taxhub`. Par défaut tous les médias de GeoNature sont stocké dans le répertoire de GeoNature : `<GEONATURE_DIR>/backend/media`. Via ce paramètre, il est possible de mettre un chemin absolu pour stocker les médias n'importe ou sur votre serveur.
+
+Gestion des permissions
+```````````````````````
+
+La gestion des permissions du module TaxHub est entierement gérée par le module de gestion de permission de GeoNature. Dans le cas d'une installation standalone de TaxHub, se réferer à la documentation de TaxHub pour la gestion des permissions.
+
+Les permissions du module TaxHub peuvent être reglé aux trois niveaux (objets) suivants : 
+- TAXON : permet voir et modifier des taxons (ajout de médias, d'attributs et association de taxon à des listes)
+- THEME : permet de voir / modifier / supprimer des thêmes. Les thêmes sont des groupes d'attributs
+- LISTE : permet de voir / modifier / supprimer des listes de taxons
+- ATTRIBUT : permet de voir / modifier / supprimer des attributs de taxons

--- a/docs/https.rst
+++ b/docs/https.rst
@@ -60,7 +60,6 @@ Modifier les éléments suivants :
 	
   URL_APPLICATION = 'https://mondomaine.fr/geonature'
   API_ENDPOINT = 'https://mondomaine.fr/geonature/api'
-  API_TAXHUB = 'https://mondomaine.fr/taxhub/api'
 
 Pour que ces modifications soient prises en compte, exécuter les :ref:`actions à effecture après modification de la configuration <post_config_change>`.
 

--- a/install/assets/vhost_apache.conf
+++ b/install/assets/vhost_apache.conf
@@ -2,7 +2,6 @@
     ServerName ${DOMAIN_NAME}
 
     IncludeOptional /etc/apache2/conf-available/geonature.conf
-    IncludeOptional /etc/apache2/conf-available/taxhub.conf
     IncludeOptional /etc/apache2/conf-available/usershub.conf
 
     ErrorLog "/var/log/apache2/geonature_error.log"

--- a/install/install_all/install_all.ini
+++ b/install/install_all/install_all.ini
@@ -17,9 +17,9 @@ my_url=http://mon.domaine.com/
 pg_host=localhost
 # Port sur lequel PostgreSQL ecoute
 pg_port=5432
-# Nom de l'utilisateur propriétaire des bases UsersHub, GeoNature, TaxHub
+# Nom de l'utilisateur propriétaire des bases UsersHub, GeoNature
 user_pg=geonatadmin
-# Mot de passe de l'utilisateur propriétaire des bases UsersHub, GeoNature, TaxHub
+# Mot de passe de l'utilisateur propriétaire des bases UsersHub, GeoNature
 user_pg_pass=monpassachanger
 
 ### CONFIGURATION USERSHUB ###
@@ -66,11 +66,3 @@ install_module_occhab=true
 # Laisser vide si vous n'avez pas de proxy
 proxy_http=
 proxy_https=
-
-### CONFIGURATION TAXHUB ###
-
-# Version de TaxHub
-taxhub_release=1.12.1
-# Pour des questions de performances de GeoNature, il n'y a pas de base de données spécifique pour TaxHub
-# Le schéma "taxonomie" de TaxHub est intégré dans la BDD de GeoNature pour que les requêtes ne soient pas trop pénalisées
-# par un accès à une BDD distante.

--- a/install/migration/migration.sh
+++ b/install/migration/migration.sh
@@ -25,6 +25,19 @@ if [ ! -d "${olddir}/backend" ] || [ ! -d "${olddir}/frontend" ] || [ ! -f "${ol
     exit 1
 fi
 
+# before 2.13 - Rappatriement des médias TaxHub necessite de connaitre l'emplacement de taxhub
+if [ ! -d "${newdir}/backend/media/taxhub" ];then
+    TAXHUB_DIR="${HOME}/taxhub"
+    if (($# > 1)); then
+        TAXHUB_DIR="$(realpath "$2")"
+    fi
+    if [ ! -d "${TAXHUB_DIR}/apptax" ];then
+        echo $2
+        echo "Le dossier ${TAXHUB_DIR} ne semble pas contenir une installation de TaxHub. Veuillez spécifier le chemin vers TaxHub et celui de GeoNature : ./install/migration/migration.sh [OLD_GeoNature_dir] [OLD_TaxHub_dir]"
+    fi
+fi
+
+
 echo "Nouveau dossier GeoNature : ${newdir} ($(cat "${newdir}/VERSION"))"
 echo "Ancien dossier GeoNature : ${olddir} ($(cat "${olddir}/VERSION"))"
 
@@ -95,14 +108,6 @@ if [ ! -f "${newdir}/custom/css/metadata_pdf_custom.css" ] && [ -f "${olddir}/ba
   cp "${olddir}/backend/static/css/custom.css" "${newdir}/custom/css/metadata_pdf_custom.css"
 fi
 
-# before 2.13 - Rappatriement des médias TaxHub
-
-if [ ! -d "${newdir}/media/taxhub" ];then
-mkdir "${newdir}/backend/media/taxhub"
-taxhub_dir="$(dirname -- "${newdir}")/taxhub"
-mv "${taxhub_dir}/static/medias/" "${newdir}/backend/media/taxhub"
-
-fi
 
 
 echo "Mise à jour de node si nécessaire …"
@@ -278,9 +283,21 @@ fi
 
 if [ -f "/etc/apache2/sites-available/taxhub-le-ssl.conf" ]; then
     rm /etc/apache2/sites-available/taxhub-le-ssl.conf
+    rm -r /var/log/taxhub/
 fi
 
+if [ ! -d "${newdir}/backend/medias/taxhub" ]; then
+    mkdir -p "${newdir}"/backend/medias/taxhub/
+    cp 
+fi
+
+# before 2.13 - Rappatriement des médias TaxHub
+
+if [ ! -d "${newdir}/backend/media/taxhub" ];then
+    mkdir "${newdir}/backend/media/taxhub"
+    cp "${TAXHUB_DIR}"/static/medias/taxhub/* "${newdir}"/backend/media/taxhub/
+fi
+
+
 sudo apachectl restart
-
-
 echo "Migration terminée"


### PR DESCRIPTION
- Chargement des routes de l'API de TaxHub directement dans GN
- Ajout de l'admin TaxHub dans l'admin GN

TODO:
- [x] : rendre le paramètre `API_TAXHUB` obselète
- [ ] revoir les tests
- l'api est donc maintenant sur /geonature/api/taxhub/api - On peut peut-être virer le second /api ...