### PR TITLE
Fix(occhab) fix edit habitats

### DIFF
--- a/contrib/gn_module_occhab/frontend/app/components/occhab-map-form/occhab-form.component.ts
+++ b/contrib/gn_module_occhab/frontend/app/components/occhab-map-form/occhab-form.component.ts
@@ -123,6 +123,7 @@ export class OccHabFormComponent implements OnInit, OnDestroy {
 
   // toggle the hab form and call the editHab function of form service
   editHab(index) {
+    this.occHabForm.cancelHab();
     this.occHabForm.editHab(index);
     this.showHabForm = true;
   }

--- a/contrib/gn_module_occhab/frontend/app/services/form-service.ts
+++ b/contrib/gn_module_occhab/frontend/app/services/form-service.ts
@@ -20,6 +20,7 @@ export class OcchabFormService {
   public typoHabControl = new UntypedFormControl();
   public selectedTypo: any;
   public currentEditingHabForm = null;
+  public currentHabCopy = null;
   constructor(
     private _fb: UntypedFormBuilder,
     private _dateParser: NgbDateParserFormatter,
@@ -137,7 +138,11 @@ export class OcchabFormService {
    * @param index: index of the habitat to edit
    */
   editHab(index) {
+    const habArrayForm = this.stationForm.controls.habitats as UntypedFormArray;
     this.currentEditingHabForm = index;
+    this.currentHabCopy = {
+      ...habArrayForm.controls[this.currentEditingHabForm].value,
+    };
   }
 
   /** Cancel the current hab
@@ -145,8 +150,12 @@ export class OcchabFormService {
    * we keep the order
    */
   cancelHab() {
-    this.deleteHab(this.currentEditingHabForm);
-    this.currentEditingHabForm = null;
+    if (this.currentEditingHabForm !== null) {
+      const habArrayForm = this.stationForm.controls.habitats as UntypedFormArray;
+      habArrayForm.controls[this.currentEditingHabForm].setValue(this.currentHabCopy);
+      this.currentHabCopy = null;
+      this.currentEditingHabForm = null;
+    }
   }
 
   /**


### PR DESCRIPTION
The edition of the `habitats` where broken, when we cancelled the edition, the `habitats` was removed from the list, and if the edition of the `station` was saved the habitats was deleted. Now we save the state of the `habitats` and if we cancel, we reapply it.