### PR TITLE
fix(backend): multiple geo filters request

### DIFF
--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -452,8 +452,13 @@ class SyntheseQuery:
         # generic filters
         for colname, value in self.filters.items():
             if colname.startswith("area"):
-                self.add_join(CorAreaSynthese, CorAreaSynthese.id_synthese, self.model.id_synthese)
-                self.query = self.query.where(CorAreaSynthese.id_area.in_(value))
+                cor_area_synthese_alias = aliased(CorAreaSynthese)
+                self.add_join(
+                    cor_area_synthese_alias,
+                    cor_area_synthese_alias.id_synthese,
+                    self.model.id_synthese,
+                )
+                self.query = self.query.where(cor_area_synthese_alias.id_area.in_(value))
             elif colname.startswith("id_"):
                 col = getattr(self.model.__table__.columns, colname)
                 if isinstance(value, list):


### PR DESCRIPTION
Closes #2639 

On a modifié les filtres en backend pour corriger le problème de sélection des obs lorsque plusieurs filtres géo sont utilisés : 

- filtre "ET" entre différents types de filtres géo (ex: sélection d'éléments dans ''communes" et "départements")
- filtre "OU" à l'intérieur d'un filtre géo si plusieurs éléments sont sélectionnés (ex: plusieurs communes)

exemple : 

![image](https://github.com/PnX-SI/GeoNature/assets/40057801/32fb1d8d-3356-48fd-9edd-18bc0524b3ff)

ceci va sélectionner pour la région PACA uniquement les obs faites dans les Hautes-Alpes et le Var.