### PR TITLE
[SYNTHESE] Feat/return only needed and wanted synthese columns

### DIFF
--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -133,46 +133,43 @@ def get_observations_for_web(permissions):
     if output_format not in ["ungrouped_geom", "grouped_geom", "grouped_geom_by_areas"]:
         raise BadRequest(f"Bad format '{output_format}'")
 
-    # Build defaut CTE observations query
-    count_min_max = case(
-        [
-            (
-                VSyntheseForWebApp.count_min != VSyntheseForWebApp.count_max,
-                func.concat(VSyntheseForWebApp.count_min, " - ", VSyntheseForWebApp.count_max),
-            ),
-            (VSyntheseForWebApp.count_min != None, func.concat(VSyntheseForWebApp.count_min)),
-        ],
-        else_="",
-    )
-
-    nom_vern_or_lb_nom = func.coalesce(
-        func.nullif(VSyntheseForWebApp.nom_vern, ""), VSyntheseForWebApp.lb_nom
-    )
-
+    # Get Column Frontend parameter to return only the needed columns
+    param_column_list = {
+        col["prop"] for col in current_app.config["SYNTHESE"]["LIST_COLUMNS_FRONTEND"]
+    }
+    # Init with compulsory columns
     columns = [
         "id",
         VSyntheseForWebApp.id_synthese,
-        "date_min",
-        VSyntheseForWebApp.date_min,
-        "lb_nom",
-        VSyntheseForWebApp.lb_nom,
-        "cd_nom",
-        VSyntheseForWebApp.cd_nom,
-        "observers",
-        VSyntheseForWebApp.observers,
-        "dataset_name",
-        VSyntheseForWebApp.dataset_name,
         "url_source",
         VSyntheseForWebApp.url_source,
-        "unique_id_sinp",
-        VSyntheseForWebApp.unique_id_sinp,
-        "nom_vern_or_lb_nom",
-        nom_vern_or_lb_nom,
-        "count_min_max",
-        count_min_max,
-        "entity_source_pk_value",
-        VSyntheseForWebApp.entity_source_pk_value,
     ]
+
+    if "count_min_max" in param_column_list:
+        # Build defaut CTE observations query
+        count_min_max = case(
+            [
+                (
+                    VSyntheseForWebApp.count_min != VSyntheseForWebApp.count_max,
+                    func.concat(VSyntheseForWebApp.count_min, " - ", VSyntheseForWebApp.count_max),
+                ),
+                (VSyntheseForWebApp.count_min != None, func.concat(VSyntheseForWebApp.count_min)),
+            ],
+            else_="",
+        )
+        columns += ["count_min_max", count_min_max]
+        param_column_list.remove("count_min_max")
+
+    if "nom_vern_or_lb_nom" in param_column_list:
+        nom_vern_or_lb_nom = func.coalesce(
+            func.nullif(VSyntheseForWebApp.nom_vern, ""), VSyntheseForWebApp.lb_nom
+        )
+        columns += ["nom_vern_or_lb_nom", nom_vern_or_lb_nom]
+        param_column_list.remove("nom_vern_or_lb_nom")
+
+    for column in param_column_list:
+        columns += [column, getattr(VSyntheseForWebApp, column)]
+
     observations = func.json_build_object(*columns).label("obs_as_json")
 
     obs_query = (

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -460,16 +460,21 @@ class TestSynthese:
         # le requete doit etre OK marlgré la geom NULL
         assert response.status_code == 200
 
-    def test_get_observations_for_web_param_column_frontend(self, app, users, synthese_data):
+    @pytest.mark.parametrize(
+        "additionnal_column",
+        [("altitude_min"), ("count_min_max"), ("nom_vern_or_lb_nom")],
+    )
+    def test_get_observations_for_web_param_column_frontend(
+        self, app, users, synthese_data, additionnal_column
+    ):
         """
         Test de renseigner le paramètre LIST_COLUMNS_FRONTEND pour renvoyer uniquement
         les colonnes souhaitées
         """
-        expected_additionnal_column = "altitude_min"
         app.config["SYNTHESE"]["LIST_COLUMNS_FRONTEND"] = [
             {
-                "prop": expected_additionnal_column,
-                "name": "Altitude min",
+                "prop": additionnal_column,
+                "name": "My label",
             }
         ]
 
@@ -478,7 +483,7 @@ class TestSynthese:
         response = self.client.get(url_for("gn_synthese.get_observations_for_web"))
         data = response.get_json()
 
-        expected_columns = {"id", "url_source", expected_additionnal_column}
+        expected_columns = {"id", "url_source", additionnal_column}
 
         assert all(
             set(feature["properties"].keys()) == expected_columns for feature in data["features"]


### PR DESCRIPTION
Dans la route `/for_web`, prend le paramètre de configuration `LIST_COLUMNS_FRONTEND` pour sélectionner et renvoyer uniquement les colonnes présentes dans ce paramètre ainsi que les colonnes obligatoires (`id` et `url_source`).

Cela permet : 
- de renvoyer uniquement les colonnes voulues (réduit la taille de la réponse de la route)
- de renvoyer n'importe quelle colonne de la vue `v_synthese_for_web_app`

Closes #2749 

---

Cette PR entre dans le cadre d'une prestation pour l'Agence Régionale de la Biodiversité en île de France