### PR TITLE
Feat/import all dest

### DIFF
--- a/backend/geonature/core/imports/blueprint.py
+++ b/backend/geonature/core/imports/blueprint.py
@@ -10,10 +10,15 @@ blueprint = Blueprint("import", __name__, template_folder="templates")
 
 @blueprint.url_value_preprocessor
 def set_current_destination(endpoint, values):
-    if current_app.url_map.is_endpoint_expecting(endpoint, "destination"):
+    if (
+        current_app.url_map.is_endpoint_expecting(endpoint, "destination")
+        and "destination" in values
+    ):
         g.destination = values["destination"] = Destination.query.filter(
             Destination.code == values["destination"]
         ).first_or_404()
+    else:
+        return
 
 
 from .routes import (

--- a/backend/geonature/core/imports/blueprint.py
+++ b/backend/geonature/core/imports/blueprint.py
@@ -17,8 +17,6 @@ def set_current_destination(endpoint, values):
         g.destination = values["destination"] = Destination.query.filter(
             Destination.code == values["destination"]
         ).first_or_404()
-    else:
-        return
 
 
 from .routes import (

--- a/backend/geonature/core/imports/routes/imports.py
+++ b/backend/geonature/core/imports/routes/imports.py
@@ -65,9 +65,10 @@ def resolve_import(endpoint, values):
         values["imprt"] = imprt
 
 
+@blueprint.route("/imports/", methods=["GET"])
 @blueprint.route("/<destination>/imports/", methods=["GET"])
 @permissions.check_cruved_scope("R", get_scope=True, module_code="IMPORT", object_code="IMPORT")
-def get_import_list(scope, destination):
+def get_import_list(scope, destination=None):
     """
     .. :quickref: Import; Get all imports.
 
@@ -107,16 +108,19 @@ def get_import_list(scope, destination):
     if sort_dir == "desc":
         order_by = desc(order_by)
 
-    imports = (
+    query = (
         TImports.query.options(contains_eager(TImports.dataset), contains_eager(TImports.authors))
         .join(TImports.dataset, isouter=True)
         .join(TImports.authors, isouter=True)
         .filter_by_scope(scope)
-        .filter(TImports.destination == destination)
         .filter(or_(*filters) if len(filters) > 0 else True)
         .order_by(order_by)
-        .paginate(page=page, error_out=False, max_per_page=limit)
     )
+
+    if destination:
+        query = query.filter(TImports.destination == destination)
+
+    imports = query.paginate(page=page, error_out=False, max_per_page=limit)
 
     data = {
         "imports": [imprt.as_dict() for imprt in imports.items],

--- a/backend/geonature/tests/imports/fixtures.py
+++ b/backend/geonature/tests/imports/fixtures.py
@@ -23,8 +23,6 @@ def default_destination(app):
             and g.default_destination
         ):
             values["destination"] = g.default_destination.code
-        else:
-            return
 
 
 @pytest.fixture(scope="session")

--- a/backend/geonature/tests/imports/fixtures.py
+++ b/backend/geonature/tests/imports/fixtures.py
@@ -20,7 +20,7 @@ def default_destination(app):
         if (
             app.url_map.is_endpoint_expecting(endpoint, "destination")
             and "destination" not in values
-            and g.default_destination
+            and hasattr(g, "default_destination")
         ):
             values["destination"] = g.default_destination.code
 

--- a/backend/geonature/tests/imports/fixtures.py
+++ b/backend/geonature/tests/imports/fixtures.py
@@ -5,6 +5,9 @@ from geonature.core.gn_commons.models import TModules
 
 from geonature.core.imports.models import Destination
 
+from sqlalchemy import select
+from geonature.utils.env import db
+
 
 @pytest.fixture(scope="session")
 def default_destination(app):
@@ -17,8 +20,11 @@ def default_destination(app):
         if (
             app.url_map.is_endpoint_expecting(endpoint, "destination")
             and "destination" not in values
+            and g.default_destination
         ):
             values["destination"] = g.default_destination.code
+        else:
+            return
 
 
 @pytest.fixture(scope="session")
@@ -33,3 +39,27 @@ def default_synthese_destination(app, default_destination, synthese_destination)
     g.default_destination = synthese_destination
     yield
     del g.default_destination
+
+
+@pytest.fixture(scope="session")
+def list_all_module_dest_code():
+    module_code_dest = db.session.scalars(
+        select(TModules.module_code).join(Destination, Destination.id_module == TModules.id_module)
+    ).all()
+    return module_code_dest
+
+
+@pytest.fixture(scope="session")
+def all_modules_destination(list_all_module_dest_code):
+    dict_modules_dest = {}
+
+    for module_code in list_all_module_dest_code:
+        query = select(Destination).filter(
+            Destination.module.has(TModules.module_code == module_code)
+        )
+
+        result = db.session.execute(query).scalar_one()
+
+        dict_modules_dest[module_code] = result
+
+    return dict_modules_dest

--- a/backend/geonature/tests/imports/test_imports_route.py
+++ b/backend/geonature/tests/imports/test_imports_route.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import pytest
+from flask import url_for
+from werkzeug.exceptions import Unauthorized, Forbidden
+from jsonschema import validate as validate_json
+
+from geonature.utils.env import db
+from geonature.tests.utils import set_logged_user
+
+from geonature.core.imports.models import TImports
+
+from .jsonschema_definitions import jsonschema_definitions
+
+
+tests_path = Path(__file__).parent
+
+
+@pytest.fixture(scope="function")
+def imports_all(all_modules_destination, users):
+    def create_import(authors=[]):
+        all_destinations = {}
+        with db.session.begin_nested():
+            for module_code, destination in all_modules_destination.items():
+                all_destinations[module_code] = TImports(destination=destination, authors=authors)
+            db.session.add_all(all_destinations.values())
+        return all_destinations
+
+    return {
+        "own_import": create_import(authors=[users["user"]]),
+        "associate_import": create_import(authors=[users["associate_user"]]),
+        "stranger_import": create_import(authors=[users["stranger_user"]]),
+        "orphan_import": create_import(),
+    }
+
+
+@pytest.mark.usefixtures("client_class", "temporary_transaction", "celery_eager")
+class TestImportsRoute:
+    def test_list_imports(self, imports_all, all_modules_destination, users):
+        r = self.client.get(url_for("import.get_import_list"))
+        assert r.status_code == Unauthorized.code, r.data
+        set_logged_user(self.client, users["noright_user"])
+        r = self.client.get(url_for("import.get_import_list"))
+        assert r.status_code == Forbidden.code, r.data
+        set_logged_user(self.client, users["user"])
+        r = self.client.get(url_for("import.get_import_list"))
+        assert r.status_code == 200, r.data
+        json_data = r.get_json()
+        validate_json(
+            json_data["imports"],
+            {
+                "definitions": jsonschema_definitions,
+                "type": "array",
+                "items": {"$ref": "#/definitions/import"},
+            },
+        )
+
+        ids_destination = [
+            module_dest.id_destination for module_dest in all_modules_destination.values()
+        ]
+
+        assert all(imprt["id_destination"] in ids_destination for imprt in json_data["imports"])


### PR DESCRIPTION
Tâche en lien : https://github.com/orgs/PnX-SI/projects/13/views/4?pane=issue&itemId=47854508

A réaliser :

- [x] Modifier la route de récupération des imports `get_import_list`
- [x] Ajout de test pour vérifier le bon fonctionnement de la route `/imports`  si `destination` n'est pas renseignée. Toutes les destinations possibles sont retournées par la route  

Le test sur le filtre par destination est déjà implémenté  par chaque module ? voir : geonature/backend/geonature/tests/imports/test_imports_synthese.py : 

https://github.com/PnX-SI/GeoNature/blob/94e880bb64b0e53fad235d208311edf5f02f8594/backend/geonature/tests/imports/test_imports_synthese.py#L337-L359 