### PR TITLE
fix: ensure cleaning of current module while initiating home component

### DIFF
--- a/frontend/src/app/components/home-content/home-content.component.ts
+++ b/frontend/src/app/components/home-content/home-content.component.ts
@@ -51,6 +51,9 @@ export class HomeContentComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
+    // Ensure cleaning of currentModule
+    this._moduleService.currentModule$.next(null);
+
     this.getI18nLocale();
 
     this._SideNavService.sidenav.open();


### PR DESCRIPTION
fix #2795

**Scope:**

Routing côté frontend
Navigation vers la page d'accueil via le bouton précédent 

**Développement Réalisé:**

A l'initialisation du composant home (ngOnInit), le currentModule du moduleService est mis à null.
Cela permet de s'assurer, peu importe le chemin d'accès, que le module est dans un état correct