### PR TITLE
fix: update black parameter to meet line-length of 100 chars requirement

### DIFF
--- a/backend/geonature/app.py
+++ b/backend/geonature/app.py
@@ -55,9 +55,7 @@ def configure_alembic(alembic_config):
     'migrations' entry point value of the 'gn_module' group for all modules having such entry point.
     Thus, alembic will find migrations of all installed geonature modules.
     """
-    version_locations = set(
-        alembic_config.get_main_option("version_locations", default="").split()
-    )
+    version_locations = set(alembic_config.get_main_option("version_locations", default="").split())
     if "VERSION_LOCATIONS" in config["ALEMBIC"]:
         version_locations |= set(config["ALEMBIC"]["VERSION_LOCATIONS"].split())
     for entry_point in chain(

--- a/backend/geonature/core/command/create_gn_module.py
+++ b/backend/geonature/core/command/create_gn_module.py
@@ -104,8 +104,7 @@ def install_gn_module(x_arg, module_path, module_code, build, upgrade_db):
         click.echo("Installation / mise à jour de la base de données…")
         if not module_db_upgrade(module_dist, x_arg=x_arg):
             click.echo(
-                "Le module est déjà déclaré en base. "
-                "Installation de la base de données ignorée."
+                "Le module est déjà déclaré en base. " "Installation de la base de données ignorée."
             )
 
 
@@ -137,6 +136,5 @@ def upgrade_modules_db(directory, sql, tag, x_arg, module_codes):
         click.echo(f"Mise-à-jour du module {module_code}…")
         if not module_db_upgrade(module_dist, directory, sql, tag, x_arg):
             click.echo(
-                "Le module est déjà déclaré en base. "
-                "Installation de la base de données ignorée."
+                "Le module est déjà déclaré en base. " "Installation de la base de données ignorée."
             )

--- a/backend/geonature/core/gn_commons/repositories.py
+++ b/backend/geonature/core/gn_commons/repositories.py
@@ -115,9 +115,7 @@ class TMediaRepository:
             if "check_entity_field_exist" in exp.args[0]:
                 raise Exception("{} doesn't exists".format(self.data["id_table_location"]))
             if "fk_t_medias_check_entity_value" in exp.args[0]:
-                raise Exception(
-                    "id {} of {} doesn't exists".format(self.data["id_table_location"])
-                )
+                raise Exception("id {} of {} doesn't exists".format(self.data["id_table_location"]))
             else:
                 raise Exception("Errors {}".format(exp.args))
 

--- a/backend/geonature/core/gn_commons/routes.py
+++ b/backend/geonature/core/gn_commons/routes.py
@@ -231,9 +231,7 @@ def get_t_mobile_apps():
             app_dict["url_apk"] = url_for("media", filename=str(relative_apk_path), _external=True)
 
         relative_settings_path = Path(f"mobile/{app.app_code.lower()}/settings.json")
-        app_dict["url_settings"] = url_for(
-            "media", filename=relative_settings_path, _external=True
-        )
+        app_dict["url_settings"] = url_for("media", filename=relative_settings_path, _external=True)
         settings_file = Path(current_app.config["MEDIA_FOLDER"]) / relative_settings_path
         with settings_file.open() as f:
             app_dict["settings"] = json.load(f)

--- a/backend/geonature/core/gn_meta/models/aframework.py
+++ b/backend/geonature/core/gn_meta/models/aframework.py
@@ -276,9 +276,7 @@ class TAcquisitionFramework(db.Model):
                 if name
                 else True
             )
-            .where(
-                TAcquisitionFramework.acquisition_framework_start_date == date if date else True
-            )
+            .where(TAcquisitionFramework.acquisition_framework_start_date == date if date else True)
         )
 
         actors = []
@@ -326,9 +324,7 @@ class TAcquisitionFramework(db.Model):
             if _ds_search:
                 ors.append(
                     TAcquisitionFramework.datasets.any(
-                        TDatasets.filter_by_params(
-                            {"search": search}, _af_search=False
-                        ).whereclause
+                        TDatasets.filter_by_params({"search": search}, _af_search=False).whereclause
                     ),
                 )
             query = query.where(sa.or_(*ors))

--- a/backend/geonature/core/gn_meta/repositories.py
+++ b/backend/geonature/core/gn_meta/repositories.py
@@ -156,9 +156,7 @@ def get_metadata_list(role, scope, args, exclude_cols):
                 if acquisition_framework_name
                 else True
             )
-            .where(
-                CorAcquisitionFrameworkActor.id_organism == id_organism if id_organism else True
-            )
+            .where(CorAcquisitionFrameworkActor.id_organism == id_organism if id_organism else True)
             .where(CorAcquisitionFrameworkActor.id_role == id_role if id_role else True)
         )
 

--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -887,9 +887,7 @@ def get_acquisition_framework_stats(id_acquisition_framework):
     nb_observations = db.session.execute(
         select(func.count("*"))
         .select_from(Synthese)
-        .where(
-            Synthese.dataset.has(TDatasets.id_acquisition_framework == id_acquisition_framework)
-        )
+        .where(Synthese.dataset.has(TDatasets.id_acquisition_framework == id_acquisition_framework))
     ).scalar_one()
 
     nb_habitats = 0
@@ -966,9 +964,7 @@ def publish_acquisition_framework_mail(af):
     )
 
     # Mail subject
-    mail_subject = (
-        "Dépôt du cadre d'acquisition " + str(af.unique_acquisition_framework_id).upper()
-    )
+    mail_subject = "Dépôt du cadre d'acquisition " + str(af.unique_acquisition_framework_id).upper()
     mail_subject_base = current_app.config["METADATA"]["MAIL_SUBJECT_AF_CLOSED_BASE"]
     if mail_subject_base:
         mail_subject = mail_subject_base + " " + mail_subject

--- a/backend/geonature/core/gn_permissions/admin.py
+++ b/backend/geonature/core/gn_permissions/admin.py
@@ -133,9 +133,7 @@ def permissions_formatter(view, context, model, name):
     for ap in available_permissions:
         own_permissions = list(
             filter(
-                lambda p: p.module == ap.module
-                and p.object == ap.object
-                and p.action == ap.action,
+                lambda p: p.module == ap.module and p.object == ap.object and p.action == ap.action,
                 model.permissions,
             )
         )

--- a/backend/geonature/core/gn_profiles/models.py
+++ b/backend/geonature/core/gn_profiles/models.py
@@ -105,9 +105,7 @@ class VSyntheseForProfiles(db.Model):
     nomenclature_life_stage = db.relationship(
         TNomenclatures, foreign_keys=[id_nomenclature_life_stage]
     )
-    id_nomenclature_valid_status = db.Column(
-        db.Integer, ForeignKey(TNomenclatures.id_nomenclature)
-    )
+    id_nomenclature_valid_status = db.Column(db.Integer, ForeignKey(TNomenclatures.id_nomenclature))
     nomenclature_valid_status = db.relationship(
         TNomenclatures, foreign_keys=[id_nomenclature_valid_status]
     )

--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -359,9 +359,7 @@ class Synthese(DB.Model):
     id_nomenclature_blurring = db.Column(
         db.Integer, ForeignKey(TNomenclatures.id_nomenclature), server_default=FetchedValue()
     )
-    nomenclature_blurring = db.relationship(
-        TNomenclatures, foreign_keys=[id_nomenclature_blurring]
-    )
+    nomenclature_blurring = db.relationship(TNomenclatures, foreign_keys=[id_nomenclature_blurring])
     id_nomenclature_source_status = db.Column(
         db.Integer, ForeignKey(TNomenclatures.id_nomenclature), server_default=FetchedValue()
     )

--- a/backend/geonature/core/gn_synthese/utils/blurring.py
+++ b/backend/geonature/core/gn_synthese/utils/blurring.py
@@ -110,9 +110,7 @@ def build_blurred_precise_geom_queries(
     )
     # Joins here are needed to retrieve the blurred geometry
     blurred_geom_query.add_join(LAreasAlias, LAreasAlias.id_area, CorAreaSyntheseAlias.id_area)
-    blurred_geom_query.add_join(
-        BibAreasTypesAlias, BibAreasTypesAlias.id_type, LAreasAlias.id_type
-    )
+    blurred_geom_query.add_join(BibAreasTypesAlias, BibAreasTypesAlias.id_type, LAreasAlias.id_type)
     blurred_geom_query.add_join(
         cor_sensitivity_area_type,
         cor_sensitivity_area_type.c.id_area_type,

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -355,9 +355,7 @@ class SyntheseQuery:
                 comment_filter = ~comment_filter
             self.query = self.query.where(comment_filter)
         if "id_dataset" in self.filters:
-            self.query = self.query.where(
-                self.model.id_dataset.in_(self.filters.pop("id_dataset"))
-            )
+            self.query = self.query.where(self.model.id_dataset.in_(self.filters.pop("id_dataset")))
         if "observers" in self.filters:
             # découpe des éléments saisies par des ","
             observers = self.filters.pop("observers").split(",")

--- a/backend/geonature/core/notifications/routes.py
+++ b/backend/geonature/core/notifications/routes.py
@@ -60,9 +60,7 @@ def count_notification():
     notificationNumber = db.session.execute(
         select(func.count("*"))
         .select_from(Notification)
-        .where(
-            Notification.id_role == g.current_user.id_role, Notification.code_status == "UNREAD"
-        )
+        .where(Notification.id_role == g.current_user.id_role, Notification.code_status == "UNREAD")
     ).scalar_one()
     return jsonify(notificationNumber)
 

--- a/backend/geonature/core/users/register_post_actions.py
+++ b/backend/geonature/core/users/register_post_actions.py
@@ -41,9 +41,7 @@ def validate_temp_user(data):
     """
     token = data.get("token", None)
 
-    user = DB.session.scalars(
-        select(TempUser).where(TempUser.token_role == token).limit(1)
-    ).first()
+    user = DB.session.scalars(select(TempUser).where(TempUser.token_role == token).limit(1)).first()
     if not user:
         return {
             "msg": "{token}: ce token n'est pas associé à un compte temporaire".format(token=token)

--- a/backend/geonature/migrations/versions/0630b93bcfe0_add_permissions_inherited_modules_objects.py
+++ b/backend/geonature/migrations/versions/0630b93bcfe0_add_permissions_inherited_modules_objects.py
@@ -638,8 +638,6 @@ def downgrade():
     drop 'backup_t_filters' after 'backup_cor_role_action_filter_module_object' because of 
     'fk_backup_cor_r_a_f_m_o_id_filter' referencing 'backup_t_filters'
     """
-    op.drop_table(
-        schema="gn_permissions", table_name="backup_cor_role_action_filter_module_object"
-    )
+    op.drop_table(schema="gn_permissions", table_name="backup_cor_role_action_filter_module_object")
     op.drop_table(schema="gn_permissions", table_name="backup_t_filters")
     op.drop_table(schema="gn_permissions", table_name="backup_bib_filters_type")

--- a/backend/geonature/migrations/versions/36d0bd313a47_add_notification_schema_tables_and_data.py
+++ b/backend/geonature/migrations/versions/36d0bd313a47_add_notification_schema_tables_and_data.py
@@ -95,9 +95,7 @@ def upgrade():
             ForeignKey(SCHEMA_NAME + ".bib_notifications_categories.code"),
             nullable=False,
         ),
-        UniqueConstraint(
-            "id_role", "code_method", "code_category", name="un_role_method_category"
-        ),
+        UniqueConstraint("id_role", "code_method", "code_category", name="un_role_method_category"),
         schema=SCHEMA_NAME,
     )
 

--- a/backend/geonature/tests/test_commands.py
+++ b/backend/geonature/tests/test_commands.py
@@ -135,9 +135,7 @@ class TestCommands:
     def test_install_gn_module_no_module_code(self, monkeypatch):
         patch_monkeypatch(monkeypatch)
         module_path = "backend/geonature/core"
-        monkeypatch.setattr(
-            install_module, "iter_modules_dist", iter_module_dist_mock("geonature")
-        )
+        monkeypatch.setattr(install_module, "iter_modules_dist", iter_module_dist_mock("geonature"))
         result = self.cli.invoke(install_module.install_gn_module, [module_path])
         assert result.exit_code == 0
 
@@ -147,25 +145,19 @@ class TestCommands:
         monkeypatch.setattr(install_module, "iter_modules_dist", lambda: [])
         result = self.cli.invoke(install_module.install_gn_module, [module_path])
         assert result.exit_code > 0
-        monkeypatch.setattr(
-            install_module, "iter_modules_dist", iter_module_dist_mock("geonature")
-        )
+        monkeypatch.setattr(install_module, "iter_modules_dist", iter_module_dist_mock("geonature"))
 
     def test_install_gn_module_nomodule_code(self, monkeypatch):
         patch_monkeypatch(monkeypatch)
         module_path = "backend/geonature/core"
-        monkeypatch.setattr(
-            install_module, "iter_modules_dist", iter_module_dist_mock("geonature")
-        )
+        monkeypatch.setattr(install_module, "iter_modules_dist", iter_module_dist_mock("geonature"))
         result = self.cli.invoke(install_module.install_gn_module, [module_path, "--build=false"])
         assert result.exit_code == 0
 
     def test_install_gn_module_false_upgrade_db(self, monkeypatch):
         patch_monkeypatch(monkeypatch)
         module_path = "backend/geonature/core"
-        monkeypatch.setattr(
-            install_module, "iter_modules_dist", iter_module_dist_mock("geonature")
-        )
+        monkeypatch.setattr(install_module, "iter_modules_dist", iter_module_dist_mock("geonature"))
 
         result = self.cli.invoke(
             install_module.install_gn_module, [module_path, "--upgrade-db=false"]
@@ -175,9 +167,7 @@ class TestCommands:
     def test_install_gn_module_symlink_not_exists(self, monkeypatch):
         patch_monkeypatch(monkeypatch)
         module_path = "backend/geonature/core"
-        monkeypatch.setattr(
-            install_module, "iter_modules_dist", iter_module_dist_mock("geonature")
-        )
+        monkeypatch.setattr(install_module, "iter_modules_dist", iter_module_dist_mock("geonature"))
         monkeypatch.setattr(install_module.os.path, "exists", lambda x: False)
         result = self.cli.invoke(install_module.install_gn_module, [module_path])
 
@@ -192,9 +182,7 @@ class TestCommands:
         assert result.exit_code > 0  # will fail
 
     def test_upgrade_modules_db(self, monkeypatch):
-        monkeypatch.setattr(
-            install_module, "iter_modules_dist", iter_module_dist_mock("geonature")
-        )
+        monkeypatch.setattr(install_module, "iter_modules_dist", iter_module_dist_mock("geonature"))
         result = self.cli.invoke(install_module.upgrade_modules_db, [])
         assert result.exit_code > 0
 

--- a/backend/geonature/tests/test_gn_commons.py
+++ b/backend/geonature/tests/test_gn_commons.py
@@ -37,9 +37,7 @@ def additional_field(app, datasets):
     module = db.session.execute(
         select(TModules).where(TModules.module_code == "SYNTHESE")
     ).scalar_one()
-    obj = db.session.execute(
-        select(PermObject).where(PermObject.code_object == "ALL")
-    ).scalar_one()
+    obj = db.session.execute(select(PermObject).where(PermObject.code_object == "ALL")).scalar_one()
     datasets = list(datasets.values())
     additional_field = TAdditionalFields(
         field_name="test",
@@ -454,9 +452,7 @@ class TestCommons:
         assert response.status_code == 200
         assert db.session.scalar(
             exists()
-            .where(
-                TPlaces.place_name == place.place_name, TPlaces.id_role == users["user"].id_role
-            )
+            .where(TPlaces.place_name == place.place_name, TPlaces.id_role == users["user"].id_role)
             .select()
         )
 

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -110,9 +110,7 @@ def get_csv_from_response(data):
 
 @pytest.mark.usefixtures("client_class", "temporary_transaction")
 class TestGNMeta:
-    def test_acquisition_frameworks_permissions(
-        self, app, acquisition_frameworks, datasets, users
-    ):
+    def test_acquisition_frameworks_permissions(self, app, acquisition_frameworks, datasets, users):
         af = acquisition_frameworks["own_af"]
         with app.test_request_context(headers=logged_user_headers(users["user"])):
             app.preprocess_request()
@@ -478,9 +476,7 @@ class TestGNMeta:
         set_logged_user(self.client, users["user"])
 
         response = self.client.post(
-            url_for(
-                "gn_meta.get_export_pdf_acquisition_frameworks", id_acquisition_framework=af_id
-            )
+            url_for("gn_meta.get_export_pdf_acquisition_frameworks", id_acquisition_framework=af_id)
         )
 
         assert response.status_code == 200
@@ -489,9 +485,7 @@ class TestGNMeta:
         af_id = acquisition_frameworks["own_af"].id_acquisition_framework
 
         response = self.client.post(
-            url_for(
-                "gn_meta.get_export_pdf_acquisition_frameworks", id_acquisition_framework=af_id
-            )
+            url_for("gn_meta.get_export_pdf_acquisition_frameworks", id_acquisition_framework=af_id)
         )
 
         assert response.status_code == Unauthorized.code
@@ -1043,9 +1037,7 @@ class TestGNMeta:
             create = TDatasets._get_create_scope(module_code=modcode)
 
         usercreate = TDatasets._get_create_scope(module_code=modcode, user=users["user"])
-        norightcreate = TDatasets._get_create_scope(
-            module_code=modcode, user=users["noright_user"]
-        )
+        norightcreate = TDatasets._get_create_scope(module_code=modcode, user=users["noright_user"])
         associatecreate = TDatasets._get_create_scope(
             module_code=modcode, user=users["associate_user"]
         )

--- a/backend/geonature/tests/test_gn_profiles.py
+++ b/backend/geonature/tests/test_gn_profiles.py
@@ -216,9 +216,7 @@ class TestGnProfiles:
 
     def test_get_phenology(self, sample_synthese_records_for_profile):
         response = self.client.get(
-            url_for(
-                "gn_profiles.get_phenology", cd_ref=sample_synthese_records_for_profile.cd_nom
-            ),
+            url_for("gn_profiles.get_phenology", cd_ref=sample_synthese_records_for_profile.cd_nom),
             query_string={
                 "id_nomenclature_life_stage": db.session.scalar(
                     sa.select(func.ref_nomenclatures.get_id_nomenclature("STADE_VIE", "10"))
@@ -344,9 +342,7 @@ class TestGnProfiles:
         assert response.status_code == 400, response.json
         assert response.json["description"] == "Missing altitude_min or altitude_max"
 
-    def test_get_observation_score_not_observed_altitude(
-        self, sample_synthese_records_for_profile
-    ):
+    def test_get_observation_score_not_observed_altitude(self, sample_synthese_records_for_profile):
         alt_min = 500
         alt_max = 600
         data = {

--- a/backend/geonature/tests/test_notifications.py
+++ b/backend/geonature/tests/test_notifications.py
@@ -167,27 +167,19 @@ class TestNotification:
     def test_update_notification(self, users, notification_data):
         # Init data for test
         url = "notifications.update_notification"
-        log.debug(
-            "Url d'appel %s", url_for(url, id_notification=notification_data.id_notification)
-        )
+        log.debug("Url d'appel %s", url_for(url, id_notification=notification_data.id_notification))
 
-        response = self.client.post(
-            url_for(url, id_notification=notification_data.id_notification)
-        )
+        response = self.client.post(url_for(url, id_notification=notification_data.id_notification))
         assert response.status_code == Unauthorized.code
 
         # TEST CONNECTED USER BUT NOTIFICATION DOES NOT EXIST FOR THIS USER
         set_logged_user(self.client, users["user"])
-        response = self.client.post(
-            url_for(url, id_notification=notification_data.id_notification)
-        )
+        response = self.client.post(url_for(url, id_notification=notification_data.id_notification))
         assert response.status_code == Forbidden.code
 
         # TEST CONNECTED USER WITH NOTIFICATION
         set_logged_user(self.client, users["admin_user"])
-        response = self.client.post(
-            url_for(url, id_notification=notification_data.id_notification)
-        )
+        response = self.client.post(url_for(url, id_notification=notification_data.id_notification))
         assert response.status_code == 200
 
     def test_delete_all_notifications(self, users, notification_data):

--- a/backend/geonature/tests/test_permissions.py
+++ b/backend/geonature/tests/test_permissions.py
@@ -138,9 +138,7 @@ def permissions(roles, groups, actions, module_gn):
                 else:
                     s = int(s)
                 db.session.add(
-                    Permission(
-                        role=role, action=actions[a], module=module, scope_value=s, **kwargs
-                    )
+                    Permission(role=role, action=actions[a], module=module, scope_value=s, **kwargs)
                 )
 
     return _permissions

--- a/backend/geonature/tests/test_pr_occtax.py
+++ b/backend/geonature/tests/test_pr_occtax.py
@@ -22,9 +22,7 @@ from .utils import set_logged_user
 from .fixtures import *
 
 occtax = pytest.importorskip("occtax")
-pytestmark = pytest.mark.skipif(
-    "OCCTAX" in config["DISABLED_MODULES"], reason="OccTax is disabled"
-)
+pytestmark = pytest.mark.skipif("OCCTAX" in config["DISABLED_MODULES"], reason="OccTax is disabled")
 
 from occtax.models import (
     DefaultNomenclaturesValue,
@@ -191,9 +189,7 @@ def additional_field(app, datasets):
     module = db.session.execute(
         select(TModules).where(TModules.module_code == "OCCTAX")
     ).scalar_one()
-    obj = db.session.execute(
-        select(PermObject).where(PermObject.code_object == "ALL")
-    ).scalar_one()
+    obj = db.session.execute(select(PermObject).where(PermObject.code_object == "ALL")).scalar_one()
     datasets = list(datasets.values())
     additional_field = TAdditionalFields(
         field_name="test",

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -272,9 +272,7 @@ class TestSynthese:
         )
 
         # test ref geo area filter
-        com_type = db.session.execute(
-            select(BibAreasTypes).filter_by(type_code="COM")
-        ).scalar_one()
+        com_type = db.session.execute(select(BibAreasTypes).filter_by(type_code="COM")).scalar_one()
         chambery = db.session.execute(
             select(LAreas).filter_by(area_type=com_type, area_name="Chambéry")
         ).scalar_one()
@@ -430,9 +428,7 @@ class TestSynthese:
         assert len(features) > 0
 
         for feat in features:
-            assert feat["properties"]["id"] in [
-                synt.id_synthese for synt in synthese_data.values()
-            ]
+            assert feat["properties"]["id"] in [synt.id_synthese for synt in synthese_data.values()]
         assert response.status_code == 200
 
     def test_get_synthese_data_aggregate(self, users, datasets, synthese_data):
@@ -1015,9 +1011,7 @@ class TestSynthese:
         # Create a dict (id_dataset, nb_obs) for the expected data
         dict_expected_datasets = {}
         expected_data_synthese = [
-            obs_synthese
-            for name_obs, obs_synthese in synthese_data.items()
-            if name_obs in ["obs1"]
+            obs_synthese for name_obs, obs_synthese in synthese_data.items() if name_obs in ["obs1"]
         ]
         for obs_data_synthese in expected_data_synthese:
             id_dataset = obs_data_synthese.id_dataset
@@ -1373,9 +1367,7 @@ def blur_sensitive_observations(monkeypatch):
 
 def get_one_synthese_reponse_from_id(response: dict, id_synthese: int):
     return [
-        synthese
-        for synthese in response["features"]
-        if synthese["properties"]["id"] == id_synthese
+        synthese for synthese in response["features"] if synthese["properties"]["id"] == id_synthese
     ][0]
 
 

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -210,9 +210,7 @@ class GnPySchemaConf(Schema):
     CELERY = fields.Nested(CeleryConfig, load_default=CeleryConfig().load({}))
     METADATA = fields.Nested(MetadataConfig, load_default=MetadataConfig().load({}))
     ADMIN_APPLICATION_LOGIN = fields.String()
-    ACCOUNT_MANAGEMENT = fields.Nested(
-        AccountManagement, load_default=AccountManagement().load({})
-    )
+    ACCOUNT_MANAGEMENT = fields.Nested(AccountManagement, load_default=AccountManagement().load({}))
     BAD_LOGIN_STATUS_CODE = fields.Integer(load_default=401)
     USERSHUB = fields.Nested(UsersHubConfig, load_default=UsersHubConfig().load({}))
     SERVER = fields.Nested(ServerConfig, load_default=ServerConfig().load({}))
@@ -545,9 +543,7 @@ class GnGeneralSchemaConf(Schema):
     ENABLE_NOMENCLATURE_TAXONOMIC_FILTERS = fields.Boolean(load_default=True)
     BDD = fields.Nested(BddConfig, load_default=BddConfig().load({}))
     URL_USERSHUB = fields.Url(required=False)
-    ACCOUNT_MANAGEMENT = fields.Nested(
-        AccountManagement, load_default=AccountManagement().load({})
-    )
+    ACCOUNT_MANAGEMENT = fields.Nested(AccountManagement, load_default=AccountManagement().load({}))
     MEDIAS = fields.Nested(MediasConfig, load_default=MediasConfig().load({}))
     STATIC_URL = fields.String(load_default="/static")
     MEDIA_URL = fields.String(load_default="/media")

--- a/contrib/gn_module_occhab/backend/gn_module_occhab/blueprint.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/blueprint.py
@@ -257,9 +257,7 @@ def export_all_habitats(
                     properties=export_view.as_dict(r, fields=columns_to_serialize),
                 )
             )
-        return to_json_resp(
-            FeatureCollection(features), as_file=True, filename=file_name, indent=4
-        )
+        return to_json_resp(FeatureCollection(features), as_file=True, filename=file_name, indent=4)
     else:
         dir_name, file_name = export_as_geo_file(
             export_format=export_format,

--- a/contrib/occtax/backend/occtax/models.py
+++ b/contrib/occtax/backend/occtax/models.py
@@ -59,9 +59,7 @@ class CorCountingOccurrence(DB.Model):
         DB.Integer, nullable=False, server_default=FetchedValue()
     )
     id_nomenclature_sex = DB.Column(DB.Integer, nullable=False, server_default=FetchedValue())
-    id_nomenclature_obj_count = DB.Column(
-        DB.Integer, nullable=False, server_default=FetchedValue()
-    )
+    id_nomenclature_obj_count = DB.Column(DB.Integer, nullable=False, server_default=FetchedValue())
     id_nomenclature_type_count = DB.Column(DB.Integer, server_default=FetchedValue())
     count_min = DB.Column(DB.Integer)
     count_max = DB.Column(DB.Integer)

--- a/contrib/occtax/backend/occtax/repositories.py
+++ b/contrib/occtax/backend/occtax/repositories.py
@@ -38,9 +38,7 @@ class ReleveRepository:
         and via the current_module (only datasets of this module)
         """
         q = select(self.model).where(
-            self.model.id_dataset.in_(
-                tuple(map(lambda x: x.id_dataset, g.current_module.datasets))
-            )
+            self.model.id_dataset.in_(tuple(map(lambda x: x.id_dataset, g.current_module.datasets)))
         )
         allowed_datasets = DB.session.scalars(TDatasets.filter_by_scope(scope)).unique().all()
         allowed_datasets = [dataset.id_dataset for dataset in allowed_datasets]

--- a/data/scripts/import_ginco/import_mtd.py
+++ b/data/scripts/import_ginco/import_mtd.py
@@ -1114,10 +1114,7 @@ for ds_iter in range(len(ds_uuid_list)):
                 else:
                     cur_protocol_url = "''"
                 # Create or update publication
-                if (
-                    "('" + cur_protocol_name.replace("''", "'") + "',)"
-                    not in get_known_protocols()
-                ):
+                if "('" + cur_protocol_name.replace("''", "'") + "',)" not in get_known_protocols():
                     insert_sinp_datatype_protocols(
                         cur_protocol_name, cur_protocol_desc, cur_protocol_url
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ omit = [
 ]
 
 [tool.black]
-line-length = 99
+line-length = 100
 exclude ='''
 (
   /(


### PR DESCRIPTION
[Périmètre] lint python 99 vs 100

[Problème]
La doc stipule un line-length de 100, mais la valeur par défaut de black est fixée dans le projet à 99

Doc: https://docs.geonature.fr/development.html#backend
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/7be64bdc-7950-4a12-9ae6-b503e2bbd46b)

Project configuration `pyproject.toml`: 
```toml
[tool.black]
line-length = 99
```

[Solution]
Forcer le lint à la valeur stipulée dans la doc

Remarque --> si 100 n'est plus une valeur satisfaisante, on peut faire varier la valeur doc et le pyproject conjointement