### PR TITLE
db.session.remove() in celery post run hook

### DIFF
--- a/backend/geonature/celery_app.py
+++ b/backend/geonature/celery_app.py
@@ -14,6 +14,7 @@ class ContextTask(app.Task):
 
 app.Task = ContextTask
 
+app.conf.imports += ("geonature.tasks",)
 app.conf.imports += tuple(
     [ep.module for dist in iter_modules_dist() for ep in dist.entry_points.select(name="tasks")]
 )

--- a/backend/geonature/tasks/__init__.py
+++ b/backend/geonature/tasks/__init__.py
@@ -1,0 +1,9 @@
+from celery.signals import task_postrun
+
+from geonature.utils.env import db
+from geonature.utils.celery import celery_app
+
+
+@task_postrun.connect
+def close_session(*args, **kwargs):
+    db.session.remove()


### PR DESCRIPTION
Ce fix a été testé en prod au MNHN quelques mois mais n’avait jamais été intégré upstream.
Il ne résous probablement pas tout les soucis soulevé dans #2717 mais peu aider.