### PR TITLE
Bump to Black 24

### DIFF
--- a/backend/geonature/core/gn_commons/medias/routes.py
+++ b/backend/geonature/core/gn_commons/medias/routes.py
@@ -2,6 +2,7 @@
     Route permettant de manipuler les fichiers
     contenus dans gn_media
 """
+
 from flask import request, redirect, jsonify
 from werkzeug.exceptions import NotFound
 

--- a/backend/geonature/core/gn_commons/models/additional_fields.py
+++ b/backend/geonature/core/gn_commons/models/additional_fields.py
@@ -1,6 +1,7 @@
 """
     Modèles du schéma gn_commons
 """
+
 from sqlalchemy.dialects.postgresql import JSONB
 
 from utils_flask_sqla.serializers import serializable

--- a/backend/geonature/core/gn_commons/models/base.py
+++ b/backend/geonature/core/gn_commons/models/base.py
@@ -1,6 +1,7 @@
 """
     Modèles du schéma gn_commons
 """
+
 import os
 from pathlib import Path
 from collections import defaultdict

--- a/backend/geonature/core/gn_meta/mtd/mtd_utils.py
+++ b/backend/geonature/core/gn_meta/mtd/mtd_utils.py
@@ -57,9 +57,11 @@ def sync_ds(ds, cd_nomenclatures):
 
     ds["id_acquisition_framework"] = af.id_acquisition_framework
     ds = {
-        k: func.ref_nomenclatures.get_id_nomenclature(NOMENCLATURE_MAPPING[k], v)
-        if k.startswith("id_nomenclature")
-        else v
+        k: (
+            func.ref_nomenclatures.get_id_nomenclature(NOMENCLATURE_MAPPING[k], v)
+            if k.startswith("id_nomenclature")
+            else v
+        )
         for k, v in ds.items()
         if v is not None
     }

--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -1,6 +1,7 @@
 """
     Routes for gn_meta 
 """
+
 import datetime as dt
 import json
 import logging
@@ -679,20 +680,20 @@ def get_export_pdf_acquisition_frameworks(id_acquisition_framework):
         acquisition_framework["chart"] = request.json["chart"]
 
     if acquisition_framework:
-        acquisition_framework[
-            "nomenclature_territorial_level"
-        ] = af.nomenclature_territorial_level.as_dict()
-        acquisition_framework[
-            "nomenclature_financing_type"
-        ] = af.nomenclature_financing_type.as_dict()
+        acquisition_framework["nomenclature_territorial_level"] = (
+            af.nomenclature_territorial_level.as_dict()
+        )
+        acquisition_framework["nomenclature_financing_type"] = (
+            af.nomenclature_financing_type.as_dict()
+        )
         if acquisition_framework["acquisition_framework_start_date"]:
-            acquisition_framework[
-                "acquisition_framework_start_date"
-            ] = af.acquisition_framework_start_date.strftime("%d/%m/%Y")
+            acquisition_framework["acquisition_framework_start_date"] = (
+                af.acquisition_framework_start_date.strftime("%d/%m/%Y")
+            )
         if acquisition_framework["acquisition_framework_end_date"]:
-            acquisition_framework[
-                "acquisition_framework_end_date"
-            ] = af.acquisition_framework_end_date.strftime("%d/%m/%Y")
+            acquisition_framework["acquisition_framework_end_date"] = (
+                af.acquisition_framework_end_date.strftime("%d/%m/%Y")
+            )
         acquisition_framework["css"] = {
             "logo": "Logo_pdf.png",
             "bandeau": "Bandeau_pdf.png",

--- a/backend/geonature/core/gn_permissions/decorators.py
+++ b/backend/geonature/core/gn_permissions/decorators.py
@@ -1,6 +1,7 @@
 """
 Decorators to protects routes with permissions
 """
+
 from functools import wraps
 from warnings import warn
 

--- a/backend/geonature/core/gn_permissions/models.py
+++ b/backend/geonature/core/gn_permissions/models.py
@@ -1,6 +1,7 @@
 """
 Models of gn_permissions schema
 """
+
 from packaging import version
 
 import sqlalchemy as sa

--- a/backend/geonature/core/gn_synthese/utils/process.py
+++ b/backend/geonature/core/gn_synthese/utils/process.py
@@ -1,6 +1,7 @@
 """
     functions to insert update or delete data in table gn_synthese.synthese
 """
+
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 from geonature.utils.env import DB
 from geonature.utils.errors import GeonatureApiError

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -5,6 +5,7 @@ Filter the query of synthese using SQLA expression language and 'select' object
 https://docs.sqlalchemy.org/en/latest/core/tutorial.html#selecting
 much more efficient
 """
+
 import datetime
 import unicodedata
 import uuid

--- a/backend/geonature/core/notifications/models.py
+++ b/backend/geonature/core/notifications/models.py
@@ -1,6 +1,7 @@
 """
 Models of gn_notifications schema
 """
+
 import datetime
 
 import sqlalchemy as sa

--- a/backend/geonature/core/users/register_post_actions.py
+++ b/backend/geonature/core/users/register_post_actions.py
@@ -1,6 +1,7 @@
 """
 Action triggered after register action (create temp user, change password etc...)
 """
+
 import datetime
 from warnings import warn
 

--- a/backend/geonature/migrations/versions/05a91edb6796_improve_v_synthese_for_export.py
+++ b/backend/geonature/migrations/versions/05a91edb6796_improve_v_synthese_for_export.py
@@ -5,6 +5,7 @@ Revises: 5d65f9c93a32
 Create Date: 2023-02-21 17:17:03.016130
 
 """
+
 from alembic import op
 
 

--- a/backend/geonature/migrations/versions/0630b93bcfe0_add_permissions_inherited_modules_objects.py
+++ b/backend/geonature/migrations/versions/0630b93bcfe0_add_permissions_inherited_modules_objects.py
@@ -9,6 +9,7 @@ Revises: cf1c1fdbde77
 Create Date: 2023-04-13 14:24:21.124669
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/07f10bbb4f3b_add_mobile_app_settings_url.py
+++ b/backend/geonature/migrations/versions/07f10bbb4f3b_add_mobile_app_settings_url.py
@@ -5,6 +5,7 @@ Revises: f4ffdc68072c
 Create Date: 2022-07-13 12:34:42.450453
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/095da7bc6667_add_table_gn_synthese_bib_reports_types.py
+++ b/backend/geonature/migrations/versions/095da7bc6667_add_table_gn_synthese_bib_reports_types.py
@@ -5,6 +5,7 @@ Revises: ca052245c6ec
 Create Date: 2022-03-17 10:57:34.730596
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from utils_flask_sqla.migrations.utils import logger

--- a/backend/geonature/migrations/versions/09a637f06b96_default_notification_rules.py
+++ b/backend/geonature/migrations/versions/09a637f06b96_default_notification_rules.py
@@ -5,6 +5,7 @@ Revises: 4cf3fd5d06f5
 Create Date: 2023-01-13 09:55:53.525869
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/0cae32a010ea_lstrip_static_media_from_path.py
+++ b/backend/geonature/migrations/versions/0cae32a010ea_lstrip_static_media_from_path.py
@@ -5,6 +5,7 @@ Revises: 497f52d996dd
 Create Date: 2023-01-25 18:01:06.482391
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/1715cf31a75d_insert_ign_250m_bd_alti_in_dem.py
+++ b/backend/geonature/migrations/versions/1715cf31a75d_insert_ign_250m_bd_alti_in_dem.py
@@ -4,6 +4,7 @@ Revision ID: 1715cf31a75d
 Create Date: 2021-09-27 22:58:27.235271
 
 """
+
 import os.path
 from zipfile import ZipFile
 from urllib.parse import urlsplit

--- a/backend/geonature/migrations/versions/1dbc45309d6e_merge_sensitivity.py
+++ b/backend/geonature/migrations/versions/1dbc45309d6e_merge_sensitivity.py
@@ -5,6 +5,7 @@ Revises: 30edd97ae582
 Create Date: 2022-02-15 17:45:54.259412
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/1eb624249f2b_add_default_value_in_additionalfields_.py
+++ b/backend/geonature/migrations/versions/1eb624249f2b_add_default_value_in_additionalfields_.py
@@ -5,6 +5,7 @@ Revises: 2aa558b1be3a
 Create Date: 2021-10-26 10:28:03.196912
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/2a2e5c519fd1_synthese_get_default_nomenclature_value.py
+++ b/backend/geonature/migrations/versions/2a2e5c519fd1_synthese_get_default_nomenclature_value.py
@@ -5,6 +5,7 @@ Revises: 7077aa76da3d
 Create Date: 2021-10-06 15:55:37.365073
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/2aa558b1be3a_add_schema_gn_profiles.py
+++ b/backend/geonature/migrations/versions/2aa558b1be3a_add_schema_gn_profiles.py
@@ -5,6 +5,7 @@ Revises: 5f4c4b644844
 Create Date: 2021-08-24 11:10:08.973033
 
 """
+
 import importlib.resources
 
 from alembic import op

--- a/backend/geonature/migrations/versions/2d7edda45dd4_sensitivity_fk_on_delete.py
+++ b/backend/geonature/migrations/versions/2d7edda45dd4_sensitivity_fk_on_delete.py
@@ -5,6 +5,7 @@ Revises: 4b5478df71cb
 Create Date: 2022-11-25 12:58:47.583031
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/30edd97ae582_remove_gn_export_t_config_exports.py
+++ b/backend/geonature/migrations/versions/30edd97ae582_remove_gn_export_t_config_exports.py
@@ -5,6 +5,7 @@ Revises: dde31e76ce45
 Create Date: 2022-01-21 10:51:15.288875
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.exc import InternalError

--- a/backend/geonature/migrations/versions/36d0bd313a47_add_notification_schema_tables_and_data.py
+++ b/backend/geonature/migrations/versions/36d0bd313a47_add_notification_schema_tables_and_data.py
@@ -5,6 +5,7 @@ Revises: 42040535a20e
 Create Date: 2022-09-22 09:58:19.055808
 
 """
+
 import datetime
 from alembic import op
 from sqlalchemy import Column, ForeignKey, Integer, Unicode, UnicodeText, DateTime

--- a/backend/geonature/migrations/versions/3d0bf4ee67d1_geonature_samples.py
+++ b/backend/geonature/migrations/versions/3d0bf4ee67d1_geonature_samples.py
@@ -4,6 +4,7 @@ Revision ID: 3d0bf4ee67d1
 Create Date: 2021-09-27 18:00:45.818766
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/42040535a20e_add_t_modules_ng_module_column.py
+++ b/backend/geonature/migrations/versions/42040535a20e_add_t_modules_ng_module_column.py
@@ -5,6 +5,7 @@ Revises: ca0fe5d21ea2
 Create Date: 2022-04-05 16:22:57.078076
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/446e902a14e7_add_id_module_to_v_synthese_for_web_app.py
+++ b/backend/geonature/migrations/versions/446e902a14e7_add_id_module_to_v_synthese_for_web_app.py
@@ -5,6 +5,7 @@ Revises: f1dd984bff97
 Create Date: 2023-09-25 10:09:39.126531
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/497f52d996dd_additional_fields_remove_columns.py
+++ b/backend/geonature/migrations/versions/497f52d996dd_additional_fields_remove_columns.py
@@ -5,6 +5,7 @@ Revises: 4cf3fd5d06f5
 Create Date: 2023-01-04 16:02:45.953579
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/4b5478df71cb_fix_update_synthese_sensitivity.py
+++ b/backend/geonature/migrations/versions/4b5478df71cb_fix_update_synthese_sensitivity.py
@@ -5,6 +5,7 @@ Revises: 42040535a20e
 Create Date: 2022-09-21 18:11:27.597095
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/4cf3fd5d06f5_set_not_null_on_synthese_id_source.py
+++ b/backend/geonature/migrations/versions/4cf3fd5d06f5_set_not_null_on_synthese_id_source.py
@@ -5,6 +5,7 @@ Revises: 36d0bd313a47
 Create Date: 2022-12-05 14:46:04.206294
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/5a2c9c65129f_add_sensitivity_filter_export_synthese.py
+++ b/backend/geonature/migrations/versions/5a2c9c65129f_add_sensitivity_filter_export_synthese.py
@@ -5,6 +5,7 @@ Revises: 446e902a14e7
 Create Date: 2023-08-08 16:23:53.059110
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/5d65f9c93a32_fix_permissions_view.py
+++ b/backend/geonature/migrations/versions/5d65f9c93a32_fix_permissions_view.py
@@ -5,6 +5,7 @@ Revises: 0cae32a010ea
 Create Date: 2023-02-20 17:49:03.156681
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/5f4c4b644844_delete_cascade_cor_dataset_territory.py
+++ b/backend/geonature/migrations/versions/5f4c4b644844_delete_cascade_cor_dataset_territory.py
@@ -5,6 +5,7 @@ Revises: 2a2e5c519fd1
 Create Date: 2021-10-07 15:27:06.364487
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/6070edb31013_set_constraint_check_cor_af_territory_.py
+++ b/backend/geonature/migrations/versions/6070edb31013_set_constraint_check_cor_af_territory_.py
@@ -5,6 +5,7 @@ Revises: d80835fb13c8
 Create Date: 2022-06-16 15:26:52.658472
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/61e46813d621_update_synthese_sensitivity.py
+++ b/backend/geonature/migrations/versions/61e46813d621_update_synthese_sensitivity.py
@@ -5,6 +5,7 @@ Revises: dde31e76ce45
 Create Date: 2022-02-15 15:23:08.732729
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/6f7d5549d49e_delete_view_v_synthese_validation_forwebapp.py
+++ b/backend/geonature/migrations/versions/6f7d5549d49e_delete_view_v_synthese_validation_forwebapp.py
@@ -5,6 +5,7 @@ Revises: 9a9f4971edcd
 Create Date: 2022-01-03 15:36:45.053127
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/7077aa76da3d_bump_dependencies.py
+++ b/backend/geonature/migrations/versions/7077aa76da3d_bump_dependencies.py
@@ -5,6 +5,7 @@ Revises: c0fdf2ee7f4f
 Create Date: 2021-09-27 22:33:47.462525
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/7471f51011c8_change_index_vm_valid_profiles_cd_ref_.py
+++ b/backend/geonature/migrations/versions/7471f51011c8_change_index_vm_valid_profiles_cd_ref_.py
@@ -5,6 +5,7 @@ Revises: 1eb624249f2b
 Create Date: 2021-11-08 10:59:23.047142
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/74908bad752e_add_altitude_calculation_in_t_base_site.py
+++ b/backend/geonature/migrations/versions/74908bad752e_add_altitude_calculation_in_t_base_site.py
@@ -5,6 +5,7 @@ Revises: ca0fe5d21ea2
 Create Date: 2022-05-19 15:07:04.613778
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/77a3bc6628d2_additional_fields_add_datalist_widget.py
+++ b/backend/geonature/migrations/versions/77a3bc6628d2_additional_fields_add_datalist_widget.py
@@ -5,6 +5,7 @@ Revises: 74908bad752e
 Create Date: 2022-04-27 17:00:38.070394
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/7dfd0a813f86_insert_inpn_sensitivity_referential.py
+++ b/backend/geonature/migrations/versions/7dfd0a813f86_insert_inpn_sensitivity_referential.py
@@ -4,6 +4,7 @@ Revision ID: 7dfd0a813f86
 Create Date: 2021-11-22
 
 """
+
 import csv
 import importlib.resources
 from functools import lru_cache, partial

--- a/backend/geonature/migrations/versions/7fe46b0e4729_multiple_filters_per_permission.py
+++ b/backend/geonature/migrations/versions/7fe46b0e4729_multiple_filters_per_permission.py
@@ -5,6 +5,7 @@ Revises: cf1c1fdbde77
 Create Date: 2023-04-12 14:38:44.788935
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import Column, ForeignKey, Integer, Unicode

--- a/backend/geonature/migrations/versions/8279ce74006b_set_default_modules_type.py
+++ b/backend/geonature/migrations/versions/8279ce74006b_set_default_modules_type.py
@@ -5,6 +5,7 @@ Revises: 5d65f9c93a32
 Create Date: 2023-02-22 12:47:26.727855
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/829a376daa52_add_table_gn_synthese_t_reports.py
+++ b/backend/geonature/migrations/versions/829a376daa52_add_table_gn_synthese_t_reports.py
@@ -5,6 +5,7 @@ Revises: 095da7bc6667
 Create Date: 2022-03-17 10:57:55.989648
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from utils_flask_sqla.migrations.utils import logger

--- a/backend/geonature/migrations/versions/87651375c2e8_vectorize_ign_bd_alti.py
+++ b/backend/geonature/migrations/versions/87651375c2e8_vectorize_ign_bd_alti.py
@@ -4,6 +4,7 @@ Revision ID: 87651375c2e8
 Create Date: 2021-09-28 10:41:26.441911
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/8888e5cce63b_add_index_on_id_area_for_table_cor_area_synthese.py
+++ b/backend/geonature/migrations/versions/8888e5cce63b_add_index_on_id_area_for_table_cor_area_synthese.py
@@ -5,6 +5,7 @@ Revises: 09a637f06b96
 Create Date: 2023-01-18 17:34:54.298323
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/8d90ab5e686d_default_profiles_parameters.py
+++ b/backend/geonature/migrations/versions/8d90ab5e686d_default_profiles_parameters.py
@@ -5,6 +5,7 @@ Revises: f4ffdc68072c
 Create Date: 2022-08-10 14:07:35.234716
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/95acee9f0452_add_comment_notification.py
+++ b/backend/geonature/migrations/versions/95acee9f0452_add_comment_notification.py
@@ -5,6 +5,7 @@ Revises: 9e9218653d6c
 Create Date: 2023-04-06 19:02:39.863972
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/geonature/migrations/versions/9e9218653d6c_add_synthese_log_history.py
+++ b/backend/geonature/migrations/versions/9e9218653d6c_add_synthese_log_history.py
@@ -5,6 +5,7 @@ Revises: 0cae32a010ea
 Create Date: 2022-04-06 15:39:37.428357
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/ac08dcf3f27b_diffusion_level.py
+++ b/backend/geonature/migrations/versions/ac08dcf3f27b_diffusion_level.py
@@ -5,6 +5,7 @@ Revises: dfec5f64ac73
 Create Date: 2022-02-10 12:45:05.472204
 
 """
+
 from distutils.util import strtobool
 
 from alembic import op, context

--- a/backend/geonature/migrations/versions/c0fdf2ee7f4f_auto_update_cor_area_synthese.py
+++ b/backend/geonature/migrations/versions/c0fdf2ee7f4f_auto_update_cor_area_synthese.py
@@ -5,6 +5,7 @@ Revises: f06cc80cc8ba
 Create Date: 2021-09-14 17:18:11.606752
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/ca052245c6ec_remove_local_srid.py
+++ b/backend/geonature/migrations/versions/ca052245c6ec_remove_local_srid.py
@@ -5,6 +5,7 @@ Revises: 1dbc45309d6e
 Create Date: 2022-03-11 15:11:46.640624
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/ca0fe5d21ea2_remove_v_synthese_decode_nomenclatures.py
+++ b/backend/geonature/migrations/versions/ca0fe5d21ea2_remove_v_synthese_decode_nomenclatures.py
@@ -5,6 +5,7 @@ Revises: 829a376daa52
 Create Date: 2022-04-04 14:59:57.340518
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/cec41a6d3a15_revome_v_roles_permissions.py
+++ b/backend/geonature/migrations/versions/cec41a6d3a15_revome_v_roles_permissions.py
@@ -5,6 +5,7 @@ Revises: 05a91edb6796
 Create Date: 2023-02-23 22:21:30.039893
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/cf1c1fdbde77_correction_sql_on_delete_module.py
+++ b/backend/geonature/migrations/versions/cf1c1fdbde77_correction_sql_on_delete_module.py
@@ -5,6 +5,7 @@ Revises: 9e9218653d6c
 Create Date: 2023-04-11 11:22:39.603084
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/d80835fb13c8_remove_cor_sensitivity_synthese.py
+++ b/backend/geonature/migrations/versions/d80835fb13c8_remove_cor_sensitivity_synthese.py
@@ -5,6 +5,7 @@ Revises: 77a3bc6628d2
 Create Date: 2022-02-15 12:16:38.003591
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/dde31e76ce45_remove_old_profile_function.py
+++ b/backend/geonature/migrations/versions/dde31e76ce45_remove_old_profile_function.py
@@ -5,6 +5,7 @@ Revises: 6f7d5549d49e
 Create Date: 2022-01-06 10:23:55.290043
 
 """
+
 import sqlalchemy as sa
 
 from alembic import op

--- a/backend/geonature/migrations/versions/df5a5099e084_add_additional_fields_object.py
+++ b/backend/geonature/migrations/versions/df5a5099e084_add_additional_fields_object.py
@@ -5,6 +5,7 @@ Revises: 0630b93bcfe0
 Create Date: 2023-04-20 10:46:00.334251
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/dfec5f64ac73_fix_sensitivity_algo.py
+++ b/backend/geonature/migrations/versions/dfec5f64ac73_fix_sensitivity_algo.py
@@ -5,6 +5,7 @@ Revises: dde31e76ce45
 Create Date: 2022-01-28 14:06:38.748133
 
 """
+
 from distutils.util import strtobool
 
 from alembic import op, context

--- a/backend/geonature/migrations/versions/e2a94808cf76_add_notifications_object.py
+++ b/backend/geonature/migrations/versions/e2a94808cf76_add_notifications_object.py
@@ -5,6 +5,7 @@ Revises: cf1c1fdbde77
 Create Date: 2023-04-14 18:16:57.981499
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/migrations/versions/f051b88a57fd_permissions_available.py
+++ b/backend/geonature/migrations/versions/f051b88a57fd_permissions_available.py
@@ -5,6 +5,7 @@ Revises: 7fe46b0e4729
 Create Date: 2023-04-14 17:19:36.490766
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.types import Integer, Boolean, Unicode

--- a/backend/geonature/migrations/versions/f06cc80cc8ba_2_7_5.py
+++ b/backend/geonature/migrations/versions/f06cc80cc8ba_2_7_5.py
@@ -4,6 +4,7 @@ Revision ID: f06cc80cc8ba
 Create Date: 2021-08-10 14:23:55.144250
 
 """
+
 import importlib
 
 from alembic import op, context

--- a/backend/geonature/migrations/versions/f1dd984bff97_add_sensitivity_filter.py
+++ b/backend/geonature/migrations/versions/f1dd984bff97_add_sensitivity_filter.py
@@ -5,6 +5,7 @@ Revises: f051b88a57fd
 Create Date: 2023-04-19 16:24:57.945428
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import Column, Boolean

--- a/backend/geonature/migrations/versions/f4ffdc68072c_add_id_module_in_t_sources.py
+++ b/backend/geonature/migrations/versions/f4ffdc68072c_add_id_module_in_t_sources.py
@@ -5,6 +5,7 @@ Revises: 3902129a52b3
 Create Date: 2022-04-27 13:42:51.851067
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/geonature/utils/command.py
+++ b/backend/geonature/utils/command.py
@@ -6,6 +6,7 @@
     fichiers de routing du frontend etc...). Ces dernières doivent pouvoir fonctionner même si
     un paquet PIP du requirement GeoNature n'a pas été bien installé
 """
+
 import os
 import json
 from subprocess import run, DEVNULL

--- a/backend/geonature/utils/utilsgeometrytools.py
+++ b/backend/geonature/utils/utilsgeometrytools.py
@@ -2,6 +2,7 @@
     Fonctions permettant de manipuler de façon génériques
     les fonctions de flask_sqla_geo
 """
+
 from pathlib import Path
 
 from flask import current_app

--- a/contrib/gn_module_occhab/backend/gn_module_occhab/migrations/21f661247023_insert_occhab_sample_data.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/migrations/21f661247023_insert_occhab_sample_data.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2021-10-04 10:15:40.419932
 
 """
+
 import importlib
 
 from alembic import op

--- a/contrib/gn_module_occhab/backend/gn_module_occhab/migrations/2984569d5df6_create_occhab_schema.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/migrations/2984569d5df6_create_occhab_schema.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2021-10-04 10:15:40.419932
 
 """
+
 import importlib
 
 from alembic import op

--- a/contrib/gn_module_occhab/backend/gn_module_occhab/migrations/85efc9bb5a47_declare_permissions.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/migrations/85efc9bb5a47_declare_permissions.py
@@ -5,6 +5,7 @@ Revises: 2984569d5df6
 Create Date: 2023-05-17 14:34:51.804258
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/gn_module_validation/backend/gn_module_validation/migrations/9a4b4b6f8fe6_add_fct_auto_validation.py
+++ b/contrib/gn_module_validation/backend/gn_module_validation/migrations/9a4b4b6f8fe6_add_fct_auto_validation.py
@@ -5,6 +5,7 @@ Revises: 446e902a14e7
 Create Date: 2023-10-25 17:18:04.438706
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/gn_module_validation/backend/gn_module_validation/migrations/df93a68242ee_declare_permissions.py
+++ b/contrib/gn_module_validation/backend/gn_module_validation/migrations/df93a68242ee_declare_permissions.py
@@ -5,6 +5,7 @@ Revises: 85efc9bb5a47
 Create Date: 2023-05-17 15:15:38.833529
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/blueprint.py
+++ b/contrib/occtax/backend/occtax/blueprint.py
@@ -89,9 +89,11 @@ def getReleves(scope):
     page = int(parameters.get("offset", 0))
     orderby = {
         "orderby": (parameters.get("orderby", "date_max")).lower(),
-        "order": (parameters.get("order", "desc")).lower()
-        if (parameters.get("order", "desc")).lower() == "asc"
-        else "desc",  # asc or desc
+        "order": (
+            (parameters.get("order", "desc")).lower()
+            if (parameters.get("order", "desc")).lower() == "asc"
+            else "desc"
+        ),  # asc or desc
     }
 
     # Filters

--- a/contrib/occtax/backend/occtax/migrations/023b0be41829_add_id_module_in_pr_occtax_t_releves.py
+++ b/contrib/occtax/backend/occtax/migrations/023b0be41829_add_id_module_in_pr_occtax_t_releves.py
@@ -5,6 +5,7 @@ Revises: 944072911ff7
 Create Date: 2022-04-06 16:19:58.971694
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/0ff94776a962_t_releves_triggers_optimization.py
+++ b/contrib/occtax/backend/occtax/migrations/0ff94776a962_t_releves_triggers_optimization.py
@@ -5,6 +5,7 @@ Revises: 61802a0f83b8
 Create Date: 2022-11-14 15:39:49.550279
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/1b4f44762020_add_cd_hab_in_fct_tri_synthese_update_.py
+++ b/contrib/occtax/backend/occtax/migrations/1b4f44762020_add_cd_hab_in_fct_tri_synthese_update_.py
@@ -5,6 +5,7 @@ Revises: 0ff94776a962
 Create Date: 2023-04-04 00:26:12.030884
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/22c2851bc387_add_database_default_value.py
+++ b/contrib/occtax/backend/occtax/migrations/22c2851bc387_add_database_default_value.py
@@ -5,6 +5,7 @@ Revises: 944072911ff7
 Create Date: 2022-04-25 13:52:16.016035
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/29c199e07eaa_create_occtax_schema.py
+++ b/contrib/occtax/backend/occtax/migrations/29c199e07eaa_create_occtax_schema.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2021-10-04 10:15:40.419932
 
 """
+
 import importlib
 
 from alembic import op

--- a/contrib/occtax/backend/occtax/migrations/2a0ab7644e1c_occtax_sample_test.py
+++ b/contrib/occtax/backend/occtax/migrations/2a0ab7644e1c_occtax_sample_test.py
@@ -5,6 +5,7 @@ Revises: 944072911ff7
 Create Date: 2022-01-18 16:55:20.493967
 
 """
+
 import importlib
 
 from alembic import op

--- a/contrib/occtax/backend/occtax/migrations/494cb2245a43_trigger_comportement.py
+++ b/contrib/occtax/backend/occtax/migrations/494cb2245a43_trigger_comportement.py
@@ -5,6 +5,7 @@ Revises: f57107d2d0ad
 Create Date: 2021-10-07 16:01:31.763465
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/4c97453a2d1a_add_missing_id_module_in_t_sources.py
+++ b/contrib/occtax/backend/occtax/migrations/4c97453a2d1a_add_missing_id_module_in_t_sources.py
@@ -5,6 +5,7 @@ Revises: df088920b2f3
 Create Date: 2022-12-14 11:43:46.873045
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/576cbd26b012_default_value_for_id_nomenclature_.py
+++ b/contrib/occtax/backend/occtax/migrations/576cbd26b012_default_value_for_id_nomenclature_.py
@@ -5,6 +5,7 @@ Revises: 9624348fea40
 Create Date: 2022-11-02 10:45:57.851612
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/61802a0f83b8_fix_occtax_triggers.py
+++ b/contrib/occtax/backend/occtax/migrations/61802a0f83b8_fix_occtax_triggers.py
@@ -5,6 +5,7 @@ Revises: 576cbd26b012
 Create Date: 2022-11-09 15:52:14.071528
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/87705981de5e_occtax_samples_with_id_module.py
+++ b/contrib/occtax/backend/occtax/migrations/87705981de5e_occtax_samples_with_id_module.py
@@ -5,6 +5,7 @@ Revises: cce08a64eb4f
 Create Date: 2023-01-18 10:29:41.071499
 
 """
+
 import importlib
 
 from alembic import op

--- a/contrib/occtax/backend/occtax/migrations/944072911ff7_update_synthese_data_bug_occtax_trigger.py
+++ b/contrib/occtax/backend/occtax/migrations/944072911ff7_update_synthese_data_bug_occtax_trigger.py
@@ -5,6 +5,7 @@ Revises: 494cb2245a43
 Create Date: 2021-10-07 16:24:09.029496
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/9624348fea40_restore_occtax_missing_counting.py
+++ b/contrib/occtax/backend/occtax/migrations/9624348fea40_restore_occtax_missing_counting.py
@@ -5,6 +5,7 @@ Revises: 22c2851bc387
 Create Date: 2022-10-12 16:19:18.065398
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/9668b861bdb6_remove_v_releve_occtax.py
+++ b/contrib/occtax/backend/occtax/migrations/9668b861bdb6_remove_v_releve_occtax.py
@@ -5,6 +5,7 @@ Revises: 4c97453a2d1a
 Create Date: 2023-02-08 16:11:52.634937
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/addb71d8efad_create_occtax_export_view.py
+++ b/contrib/occtax/backend/occtax/migrations/addb71d8efad_create_occtax_export_view.py
@@ -5,6 +5,7 @@ Revises: 29c199e07eaa
 Create Date: 2021-10-04 11:22:19.819944
 
 """
+
 import importlib
 
 from alembic import op

--- a/contrib/occtax/backend/occtax/migrations/c26c770b00ae_fix_occtax_trigger.py
+++ b/contrib/occtax/backend/occtax/migrations/c26c770b00ae_fix_occtax_trigger.py
@@ -5,6 +5,7 @@ Revises: 22c2851bc387
 Create Date: 2022-10-12 16:05:50.816962
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/cce08a64eb4f_insert_occtax_sample_data.py
+++ b/contrib/occtax/backend/occtax/migrations/cce08a64eb4f_insert_occtax_sample_data.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2021-10-04 11:31:50.957854
 
 """
+
 import importlib
 
 from alembic import op

--- a/contrib/occtax/backend/occtax/migrations/df088920b2f3_set_not_null_on_id_module.py
+++ b/contrib/occtax/backend/occtax/migrations/df088920b2f3_set_not_null_on_id_module.py
@@ -5,6 +5,7 @@ Revises: 61802a0f83b8
 Create Date: 2022-12-05 10:44:39.166886
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/e170d1902137_declare_permissions.py
+++ b/contrib/occtax/backend/occtax/migrations/e170d1902137_declare_permissions.py
@@ -5,6 +5,7 @@ Revises: 1b4f44762020
 Create Date: 2023-05-16 09:55:41.005029
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/contrib/occtax/backend/occtax/migrations/f57107d2d0ad_get_default_nomenclature_value.py
+++ b/contrib/occtax/backend/occtax/migrations/f57107d2d0ad_get_default_nomenclature_value.py
@@ -5,6 +5,7 @@ Revises: addb71d8efad
 Create Date: 2021-10-06 16:36:13.566702
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/data/scripts/import_ginco/import_ca.py
+++ b/data/scripts/import_ginco/import_ca.py
@@ -2,6 +2,7 @@
 	Script importing metadata in GeoNature DataBase based on uuid of datasets to import
 	Use the inpn webservice to get corresponding xml files. Works with datasets and acquisition frameworks, not yet with parents acquisition frameworks (to do)
 """
+
 import os
 import datetime
 import xml.etree.ElementTree as ET

--- a/data/scripts/import_ginco/import_mtd.py
+++ b/data/scripts/import_ginco/import_mtd.py
@@ -2,6 +2,7 @@
 	Script importing metadata in GeoNature DataBase based on uuid of datasets to import
 	Use the inpn webservice to get corresponding xml files. Works with datasets and acquisition frameworks, not yet with parents acquisition frameworks (to do)
 """
+
 import os
 import xml.etree.ElementTree as ET
 

--- a/data/scripts/import_mtd/import_jdd_and_ca.py
+++ b/data/scripts/import_mtd/import_jdd_and_ca.py
@@ -1,6 +1,7 @@
 """ 
 Ce script importe les informations des JDD et des CA à partir du webservice MTD. A la difference du script run_import_mtd, il trouve les CA correspondant aux JDD à partir du XML d'un JDD. Il n'est pas necessaire d'avoir une liste de CA
 """
+
 import requests
 import psycopg2
 import xml.etree.ElementTree as ET

--- a/data/scripts/import_mtd/run_import_mtd.py
+++ b/data/scripts/import_mtd/run_import_mtd.py
@@ -2,6 +2,7 @@
 	Script importing metadata in GeoNature DataBase based on uuid of datasets to import
 	Use the inpn webservice to get corresponding xml files. Works with datasets and acquisition frameworks, not yet with parents acquisition frameworks (to do)
 """
+
 import requests
 import psycopg2
 import xml.etree.ElementTree as ET

--- a/install/03b_populate_db.sh
+++ b/install/03b_populate_db.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 geonature db upgrade geonature@head -x local-srid=$srid_local
-geonature db upgrade taxonomie@head -x local-srid=$srid_local
 geonature db autoupgrade -x local-srid=$srid_local
 
 geonature db exec "DO 'BEGIN ASSERT EXISTS (SELECT 1 FROM taxonomie.taxref); END'" 2>/dev/null \

--- a/install/03b_populate_db.sh
+++ b/install/03b_populate_db.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 geonature db upgrade geonature@head -x local-srid=$srid_local
+geonature db upgrade taxonomie@head -x local-srid=$srid_local
 geonature db autoupgrade -x local-srid=$srid_local
 
 geonature db exec "DO 'BEGIN ASSERT EXISTS (SELECT 1 FROM taxonomie.taxref); END'" 2>/dev/null \
@@ -43,11 +44,11 @@ geonature db exec "DO 'BEGIN ASSERT EXISTS (SELECT 1 FROM gn_sensitivity.t_sensi
 then
     geonature db upgrade ref_geo_fr_departments@head
     geonature sensitivity add-referential \
-            --source-name "Référentiel sensibilité TAXREF v16 20230203" \
-            --url https://geonature.fr/data/inpn/sensitivity/RefSensibiliteV16_20230203.zip \
-            --zipfile RefSensibiliteV16_20230203.zip \
-            --csvfile RefSensibiliteV16_20230203/RefSensibilite_16.csv  \
-            --encoding=iso-8859-15
+    --source-name "Référentiel sensibilité TAXREF v16 20230203" \
+    --url https://geonature.fr/data/inpn/sensitivity/RefSensibiliteV16_20230203.zip \
+    --zipfile RefSensibiliteV16_20230203.zip \
+    --csvfile RefSensibiliteV16_20230203/RefSensibilite_16.csv  \
+    --encoding=iso-8859-15
     geonature sensitivity refresh-rules-cache
 fi
 


### PR DESCRIPTION
Le formateur Black est mise à jour (version 24). Cette PR reformate le code de GeoNature selon les nouvelles normes de cette version. Pour plus d'informations: https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html

A merge en dernier !! 