### PR TITLE
fixes nom_vern search frontend

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/taxonomy/taxonomy.component.scss
+++ b/frontend/src/app/GN2CommonModule/form/taxonomy/taxonomy.component.scss
@@ -25,4 +25,5 @@
 .dropdown-item {
   font-size: .8em;
   padding: 0.2rem;
+  white-space: normal;
 }


### PR DESCRIPTION
Pour le contexte : https://github.com/PnX-SI/TaxHub/issues/332

La PR de la partie alembic de l'issue est donc liée à TaxHub : https://github.com/PnX-SI/TaxHub/pull/435

Ici la PR concerne uniquement la partie frontend. Permet d'améliorer l'affichage de l'autocomplete lorsqu'il y a de multiples noms vernaculaires (exemples donnés dans l'issue)