### PR TITLE
fix(docs): remove two broken references to removed file

### DIFF
--- a/docs/installation-all.rst
+++ b/docs/installation-all.rst
@@ -36,7 +36,7 @@ Commencer la procédure en se connectant au serveur en SSH avec l'utilisateur d�
 
 Renseignez à minima votre utilisateur linux, l'URL (ou IP) de votre serveur (avec un ``/`` à la fin) ainsi que l'utilisateur PostgreSQL que vous souhaitez et son mot de passe. Le script se chargera d'installer PostgreSQL et de créer l'utilisateur de base de données que vous avez renseigné. Pour une installation de développement, pensez à renseigner ``mode=dev``.
 
-Pour la définition des numéros de version des dépendances, voir le `tableau de compatibilité <versions-compatibility.rst>`_ des versions de GeoNature avec ses dépendances. Il est déconseillé de modifier ces versions, chaque nouvelle version de GeoNature étant fournie avec les versions adaptées de ses dépendances.
+Il est déconseillé de modifier les numéros de version des dépendances, chaque nouvelle version de GeoNature étant fournie avec les versions adaptées de ses dépendances.
 
 * Lancer l'installation :
  

--- a/docs/installation-standalone.rst
+++ b/docs/installation-standalone.rst
@@ -19,7 +19,7 @@ Récupération de l'application
 
 * Se placer dans le répertoire de l'utilisateur (``/home/geonatureadmin/`` dans notre cas) 
 
-* Récupérer l'application (``X.Y.Z`` à remplacer par le numéro de la `dernière version stable de GeoNature <https://github.com/PnEcrins/GeoNature/releases>`_). Voir le `tableau de compatibilité <versions-compatibility.rst>`_ des versions de GeoNature avec ses dépendances.
+* Récupérer l'application (``X.Y.Z`` à remplacer par le numéro de la `dernière version stable de GeoNature <https://github.com/PnEcrins/GeoNature/releases>`_).
 
   ::
 


### PR DESCRIPTION
The two lines modified were referencing the file `versions-compatibility.rst` removed in commit `632464e`.

Information about versions compatibility between GeoNature, TaxHub, UsersHub and other dependencies can be found in the requirements files : "backend/requirements-*".