### PR TITLE
[Synthese] modif route taxons_autocomplete pour faire remonter les synonymes + nom valide des taxons

### DIFF
--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -972,7 +972,8 @@ def get_autocomplete_taxons_synthese():
             ),
         )
         .distinct()
-        .join(Synthese, Synthese.cd_nom == VMTaxrefListForautocomplete.cd_nom)
+        .join(Taxref, Taxref.cd_ref == VMTaxrefListForautocomplete.cd_ref)
+        .join(Synthese, Synthese.cd_nom == Taxref.cd_nom)
     )
     search_name = search_name.replace(" ", "%")
     query = query.where(


### PR DESCRIPTION
Salut, 
Une petite PR permettant de faire remonter les synonymes/nom valides des taxons existants en base au niveau de la recherche d'un taxon dans la synthèse.

Jusqu'à présent si dans la synthèse il ne se trouvaient que des données saisies au synonyme (`cd_nom <> cd_ref`) la recherche via le nom valide faisait ressortir l'erreur "`Aucun taxon trouvé pour cette recherche`", pour recherche ces données il fallait absolument saisir le synonyme présent dans la synthèse. Pénible...
Idem si c'est l'inverse : que du nom valide présent en synthèse -> il n'est pas possible de faire une recherche via un synonyme.

Du coup la PR permet de rechercher via un synonyme ou le nom valide tant qu'un taxon existe dans la synthèse. L'erreur "`Aucun taxon trouvé pour cette recherche`" est toujours présente si aucun cd_nom d'un taxon n'est présent dans la synthèse.

Il me semblait que des échanges existaient sur ce point, mais je n'ai pas réussi à remettre la main dessus dans les issues ouvertes ou fermées... 