### PR TITLE
feat(auth): config update or not user data from INPN Authentication

### DIFF
--- a/backend/geonature/core/auth/routes.py
+++ b/backend/geonature/core/auth/routes.py
@@ -94,7 +94,7 @@ def loginCas():
                 .id_application
             )
             token = encode_token(data)
-            response.set_cookie("token", token, expires=cookie_exp)
+            response.set_cookie("token", str(token), expires=cookie_exp)
 
             # User cookie
             organism_id = info_user["codeOrganisme"]

--- a/backend/geonature/core/auth/routes.py
+++ b/backend/geonature/core/auth/routes.py
@@ -112,6 +112,15 @@ def loginCas():
                 "id_organisme": organism_id,
             }
             response.set_cookie("current_user", str(current_user), expires=cookie_exp)
+
+            # Log the user in
+            user = db.session.execute(
+                sa.select(models.User)
+                .where(models.User.identifiant == current_user["user_login"])
+                .where(models.User.filter_by_app())
+            ).scalar_one()
+            login_user(user)
+            
             return response
         else:
             log.info("Erreur d'authentification lié au CAS, voir log du CAS")

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -64,6 +64,7 @@ class CasSchemaConf(Schema):
     )
     CAS_USER_WS = fields.Nested(CasUserSchemaConf, load_default=CasUserSchemaConf().load({}))
     USERS_CAN_SEE_ORGANISM_DATA = fields.Boolean(load_default=False)
+    UPDATE_USER_DATA_FROM_INPN_AUTHENTICATION = fields.Boolean(load_default=True)
     # Quel modules seront associés au JDD récupérés depuis MTD
 
 

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -115,6 +115,8 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
 
 [CAS]
     CAS_URL_VALIDATION = "https://preprod-inpn.mnhn.fr/auth/serviceValidate"
+    USERS_CAN_SEE_ORGANISM_DATA = false
+    UPDATE_USER_DATA_FROM_INPN_AUTHENTICATION = true
 
 [CAS.CAS_USER_WS]
     URL = "https://inpn2.mnhn.fr/authentication/information"

--- a/frontend/src/app/components/auth/auth.service.ts
+++ b/frontend/src/app/components/auth/auth.service.ts
@@ -155,7 +155,7 @@ export class AuthService {
   }
 
   isAuthenticated(): boolean {
-    return this._cookie.get('token') !== null;
+    return this._cookie.check('token') && this._cookie.get('token') !== null;
   }
 
   handleLoginError() {

--- a/frontend/src/app/modules/login/login/login.component.ts
+++ b/frontend/src/app/modules/login/login/login.component.ts
@@ -8,6 +8,7 @@ import { ConfigService } from '@geonature/services/config.service';
 import { ModuleService } from '@geonature/services/module.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RoutingService } from '@geonature/routing/routing.service';
+import * as moment from 'moment';
 
 @Component({
   selector: 'pnx-login',
@@ -47,7 +48,11 @@ export class LoginComponent implements OnInit {
     if (this.config.CAS_PUBLIC.CAS_AUTHENTIFICATION) {
       // if token not here here, redirection to CAS login page
       const url_redirection_cas = `${this.config.CAS_PUBLIC.CAS_URL_LOGIN}?service=${this.config.API_ENDPOINT}/gn_auth/login_cas`;
-      document.location.href = url_redirection_cas;
+      if (!this._authService.isAuthenticated()) {
+        // TODO: set the local storage item 'expires_at' in the API route "gn_auth/login_cas"
+        localStorage.setItem('expires_at', moment().add(1, 'days').toISOString());
+        document.location.href = url_redirection_cas;
+      }
     }
   }
 


### PR DESCRIPTION
⚠️ First two commits ; [fix(auth): fix cookie setup casting token to a string](https://github.com/PnX-SI/GeoNature/pull/2869/commits/0cabf07639e2f64ce33fb2e809f0b48c6e69787c) and [fix(auth): fix authentication via CAS INPN login](https://github.com/PnX-SI/GeoNature/pull/2869/commits/5fcbf6e25faf398e1e4222b646f04a5fca2440c6) ; from the PR https://github.com/PnX-SI/GeoNature/pull/2866 are necessary to be able to use CAS INPN login and thus to test this PR

TODO : 
- [ ] Merge the PR https://github.com/PnX-SI/GeoNature/pull/2866 

### Commit [feat(auth): config update or not user data from inpn auth](https://github.com/PnX-SI/GeoNature/pull/2869/commits/be5bd5fb14958646fb5d19780856244f2dfd450c) : 
- Improve the function `insert_user_and_org`
  - Add an argument `update_user`
  - If user already exists and not updating, retrieve existing user information rather than argument `info_user`
  - Refactorize and comment section dedicated to associating user to a default group
- Add a geonature config boolean parameter `UPDATE_USER_DATA_FROM_INPN_AUTHENTICATION` : used in the route `gn_auth/login_cas`