### PR TITLE
add trailing / in nginx alias config

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,7 +3,7 @@ server {
     server_name  ${NGINX_HOST};
 
     location ${NGINX_LOCATION} {
-        alias  /usr/share/nginx/html;
+        alias  /usr/share/nginx/html/;
         index  index.html index.htm;
     }
 }


### PR DESCRIPTION
This is necessary to serve GeoNature without prefix, and still compatible with a prefix.