### PR TITLE
celery: enable_utc=False

### DIFF
--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -102,6 +102,8 @@ class MailConfig(Schema):
 class CeleryConfig(Schema):
     broker_url = fields.String(load_default="redis://localhost:6379/0")
     result_backend = fields.String(load_default="redis://localhost:6379/0")
+    enable_utc = fields.Boolean(load_default=False)
+    timezone = fields.String(load_default=None)
 
 
 class AccountManagement(Schema):


### PR DESCRIPTION
Consequently, timezone becomes system local timezone instead of UTC.

En conséquence, les tâches planifiées sont lancé à l’heure local et non UTC, ce qui est sans doute plus naturel pour la plupart des utilisateurs. Il reste possible de spécifier une timezone donnée avec le paramètre `timezone`.

Problème évoqué dans le ticket #2717