### PR TITLE
Feat/Occtax: group3_inpn dans les nomenclatures de saisie

### DIFF
--- a/contrib/occtax/frontend/app/occtax-form/counting/counting.component.html
+++ b/contrib/occtax/frontend/app/occtax-form/counting/counting.component.html
@@ -8,7 +8,8 @@
       codeNomenclatureType="OBJ_DENBR"
       [parentFormControl]="form.get('id_nomenclature_obj_count')"
       [regne]="(occtaxFormOccurrenceService.taxref|async)?.regne"
-      [group2Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group2_inpn">
+      [group2Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group2_inpn"
+      [group3Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group3_inpn">
     </pnx-nomenclature>
   </div>
   <div
@@ -21,7 +22,8 @@
       codeNomenclatureType="TYP_DENBR"
       [parentFormControl]="form.get('id_nomenclature_type_count')"
       [regne]="(occtaxFormOccurrenceService.taxref|async)?.regne"
-      [group2Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group2_inpn">
+      [group2Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group2_inpn"
+      [group3Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group3_inpn">
     </pnx-nomenclature>
   </div>
 
@@ -83,7 +85,8 @@
       codeNomenclatureType="STADE_VIE"
       [parentFormControl]="form.get('id_nomenclature_life_stage')"
       [regne]="(occtaxFormOccurrenceService.taxref|async)?.regne"
-      [group2Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group2_inpn">
+      [group2Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group2_inpn"
+      [group3Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group3_inpn">
     </pnx-nomenclature>
     <small
       *ngIf="form.get('id_nomenclature_life_stage').hasError('required') && form.get('id_nomenclature_life_stage').touched"
@@ -102,7 +105,8 @@
       codeNomenclatureType="SEXE"
       [parentFormControl]="form.get('id_nomenclature_sex')"
       [regne]="(occtaxFormOccurrenceService.taxref|async)?.regne"
-      [group2Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group2_inpn">
+      [group2Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group2_inpn"
+      [group3Inpn]="(occtaxFormOccurrenceService.taxref|async)?.group3_inpn">
     </pnx-nomenclature>
     <small
       *ngIf="form.get('id_nomenclature_sex').hasError('required') && form.get('id_nomenclature_sex').touched"

--- a/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.component.html
+++ b/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.component.html
@@ -55,6 +55,7 @@
       codeNomenclatureType="METH_OBS"
       [regne]="taxref?.regne"
       [group2Inpn]="taxref?.group2_inpn"
+      [group3Inpn]="taxref?.group3_inpn"
       data-qa="pnx-nomenclature-meth-obs"
     >
     </pnx-nomenclature>
@@ -77,6 +78,7 @@
       codeNomenclatureType="ETA_BIO"
       [regne]="taxref?.regne"
       [group2Inpn]="taxref?.group2_inpn"
+      [group3Inpn]="taxref?.group3_inpn"
       data-qa="pnx-nomenclature-eta-bio"
     >
     </pnx-nomenclature>
@@ -135,7 +137,8 @@
           [parentFormControl]="occurrenceForm.get('id_nomenclature_determination_method')"
           codeNomenclatureType="METH_DETERMIN" 
           [regne]="taxref?.regne"
-          [group2Inpn]="taxref?.group2_inpn">
+          [group2Inpn]="taxref?.group2_inpn"
+          [group3Inpn]="taxref?.group3_inpn">
         </pnx-nomenclature>
         <small
           *ngIf="occurrenceForm.get('id_nomenclature_determination_method').hasError('required') && occurrenceForm.get('id_nomenclature_determination_method').touched"
@@ -176,6 +179,7 @@
         codeNomenclatureType="NATURALITE"
         [regne]="taxref?.regne"
         [group2Inpn]="taxref?.group2_inpn"
+        [group3Inpn]="taxref?.group3_inpn"
       >
       </pnx-nomenclature>
     </div>
@@ -194,7 +198,8 @@
         [parentFormControl]="occurrenceForm.get('id_nomenclature_bio_status')"
         codeNomenclatureType="STATUT_BIO"
         [regne]="taxref?.regne"
-        [group2Inpn]="taxref?.group2_inpn">
+        [group2Inpn]="taxref?.group2_inpn"
+        [group3Inpn]="taxref?.group3_inpn">
       </pnx-nomenclature>
     </div>
 
@@ -208,6 +213,7 @@
         codeNomenclatureType="OCC_COMPORTEMENT"
         [regne]="taxref?.regne"
         [group2Inpn]="taxref?.group2_inpn"
+        [group3Inpn]="taxref?.group3_inpn"
       >
       </pnx-nomenclature>
     </div>
@@ -247,6 +253,7 @@
         codeNomenclatureType="PREUVE_EXIST"
         [regne]="taxref?.regne"
         [group2Inpn]="taxref?.group2_inpn"
+        [group3Inpn]="taxref?.group3_inpn"
         (labelsLoaded)="setExistProofData($event)"
       >
       </pnx-nomenclature>

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -35,6 +35,7 @@ export class DataFormService {
     codeNomenclatureType: string,
     regne?: string,
     group2_inpn?: string,
+    group3_inpn?: string,
     filters?: any
   ) {
     let params: HttpParams = new HttpParams();
@@ -42,6 +43,9 @@ export class DataFormService {
     group2_inpn
       ? (params = params.set('group2_inpn', group2_inpn))
       : (params = params.set('group2_inpn', ''));
+    group3_inpn
+      ? (params = params.set('group3_inpn', group3_inpn))
+      : (params = params.set('group3_inpn', ''));
     if (filters['orderby']) {
       params = params.set('orderby', filters['orderby']);
     }

--- a/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.ts
@@ -65,6 +65,10 @@ export class NomenclatureComponent
    */
   @Input() group2Inpn: string;
   /**
+   * Filter group 3 INPN
+   */
+  @Input() group3Inpn?: string;
+  /**
    * Attribut de l'objet nomenclature renvoyé au formControl (facultatif, par défaut ``id_nomenclature``).
    * Valeur possible: n'importequel attribut de l'objet ``nomenclature`` renvoyé par l'API
    */
@@ -128,7 +132,9 @@ export class NomenclatureComponent
     if (
       changes.regne === undefined &&
       changes.group2Inpn !== undefined &&
-      !changes.group2Inpn.firstChange
+      !changes.group2Inpn.firstChange &&
+      changes.group3Inpn !== undefined &&
+      !changes.group3Inpn.firstChange
     ) {
       this.initLabels();
     }
@@ -137,7 +143,13 @@ export class NomenclatureComponent
   initLabels() {
     const filters = { orderby: 'label_default', cd_nomenclature: this.cdNomenclatures };
     this._dfService
-      .getNomenclature(this.codeNomenclatureType, this.regne, this.group2Inpn, filters)
+      .getNomenclature(
+        this.codeNomenclatureType,
+        this.regne,
+        this.group2Inpn,
+        this.group3Inpn,
+        filters
+      )
       .subscribe((data) => {
         this.labels = data.values;
         this.savedLabels = data.values;

--- a/frontend/src/app/metadataModule/services/actor-form.service.ts
+++ b/frontend/src/app/metadataModule/services/actor-form.service.ts
@@ -54,7 +54,7 @@ export class ActorFormService {
     this.dfs.getRoles({ group: false }).subscribe((roles: any[]) => this._roles.next(roles));
 
     this.dfs
-      .getNomenclature('ROLE_ACTEUR', null, null, { orderby: 'label_default' })
+      .getNomenclature('ROLE_ACTEUR', null, null, null, { orderby: 'label_default' })
       .pipe(map((res: any) => res.values))
       .subscribe((role_types: any[]) => this._role_types.next(role_types));
   }


### PR DESCRIPTION
Ajout de la possibilité de personnaliser les nomenclature pour la saisie dans Occtax en fonction du groupe 3 Inpn.

Cette contribution a mené à d'autres contributions au travers des différentes librairies et applications utilisées dans GeoNature, cette PR dépend donc de : 
- https://github.com/PnX-SI/TaxHub/pull/433 : permet d'ajouter un check pour vérifier si la chaîne de caractère fournie est bien un groupe 3 inpn, ce qui dépend également d'une vue matérialisée créée aussi dans cette PR
- https://github.com/PnX-SI/Nomenclature-api-module/pull/53 : permet d'ajouter la colonne à `group3_inpn` à `ref_nomenclatures.cor_taxref_nomenclature` ainsi que les routes API nécessaires pour filtrer les nomenclatures avec le `group3_inpn` et utilise la PR ci-dessus pour vérifier que le groupe3_inpn inséré `ref_nomenclatures.cor_taxref_nomenclature` dans en est bien un
- https://github.com/PnX-SI/TaxHub/pull/432 (ajout du groupe3 inpn dans le retour de la route `/taxref/allnamebylist` de Taxhub)


---

Cette PR s'inscrit dans le cadre d'une prestation pour l'Agence Régionale de la Biodiversité en île de France