### PR TITLE
fix(synthese) changed required permissions to change report

### DIFF
--- a/frontend/src/app/shared/alertInfoModule/alert-Info.component.ts
+++ b/frontend/src/app/shared/alertInfoModule/alert-Info.component.ts
@@ -51,7 +51,7 @@ export class AlertInfoComponent implements OnInit, OnChanges {
       });
   }
   ngOnChanges() {
-    this.canChangeAlert = this.userCruved?.V && this.userCruved?.V > 0 && !isEmpty(this.alert);
+    this.canChangeAlert = this.userCruved?.R && this.userCruved?.R > 0 && !isEmpty(this.alert);
   }
   /**
    * Create new alert with /reports GET service

--- a/frontend/src/app/shared/alertInfoModule/alert-Info.component.ts
+++ b/frontend/src/app/shared/alertInfoModule/alert-Info.component.ts
@@ -51,7 +51,10 @@ export class AlertInfoComponent implements OnInit, OnChanges {
       });
   }
   ngOnChanges() {
-    this.canChangeAlert = this.userCruved?.R && this.userCruved?.R > 0 && !isEmpty(this.alert);
+    let moduleValidation = this.moduleService.getModule('VALIDATION');
+
+    this.canChangeAlert =
+      moduleValidation?.cruved?.R && moduleValidation?.cruved?.R > 0 && !isEmpty(this.alert);
   }
   /**
    * Create new alert with /reports GET service


### PR DESCRIPTION
On avait retenu que pour que seuls les validateurs puissent supprimer un signalement, on regardait la permission R du module Validation : https://github.com/PnX-SI/GeoNature/pull/1817#issuecomment-1086080755

Mais c'était resté sur la permission V du module Synthèse qui n'existe pas et a été nettoyé lors du passage en 2.13.0.