### PR TITLE
fix(front): OCCTAX displaying last geometry point

### DIFF
--- a/contrib/occtax/frontend/app/occtax-form/map/occtax-map.service.ts
+++ b/contrib/occtax/frontend/app/occtax-form/map/occtax-map.service.ts
@@ -37,6 +37,7 @@ export class OcctaxFormMapService {
     this.manageGeometryChange(geojson);
     if (geojson.type == 'Point') {
       this.markerCoordinates = geojson.coordinates;
+      this.leafletDrawGeoJson = geojson;
     } else {
       this.leafletDrawGeoJson = geojson;
     }


### PR DESCRIPTION
Fix --> Erreur d'affichage lors de l'enchainement de saisie de relevé pour le module occtax . Si la géométrie saisie pour le premier  relevé est un polygon/polyline et que le second relevé est un point ce dernier n'est pas affiché au retour sur le composant map pour le relevé suivant.

Closes #2657
[Refs_ticket]: #2657
Reviewed-by: andriacap