### PR TITLE
[IMPORT] feat(import): add counting statistics in import report

### DIFF
--- a/backend/geonature/core/gn_synthese/module.py
+++ b/backend/geonature/core/gn_synthese/module.py
@@ -13,4 +13,7 @@ class SyntheseModule(TModules):
         "check_transient_data": check_transient_data,
         "import_data_to_destination": import_data_to_synthese,
         "remove_data_from_destination": remove_data_from_synthese,
+        "statistics_labels": [
+            {"key": "taxa_count", "value": "Nombre de taxons importés"},
+        ],
     }

--- a/backend/geonature/core/imports/models.py
+++ b/backend/geonature/core/imports/models.py
@@ -146,6 +146,10 @@ class Destination(db.Model):
     def remove_data_from_destination(self):
         return self.module._imports_["remove_data_from_destination"]
 
+    @property
+    def statistics_labels(self):
+        return self.module._imports_.get("statistics_labels", {})
+
 
 @serializable
 class BibThemes(db.Model):
@@ -257,6 +261,7 @@ class ImportQuery(Query):
         "dataset.active",
         "destination.code",
         "destination.label",
+        "destination.statistics_labels",
     ]
 )
 class TImports(InstancePermissionMixin, db.Model):

--- a/contrib/gn_module_occhab/backend/gn_module_occhab/module.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/module.py
@@ -15,4 +15,8 @@ class OcchabModule(TModules):
         "check_transient_data": check_transient_data,
         "import_data_to_destination": import_data_to_occhab,
         "remove_data_from_destination": remove_data_from_occhab,
+        "statistics_labels": [
+            {"key": "station_count", "value": "Nombre de stations importées"},
+            {"key": "habitat_count", "value": "Nombre d’habitats importés"},
+        ],
     }

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.html
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.html
@@ -43,7 +43,15 @@
             <p><b> SRID : </b> {{ importData?.srid }}</p>
             <p><b> Encodage :</b> {{ importData?.encoding }}</p>
             <p><b> Format : </b>{{ importData?.format_source_file }}</p>
-            <p><b>Nombre de lignes importées : </b> ({{importData?.import_count || 0}} / {{ importData?.source_count || 0 }})</p>
+            <p><b> Nombre de lignes : </b> {{ importData?.source_count || 0 }}</p>
+            <div *ngIf="importStatus === 'TERMINE'">
+              <p><b> Nombre d’entités importées : </b> {{importData?.import_count || 0}}</p>
+              <div *ngFor="let item of importData?.destination.statistics_labels">
+                <ng-container *ngIf="importData?.statistics[item.key] !== null">
+                  <p><b> {{ item.value }} : </b> {{ importData?.statistics[item.key] }}</p>
+                </ng-container>
+              </div>
+            </div>
           </div>
           <div class="col-sm-4 d-flex flex-column justify-content-center">
             <button  mat-raised-button color="primary" [disabled]="loadingPdf" (click)="exportAsPDF()" class="align-self-center">


### PR DESCRIPTION
# DESCRIPTION

Add **destination-specific ; Synthese, OccHab... ; counting statistics in import report**, inside import description panel.

Statistics as for now: 
- Synthese: 
  - **Taxa count**
- OccHab: 
  - **Stations counts**
  - **Habitats count**


# RESULT

Below are screen captures of **imports reports with three representative cases** : 

1. An **import not done** ; more precisely in progress with status 'EN COURS' ; for which statistics are not displayed : 
![image](https://github.com/PnX-SI/GeoNature/assets/92695617/36fc6d38-e791-448a-9d45-fabc5c178ce9)

2. An **import done ; with status 'TERMINE' ; and with destination Synthese**, for which statistics ; count of imported entities and count of imported taxa ; are displayed : 
![image](https://github.com/PnX-SI/GeoNature/assets/92695617/ee0fa7b4-04bd-4117-ab02-3e334506ac8f)

3. An **import done ; with status 'TERMINE' ; and with destination OccHab**, for which statistics ; count of imported entities, count of imported habitats and count of imported stations ; are displayed : 
![image](https://github.com/PnX-SI/GeoNature/assets/92695617/322991df-c71d-4b0d-bf96-56682a98f76c)


