### PR TITLE
Feat/update to prettier 3 1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,5 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
       - name: Frontend code formatting check (Prettier)
-        run: npm install prettier && npm run format:check
+        run: npm install prettier@~3.1.0 && npm run format:check
         working-directory: ./frontend

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,7 +61,7 @@
         "@types/node": "^18.0.0",
         "cypress": "^13.4.0",
         "cypress-promise": "^1.1.0",
-        "prettier": "^3.0.0",
+        "prettier": "~3.1.0",
         "typescript": "4.9.4"
       }
     },
@@ -10113,9 +10113,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -20027,9 +20027,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true
     },
     "pretty-bytes": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
     "@types/node": "^18.0.0",
     "cypress": "^13.4.0",
     "cypress-promise": "^1.1.0",
-    "prettier": "^3.0.0",
+    "prettier": "~3.1.0",
     "typescript": "4.9.4"
   }
 }

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -526,8 +526,8 @@ export class DataFormService {
       application === 'GeoNature'
         ? `${this.config.API_ENDPOINT}/${api}`
         : application === 'TaxHub'
-        ? `${this.config.API_TAXHUB}/${api}`
-        : api;
+          ? `${this.config.API_TAXHUB}/${api}`
+          : api;
 
     return this._http.get<any>(url, { params: queryString });
   }

--- a/frontend/src/app/GN2CommonModule/form/media/media.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/media/media.component.ts
@@ -117,10 +117,10 @@ export class MediaComponent implements OnInit {
     return this.media.sent
       ? ''
       : this.mediaFormReadyToSend()
-      ? 'Veuillez valider le média en appuyant sur le bouton de validation'
-      : this.media.bFile
-      ? 'Veuillez compléter le formulaire et renseigner un fichier'
-      : 'Veuillez compléter le formulaire et Renseigner une URL valide';
+        ? 'Veuillez valider le média en appuyant sur le bouton de validation'
+        : this.media.bFile
+          ? 'Veuillez compléter le formulaire et renseigner un fichier'
+          : 'Veuillez compléter le formulaire et Renseigner une URL valide';
   }
 
   /**

--- a/frontend/src/app/metadataModule/actors/actors.component.ts
+++ b/frontend/src/app/metadataModule/actors/actors.component.ts
@@ -137,8 +137,8 @@ export class ActorComponent implements OnInit {
       this.actorForm.get('id_organism').value && this.actorForm.get('id_role').value
         ? 'all'
         : this.actorForm.get('id_role').value
-        ? 'person'
-        : 'organism';
+          ? 'person'
+          : 'organism';
 
     this.toggleActorOrganismChoiceChange({ value: btn });
   }


### PR DESCRIPTION
Périmètre: config de prettier et formatage

Pourquoi: 
La CI est cassée car les vérifications du frontend ne passent plus. 
Entre la version 3.0 et la version 3.1, il semble que prettier ne gère pas les règles d’opérateurs ternaires imbriqués de la même manière. 
Il s'agit bien d'une incompatibilité. 
Un formatage avec prettier 3.0.3 ne passe pas la vérification avec prettier 3.1.0
Un formatage avec prettier 3.1.0 ne passe pas la vérification avec prettier 3.0.3

Quoi: 
- Mise à jour de prettier à la version 3.1.0
- Contrainte appliquée à la version de type '~' (uniquement les patchs)
--> Puisqu'il semble que les versions ne soient pas strictement compatibles
- formatage des 3 fichiers en question

Autre option, non développée ici: 
- pas de mise à jour de version
- Contrainte appliquée à la version de type '~' (uniquement les patchs)

 