### PR TITLE
Fix/set sentry context

### DIFF
--- a/backend/geonature/app.py
+++ b/backend/geonature/app.py
@@ -171,7 +171,7 @@ def create_app(with_external_mods=True):
         def set_sentry_context():
             if "FLASK_REQUEST_ID" in request.environ:
                 set_tag("request.id", request.environ["FLASK_REQUEST_ID"])
-            if hasattr(g, "current_user") and g.current_user:
+            if hasattr(g, "current_user") and g.current_user.is_authenticated:
                 set_user(
                     {
                         "id": g.current_user.id_role,

--- a/backend/geonature/app.py
+++ b/backend/geonature/app.py
@@ -171,7 +171,7 @@ def create_app(with_external_mods=True):
         def set_sentry_context():
             if "FLASK_REQUEST_ID" in request.environ:
                 set_tag("request.id", request.environ["FLASK_REQUEST_ID"])
-            if g.current_user:
+            if hasattr(g, "current_user") and g.current_user:
                 set_user(
                     {
                         "id": g.current_user.id_role,


### PR DESCRIPTION
Je suis tombé sur cette erreur sur un appel de la route de config apparrement g n'a pas encore d'attribut current user à ce statde?

```
[2023-12-01 15:56:24 +0000] [10808] [ERROR] Exception on /gn_commons/config [GET]
Traceback (most recent call last):
  File "/home/joel/geonature/backend/venv/lib/python3.8/site-packages/flask/app.py", line 1821, in full_dispatch_request
    rv = self.preprocess_request()
  File "/home/joel/geonature/backend/venv/lib/python3.8/site-packages/flask/app.py", line 2313, in preprocess_request
    rv = self.ensure_sync(before_func)()
  File "/home/joel/geonature/backend/geonature/app.py", line 174, in set_sentry_context
    if g.current_user:
  File "/home/joel/geonature/backend/venv/lib/python3.8/site-packages/flask/ctx.py", line 52, in __getattr__
    raise AttributeError(name) from None
AttributeError: current_user

```