### PR TITLE
feat: add Event DRAWSTOP (improve ux)

### DIFF
--- a/frontend/src/app/GN2CommonModule/map/leaflet-draw/leaflet-draw.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/leaflet-draw/leaflet-draw.component.ts
@@ -54,7 +54,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
   constructor(
     public mapservice: MapService,
     private _commonService: CommonService,
-    public config: ConfigService,
+    public config: ConfigService
   ) {}
 
   ngOnInit() {
@@ -151,15 +151,6 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
     });
 
     this.map.on(this._Le.Draw.Event.DRAWSTOP, (e) => {
-      // if (this._currentDraw) {
-      //   if (
-      //     !this.mapservice.leafletDrawFeatureGroup.hasLayer(this._currentDraw) &&
-      //     this._currentGeojson
-      //   ) {
-      //     this.loadDrawfromGeoJson(this._currentGeojson.geometry);
-      //   }
-      //   return;
-      // } else
       if (this._currentGeojson) {
         this.mapservice.removeAllLayers(this.map, this.mapservice.leafletDrawFeatureGroup);
         const layer: L.Layer = this.mapservice.createGeojson(this._currentGeojson.geometry, false);
@@ -167,13 +158,6 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
           this.loadDrawfromGeoJson(this._currentGeojson.geometry);
         }
       }
-      // } else {
-      //   this.mapservice.removeAllLayers(this.map, this.mapservice.leafletDrawFeatureGroup);
-      //   const layer: L.Layer = this.mapservice.createGeojson(this.geojson, false);
-      //   if (!this.mapservice.leafletDrawFeatureGroup.hasLayer(layer)) {
-      //     this.loadDrawfromGeoJson(this.geojson);
-      //   }
-      // }
     });
   }
 
@@ -195,7 +179,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
     if (geojson.type === 'LineString' || geojson.type === 'MultiLineString') {
       const latLng = L.GeoJSON.coordsToLatLngs(
         geojson.coordinates,
-        geojson.type === 'LineString' ? 0 : 1,
+        geojson.type === 'LineString' ? 0 : 1
       );
       layer = L.polyline(latLng);
       this.mapservice.leafletDrawFeatureGroup.addLayer(layer);
@@ -203,7 +187,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
     if (geojson.type === 'Polygon' || geojson.type === 'MultiPolygon') {
       const latLng = L.GeoJSON.coordsToLatLngs(
         geojson.coordinates,
-        geojson.type === 'Polygon' ? 1 : 2,
+        geojson.type === 'Polygon' ? 1 : 2
       );
       layer = L.polygon(latLng);
       this.mapservice.leafletDrawFeatureGroup.addLayer(layer);
@@ -224,7 +208,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
         this.mapservice.map.setView(
           layer._latlng,
           this.zoomLevelOnPoint,
-          this.mapservice.map['_zoom'],
+          this.mapservice.map['_zoom']
         );
       } else {
         this.mapservice.map.panTo(layer._latlng);

--- a/frontend/src/app/GN2CommonModule/map/leaflet-draw/leaflet-draw.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/leaflet-draw/leaflet-draw.component.ts
@@ -54,7 +54,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
   constructor(
     public mapservice: MapService,
     private _commonService: CommonService,
-    public config: ConfigService
+    public config: ConfigService,
   ) {}
 
   ngOnInit() {
@@ -151,27 +151,29 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
     });
 
     this.map.on(this._Le.Draw.Event.DRAWSTOP, (e) => {
-      if (this._currentDraw) {
-        if (
-          !this.mapservice.leafletDrawFeatureGroup.hasLayer(this._currentDraw) &&
-          this._currentGeojson
-        ) {
-          this.loadDrawfromGeoJson(this._currentGeojson.geometry);
-        }
-        return;
-      } else if (this._currentGeojson) {
-        this.mapservice.removeAllLayers(this.map, this.mapservice.fileLayerFeatureGroup);
+      // if (this._currentDraw) {
+      //   if (
+      //     !this.mapservice.leafletDrawFeatureGroup.hasLayer(this._currentDraw) &&
+      //     this._currentGeojson
+      //   ) {
+      //     this.loadDrawfromGeoJson(this._currentGeojson.geometry);
+      //   }
+      //   return;
+      // } else
+      if (this._currentGeojson) {
+        this.mapservice.removeAllLayers(this.map, this.mapservice.leafletDrawFeatureGroup);
         const layer: L.Layer = this.mapservice.createGeojson(this._currentGeojson.geometry, false);
         if (!this.mapservice.leafletDrawFeatureGroup.hasLayer(layer)) {
           this.loadDrawfromGeoJson(this._currentGeojson.geometry);
         }
-      } else {
-        this.mapservice.removeAllLayers(this.map, this.mapservice.leafletDrawFeatureGroup);
-        const layer: L.Layer = this.mapservice.createGeojson(this.geojson, false);
-        if (!this.mapservice.leafletDrawFeatureGroup.hasLayer(layer)) {
-          this.loadDrawfromGeoJson(this.geojson);
-        }
       }
+      // } else {
+      //   this.mapservice.removeAllLayers(this.map, this.mapservice.leafletDrawFeatureGroup);
+      //   const layer: L.Layer = this.mapservice.createGeojson(this.geojson, false);
+      //   if (!this.mapservice.leafletDrawFeatureGroup.hasLayer(layer)) {
+      //     this.loadDrawfromGeoJson(this.geojson);
+      //   }
+      // }
     });
   }
 
@@ -193,7 +195,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
     if (geojson.type === 'LineString' || geojson.type === 'MultiLineString') {
       const latLng = L.GeoJSON.coordsToLatLngs(
         geojson.coordinates,
-        geojson.type === 'LineString' ? 0 : 1
+        geojson.type === 'LineString' ? 0 : 1,
       );
       layer = L.polyline(latLng);
       this.mapservice.leafletDrawFeatureGroup.addLayer(layer);
@@ -201,7 +203,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
     if (geojson.type === 'Polygon' || geojson.type === 'MultiPolygon') {
       const latLng = L.GeoJSON.coordsToLatLngs(
         geojson.coordinates,
-        geojson.type === 'Polygon' ? 1 : 2
+        geojson.type === 'Polygon' ? 1 : 2,
       );
       layer = L.polygon(latLng);
       this.mapservice.leafletDrawFeatureGroup.addLayer(layer);
@@ -222,7 +224,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
         this.mapservice.map.setView(
           layer._latlng,
           this.zoomLevelOnPoint,
-          this.mapservice.map['_zoom']
+          this.mapservice.map['_zoom'],
         );
       } else {
         this.mapservice.map.panTo(layer._latlng);

--- a/frontend/src/app/GN2CommonModule/map/leaflet-draw/leaflet-draw.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/leaflet-draw/leaflet-draw.component.ts
@@ -24,6 +24,7 @@ L.Icon.Default.mergeOptions(CustomIcon);
 export class LeafletDrawComponent implements OnInit, OnChanges {
   public map: Map;
   private _currentDraw: any;
+  private _currentGeojson: any;
   private _Le: any;
   public drawnItems: any;
   // save the current layer type because the edite event do not send it...
@@ -80,6 +81,8 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
     }
 
     this.map.on(this._Le.Draw.Event.DRAWSTART, (e) => {
+      this._currentGeojson =
+        this._currentGeojson == null ? { geometry: this.geojson } : this._currentGeojson;
       this.mapservice.removeAllLayers(this.map, this.mapservice.fileLayerFeatureGroup);
       if (this.map.getZoom() < this.zoomLevel) {
         this._commonService.translateToaster('warning', 'Map.ZoomWarning');
@@ -110,6 +113,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
 
     // on draw layer created
     this.map.on(this._Le.Draw.Event.CREATED, (e) => {
+      this.mapservice.removeAllLayers(this.map, this.mapservice.leafletDrawFeatureGroup);
       if (this.map.getZoom() < this.zoomLevel) {
         this._commonService.translateToaster('warning', 'Map.ZoomWarning');
         this.layerDrawed.emit({ geojson: null });
@@ -120,6 +124,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
         this.mapservice.leafletDrawFeatureGroup.addLayer(this._currentDraw);
         const geojson = this.getGeojsonFromFeatureGroup(this.currentLayerType);
         this.mapservice.setGeojsonCoord(geojson);
+        this._currentGeojson = geojson;
         this.layerDrawed.emit(geojson);
       }
     });
@@ -128,6 +133,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
     this.mapservice.map.on(this._Le.Draw.Event.EDITED, (e) => {
       const geojson = this.getGeojsonFromFeatureGroup(this.currentLayerType);
       this.mapservice.setGeojsonCoord(geojson);
+      this._currentGeojson = geojson;
       this.layerDrawed.emit(geojson);
     });
 
@@ -141,6 +147,30 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
       if (geojson) {
         this.layerDrawed.emit(geojson);
         this.mapservice.setGeojsonCoord(geojson);
+      }
+    });
+
+    this.map.on(this._Le.Draw.Event.DRAWSTOP, (e) => {
+      if (this._currentDraw) {
+        if (
+          !this.mapservice.leafletDrawFeatureGroup.hasLayer(this._currentDraw) &&
+          this._currentGeojson
+        ) {
+          this.loadDrawfromGeoJson(this._currentGeojson.geometry);
+        }
+        return;
+      } else if (this._currentGeojson) {
+        this.mapservice.removeAllLayers(this.map, this.mapservice.fileLayerFeatureGroup);
+        const layer: L.Layer = this.mapservice.createGeojson(this._currentGeojson.geometry, false);
+        if (!this.mapservice.leafletDrawFeatureGroup.hasLayer(layer)) {
+          this.loadDrawfromGeoJson(this._currentGeojson.geometry);
+        }
+      } else {
+        this.mapservice.removeAllLayers(this.map, this.mapservice.leafletDrawFeatureGroup);
+        const layer: L.Layer = this.mapservice.createGeojson(this.geojson, false);
+        if (!this.mapservice.leafletDrawFeatureGroup.hasLayer(layer)) {
+          this.loadDrawfromGeoJson(this.geojson);
+        }
       }
     });
   }
@@ -208,6 +238,7 @@ export class LeafletDrawComponent implements OnInit, OnChanges {
       return;
     }
     this.mapservice.leafletDrawFeatureGroup.clearLayers();
+    this._currentGeojson = null;
     this.drawControl.remove();
   }
 


### PR DESCRIPTION
Avant à l'ajout d'une géométrie si on annulait ("cancel") l'ajout de la géométrie alors on revenait sur une map sans aucune layer (la layer d'origine n'était plus présente)
L'ajout de l'event DRAWSTOP permet de gérer ce cas de figure et améliorer l'UX

[Refs_ticket] : #2778 
Reviewed-by: andriacap