### PR TITLE
feat(occtax): add config to expand advanced btn

### DIFF
--- a/contrib/occtax/backend/occtax/conf_schema_toml.py
+++ b/contrib/occtax/backend/occtax/conf_schema_toml.py
@@ -191,3 +191,4 @@ class GnModuleSchemaConf(Schema):
     ADD_MEDIA_IN_EXPORT = fields.Boolean(load_default=False)
     ID_LIST_HABITAT = fields.Integer(load_default=None)
     CD_TYPO_HABITAT = fields.Integer(load_default=None)
+    ADVANCED_DETAILS_OCCURRENCE_EXPANDED = fields.Boolean(load_default=False)

--- a/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.component.ts
+++ b/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.component.ts
@@ -77,7 +77,9 @@ export class OcctaxFormOccurrenceComponent implements OnInit, OnDestroy {
         )
         .subscribe((display: boolean) => (this.displayProofFromElements = display))
     );
-
+    this.advanced = this.config.OCCTAX.ADVANCED_DETAILS_OCCURRENCE_EXPANDED
+      ? 'expanded'
+      : 'collapsed';
     this.initTaxrefSearch();
   }
 

--- a/contrib/occtax/occtax_config.toml.example
+++ b/contrib/occtax/occtax_config.toml.example
@@ -24,6 +24,9 @@ DATE_FORM_WITH_TODAY = true
 # Displays the possibility for the user to indicate a default value for the different fields of the form
 ENABLE_SETTINGS_TOOLS = false
 
+# Automatically expand the advanced button when adding a taxon
+ADVANCED_DETAILS_OCCURRENCE_EXPANDED = false
+
 # -------- MAPLIST PARAMETER ------------
 
 # Zoom level on the map from which you can add point/line/polygon


### PR DESCRIPTION
Ajout d'un paramètre en configuration pour automatiquement déplier le bouton "Avancé" dans la saisie d'un taxon lors d'une occurrence.

Closes #2446