### PR TITLE
Improve basemap and reflayers mgmt + update IGN urls

### DIFF
--- a/backend/geonature/tests/test_config_basemaps.py
+++ b/backend/geonature/tests/test_config_basemaps.py
@@ -1,0 +1,24 @@
+import pytest
+
+from geonature.utils.config_basemaps import ConfigBasemap
+
+
+@pytest.mark.usefixtures()
+class TestConfigBasemap:
+    def test_basemap_preprocessing_layer(self):
+        test = ConfigBasemap.generate_basemap(
+            {
+                "layer": "test1_url",
+                "name": "test1_name",
+                "option1": "test1_option1",
+                "options": {
+                    "option2": "test1_option2",
+                },
+            }
+        )
+        assert "layer" not in test
+        assert test["url"] == "test1_url"
+
+        assert "option1" not in test
+        assert test["options"]["option1"] == "test1_option1"
+        assert test["options"]["option2"] == "test1_option2"

--- a/backend/geonature/utils/config.py
+++ b/backend/geonature/utils/config.py
@@ -15,6 +15,7 @@ from geonature.utils.utilstoml import load_toml
 from geonature.utils.env import CONFIG_FILE
 from geonature.utils.errors import ConfigError
 
+from geonature.utils.config_processing import ConfigProcessing
 
 __all__ = ["config", "config_frontend"]
 
@@ -28,6 +29,9 @@ if "GEONATURE_SETTINGS" in os.environ:
 # Load toml file and override with env & py config
 config_toml = load_toml(CONFIG_FILE) if CONFIG_FILE else {}
 config_toml.update(config_programmatic)
+
+# Apply preprocessing on some field
+config_toml = ConfigProcessing.process_basemaps(config_toml)
 
 # Validate config
 try:

--- a/backend/geonature/utils/config_basemaps.py
+++ b/backend/geonature/utils/config_basemaps.py
@@ -1,0 +1,99 @@
+#
+# BASEMAPS
+#
+
+from enum import Enum, unique
+import typing
+
+
+class ConfigBasemap:
+    """
+    Class that namespace the handling of config basemaps
+    """
+
+    DEFAULT = [
+        {
+            "name": "OpenStreetMap",
+            "url": "//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+            "options": {
+                "attribution": "<a href='https://www.openstreetmap.org/copyright' target='_blank'>© OpenStreetMap contributors</a>",
+            },
+        },
+        {
+            "name": "OpenTopoMap",
+            "url": "//a.tile.opentopomap.org/{z}/{x}/{y}.png",
+            "options": {
+                "attribution": "Map data: © <a href='https://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap contributors</a>, SRTM | Map style: © <a href='https://opentopomap.org' target='_blank'>OpenTopoMap</a> (<a href='https://creativecommons.org/licenses/by-sa/3.0/' target='_blank'>CC-BY-SA</a>)",
+            },
+        },
+        {
+            "name": "Google Satellite",
+            "url": "//{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
+            "options": {
+                "attribution": "© Google Maps",
+                "subdomains": ["mt0", "mt1", "mt2", "mt3"],
+            },
+        },
+    ]
+
+    @staticmethod
+    def __extract_option_subdict(config_basemap: typing.Dict):
+        typing.Dict
+        """
+        Utility method
+        Create a dictionary that contains only options item using a list of "not options" fields
+        """
+        NOT_OPTION_FIELDS = [
+            "apikey",
+            "layer",
+            "name",
+            "options",
+            "service",
+            "url",
+        ]
+        return {x: config_basemap[x] for x in config_basemap if x not in NOT_OPTION_FIELDS}
+
+    @staticmethod
+    def map_field_for_retro_compatibility(config_basemap: typing.Dict):
+        typing.Dict
+        """
+        Utility method
+        Map field for compatibility with previous version
+        ex: layer --> url, etc. move options to options
+        """
+        # layer --> url
+        if "layer" in config_basemap:
+            config_basemap["url"] = config_basemap["layer"]
+            del config_basemap["layer"]
+
+        # zoom, maxzoom, etc. --> "options: { zoom, max zoom , etc.}"
+        if "options" not in config_basemap:
+            config_basemap["options"] = {}
+
+        # get option
+        options = ConfigBasemap.__extract_option_subdict(config_basemap)
+        config_basemap["options"] = config_basemap["options"] | options
+        for option in options.keys():
+            del config_basemap[option]
+
+        return config_basemap
+
+    @staticmethod
+    def generate_basemap(config_basemap: typing.Dict) -> typing.Dict:
+        """
+        Facade method
+        Generate a basemap based on configuration
+        It handles option mapping and the retro compatibility
+        """
+
+        # retrocompatiblity
+        config_basemap = ConfigBasemap.map_field_for_retro_compatibility(config_basemap)
+
+        # update basemap with content
+        basemap = {"name": "", "url": "", "options": {}}
+
+        for field in ["name", "url", "service", "options"]:
+            if field in config_basemap:
+                basemap[field] = config_basemap[field]
+
+        return basemap

--- a/backend/geonature/utils/config_processing.py
+++ b/backend/geonature/utils/config_processing.py
@@ -1,0 +1,25 @@
+#
+# Config Default
+#
+
+import typing
+
+from geonature.utils.config_basemaps import ConfigBasemap
+
+
+class ConfigProcessing:
+    """
+    Class that namespace the handling of config processing
+    """
+
+    @staticmethod
+    def process_basemaps(config: typing.Dict) -> typing.Dict:
+        # Apply preprocessing on some field
+        if "MAPCONFIG" in config:
+            # handle preset basemap profile
+            if "BASEMAP" in config["MAPCONFIG"]:
+                config["MAPCONFIG"]["BASEMAP"] = [
+                    ConfigBasemap.generate_basemap(basemap)
+                    for basemap in config["MAPCONFIG"]["BASEMAP"]
+                ]
+        return config

--- a/backend/geonature/utils/config_ref_layers.py
+++ b/backend/geonature/utils/config_ref_layers.py
@@ -1,0 +1,46 @@
+#
+# REF LAYERS
+#
+
+from enum import Enum, unique
+
+class ConfigRefLayers:
+    """
+    Class that namespace the handling of config ref layers
+    """
+
+    DEFAULT = [
+        {
+            "code": "limitesadministratives",
+            "label": "Limites administratives (IGN)",
+            "type": "wms",
+            "url": "https://data.geopf.fr/wms-r",
+            "activate": False,
+            "params": {
+                "sevice": "wms",
+                "version": "1.3.0",
+                "request": "GetMap",
+                "layers": "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST",
+                "styles": "normal",
+                "format": "image/png",
+                "crs": "CRS:84",
+                "dpiMode": 7,
+            },
+        }, {
+            "code": "znieff1",
+            "label": "ZNIEFF1 (INPN)",
+            "type": "wms",
+            "url": "https://ws.carmencarto.fr/WMS/119/fxx_inpn",
+            "activate": False,
+            "params": {
+                "service": "wms",
+                "version": "1.3.0",
+                "request": "GetMap",
+                "layers": "znieff1",
+                "format": "image/png",
+                "crs": "EPSG:4326",
+                "opacity": 0.2,
+                "transparent": True,
+            },
+        },
+    ]

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -22,6 +22,8 @@ from geonature.utils.env import GEONATURE_VERSION, BACKEND_DIR, ROOT_DIR
 from geonature.utils.module import iter_modules_dist, get_module_config
 from geonature.utils.utilsmails import clean_recipients
 from geonature.utils.utilstoml import load_and_validate_toml
+from geonature.utils.config_basemaps import ConfigBasemap
+from geonature.utils.config_ref_layers import ConfigRefLayers
 
 
 class EmailStrOrListOfEmailStrField(fields.Field):
@@ -435,35 +437,11 @@ class Synthese(Schema):
     BLUR_SENSITIVE_OBSERVATIONS = fields.Boolean(load_default=False)
 
 
-# Map configuration
-BASEMAP = [
-    {
-        "name": "OpenStreetMap",
-        "url": "//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
-        "options": {
-            "attribution": "<a href='https://www.openstreetmap.org/copyright' target='_blank'>© OpenStreetMap contributors</a>",
-        },
-    },
-    {
-        "name": "OpenTopoMap",
-        "url": "//a.tile.opentopomap.org/{z}/{x}/{y}.png",
-        "options": {
-            "attribution": "Map data: © <a href='https://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap contributors</a>, SRTM | Map style: © <a href='https://opentopomap.org' target='_blank'>OpenTopoMap</a> (<a href='https://creativecommons.org/licenses/by-sa/3.0/' target='_blank'>CC-BY-SA</a>)",
-        },
-    },
-    {
-        "name": "GoogleSatellite",
-        "layer": "//{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
-        "options": {
-            "subdomains": ["mt0", "mt1", "mt2", "mt3"],
-            "attribution": "© Google Maps",
-        },
-    },
-]
-
-
 class MapConfig(Schema):
-    BASEMAP = fields.List(fields.Dict(), load_default=BASEMAP)
+    BASEMAP = fields.List(
+        fields.Dict(),
+        load_default=ConfigBasemap.DEFAULT,
+    )
     CENTER = fields.List(fields.Float, load_default=[46.52863469527167, 2.43896484375])
     ZOOM_LEVEL = fields.Integer(load_default=6)
     ZOOM_LEVEL_RELEVE = fields.Integer(load_default=15)
@@ -480,40 +458,7 @@ class MapConfig(Schema):
     OSM_RESTRICT_COUNTRY_CODES = fields.String(load_default=None)
     REF_LAYERS = fields.List(
         fields.Dict(),
-        load_default=[
-            {
-                "code": "limitesadministratives",
-                "label": "Limites administratives (IGN)",
-                "type": "wms",
-                "url": "https://wxs.ign.fr/essentiels/geoportail/r/wms",
-                "activate": False,
-                "params": {
-                    "VERSION": "1.3.0",
-                    "crs": "CRS:84",
-                    "dpiMode": 7,
-                    "format": "image/png",
-                    "layers": "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST",
-                    "styles": "",
-                },
-            },
-            {
-                "code": "znieff1",
-                "label": "ZNIEFF1 (INPN)",
-                "type": "wms",
-                "url": "https://ws.carmencarto.fr/WMS/119/fxx_inpn",
-                "activate": False,
-                "params": {
-                    "layers": "znieff1",
-                    "opacity": 0.2,
-                    "crs": "EPSG:4326",
-                    "service": "wms",
-                    "format": "image/png",
-                    "version": "1.3.0",
-                    "request": "GetMap",
-                    "transparent": True,
-                },
-            },
-        ],
+        load_default=ConfigRefLayers.DEFAULT,
     )
     REF_LAYERS_LEGEND = fields.Boolean(load_default=False)
 

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -205,45 +205,64 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
 # l'option service est obligatoire uniquement pour les wms
 # l'ensemble des paramètre WMS peuvent être passé dans cette section
 [[MAPCONFIG.BASEMAP]]
-    name = "OpenstreetMap"
+    attribution = "<a href='https://www.openstreetmap.org/copyright' target='_blank'>© OpenStreetMap contributors</a>"
+    name = "OpenStreetMap"
     url = "//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png"
-    attribution = "OSM contributors"
 [[MAPCONFIG.BASEMAP]]
-    name = "IGN Plan v2"
-    url = "https://wxs.ign.fr/cartes/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/png&LAYER=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
-    attribution = "&copy IGN"
+    attribution = "Map data: © <a href='https://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap contributors</a>, SRTM | Map style: © <a href='https://opentopomap.org' target='_blank'>OpenTopoMap</a> (<a href='https://creativecommons.org/licenses/by-sa/3.0/' target='_blank'>CC-BY-SA</a>)"
+    name = "OpenTopoMap"
+    url = "//a.tile.opentopomap.org/{z}/{x}/{y}.png"
 [[MAPCONFIG.BASEMAP]]
-    name = "IGN Ortho"
-    url = "https://wxs.ign.fr/ortho/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
-    attribution = "&copy IGN"
-[[MAPCONFIG.BASEMAP]]
-    name = "IGN Scan 25"
-    url = "https://wxs.ign.fr/YOUR-IGN-KEY/geoportail/wmts?LAYER=GEOGRAPHICALGRIDSYSTEMS.MAPS&EXCEPTIONS=text/xml&FORMAT=image/jpeg&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
-    attribution = "&copy IGN"
-[[MAPCONFIG.BASEMAP]]
-    name = "IGN Cadastre"
-    url = "https://wxs.ign.fr/parcellaire/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/png&LAYER=CADASTRALPARCELS.PARCELS&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
-    attribution = "&copy IGN"
-[[MAPCONFIG.BASEMAP]]
-    name = "WMS"
-    url = "https://mon_flux_wms"
-    service = "wms"
-    layers = 'ma_layer'
-    attribution = 'lala'
-[[MAPCONFIG.BASEMAP]]
-    attribution = "GoogleSatellite"
-    name = "google"
-    url = "//{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}"
+    attribution = "© Google Maps"
+    name = "Google Satellite"
     subdomains = ["mt0", "mt1", "mt2", "mt3"]
+    url = "//{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}"
+[[MAPCONFIG.BASEMAP]]
+    attribution = "© IGN"
+    name = "IGN Plan v2"
+    url = "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&LAYER=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}&FORMAT=image/png&STYLE=normal"
+[[MAPCONFIG.BASEMAP]]
+    attribution = "© IGN"
+    name = "IGN Ortho"
+    url = "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}&FORMAT=image/jpeg&STYLE=normal"
+[[MAPCONFIG.BASEMAP]]
+    attribution = "© IGN"
+    name = "IGN Cadastre"
+    url = "https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&LAYER=CADASTRALPARCELS.PARCELS&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}&FORMAT=image/png&STYLE=normal"
+[[MAPCONFIG.BASEMAP]]
+    attribution = "© IGN"
+    name = "IGN Scan 25"
+    url = "https://data.geopf.fr/private/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&apikey=ign_scan_ws&LAYER=GEOGRAPHICALGRIDSYSTEMS.MAPS&EXCEPTIONS=text/xml&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}&FORMAT=image/jpeg&STYLE=normal"
+[[MAPCONFIG.BASEMAP]]
+    attribution = 'lala'
+    layers = 'ma_layer'
+    name = "WMS"
+    service = "wms"
+    url = "https://mon_flux_wms"
+
 
 # Add base layers on maps (from ref_geo, WMS, WFS, GeoJSON...)
-#[[MAPCONFIG.REF_LAYERS]]
-#    code = "COM"
-#    label = "Communes"
-#    type = "area"
-#    activate = false
-#    style = { color = "grey", fill = false, fillOpacity = "0.0", weight = 2 }
-#    params = {limit = 2000}
+[[MAPCONFIG.REF_LAYERS]]
+    code = "limitesadministratives"
+    label = "Limites administratives (IGN)"
+    type = "wms"
+    url = "https://data.geopf.fr/wms-r"
+    params = { sevice="wms", version = "1.3.0", request="GetMap", layers = "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST", style = "normal", format = "image/png", crs = "CRS:84", dpiMode = 7 }
+    activate = false
+[[MAPCONFIG.REF_LAYERS]]
+    code = "znieff1"
+    label = "ZNIEFF1 (INPN)"
+    type = "wms"
+    url = "https://ws.carmencarto.fr/WMS/119/fxx_inpn"
+    activate = false
+    params = { layers = "znieff1", opacity = 0.2, crs = "EPSG:4326", service = "wms", format = "image/png", version = "1.3.0", request = "GetMap", transparent = true }
+[[MAPCONFIG.REF_LAYERS]]
+    code = "COM"
+    label = "Communes"
+    type = "area"
+    activate = false
+    style = { color = "grey", fill = false, fillOpacity = "0.0", weight = 2 }
+    params = {limit = 2000}
 
 # Configuration du module Synthese
 [SYNTHESE]

--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -164,18 +164,12 @@ export class MapComponent implements OnInit {
     // Baselayers
     const baseControl = {};
     const BASEMAP = JSON.parse(JSON.stringify(this.config.MAPCONFIG.BASEMAP));
+
     BASEMAP.forEach((basemap, index) => {
-      const formatedBasemap = this.formatBaseMapConfig(basemap);
       if (basemap.service === 'wms') {
-        baseControl[formatedBasemap.name] = L.tileLayer.wms(
-          formatedBasemap.url,
-          formatedBasemap.options
-        );
+        baseControl[basemap.name] = L.tileLayer.wms(basemap.url, basemap.options);
       } else {
-        baseControl[formatedBasemap.name] = L.tileLayer(
-          formatedBasemap.url,
-          formatedBasemap.options
-        );
+        baseControl[basemap.name] = L.tileLayer(basemap.url, basemap.options);
       }
       if (index === 0) {
         map.addLayer(baseControl[basemap.name]);
@@ -222,38 +216,6 @@ export class MapComponent implements OnInit {
     setTimeout(() => {
       this.map.invalidateSize();
     }, 50);
-  }
-
-  /** Retrocompatibility hack to format map config to the expected format:
-   *
-   {
-    name: string,
-    url: string,
-    service?: wms|wmts|null
-    options?: {
-        layer?: string,
-        attribution?: string,
-        format?: string
-        [...]
-    }
-  }
-   */
-  formatBaseMapConfig(baseMap) {
-    // eslint-disable-next-line guard-for-in
-    for (let attr in baseMap) {
-      if (attr === 'layer') {
-        baseMap['url'] = baseMap[attr];
-        delete baseMap['layer'];
-      }
-      if (!['url', 'layer', 'name', 'service', 'options'].includes(attr)) {
-        if (!baseMap['options']) {
-          baseMap['options'] = {};
-        }
-        baseMap['options'][attr] = baseMap[attr];
-        delete baseMap[attr];
-      }
-    }
-    return baseMap;
   }
 
   formatter(nominatim) {


### PR DESCRIPTION
[Périmètre] MapConfig: basemap + ref_layers

[Problème] 
- La config par défaut (`backend/geonature/utils/config_schema.py`) le fichier d'exemple de config `config/default_config.toml.example` ne reflétaient pas les changements de syntaxe de flux
Changement des URL des flux IGN: Issue sur le sujet: https://github.com/PnX-SI/GeoNature/issues/2789
- Une correction sur le contenu de la config est appliquée côté frontend (map.component.ts)

[Solution] 
- Suppression de la modification côté frontend
- Ajout de la modification côté backend au chargement de la config: config.py
- Création de classe de gestion des configs de basemaps et de ref_layers
  Ces classes s'appuient sur une mécanique d'enum + dictionnaire
- Ajout d'un champ 'preset', pour encapsuler la config standard des basemap/ref_layers dans géonature

