### PR TITLE
feat: add tab to handle multiple entities in fields-mapping-step

### DIFF
--- a/frontend/src/app/modules/imports/components/import_process/fields-mapping-step/fields-mapping-step.component.html
+++ b/frontend/src/app/modules/imports/components/import_process/fields-mapping-step/fields-mapping-step.component.html
@@ -1,380 +1,375 @@
-    <div class="card">
-        <div class="card-header">
-            <h5 class="card-title mb-0"> Correspondance des champs avec le modèle </h5>
+<div class="card">
+  <div class="card-header">
+    <h5 class="card-title mb-0">Correspondance des champs avec le modèle</h5>
+  </div>
+  <div *ngIf="formReady" class="card-body">
+    <!-- Choix de la liste des nomenclatures -->
+    <form>
+      <fieldset>
+        <div *ngIf="userFieldMappings.length > 0" class="form-group">
+          <legend class="px-1">Choix d’un modèle d'import prédéfini</legend>
+          <select
+            class="form-control"
+            id="mappingSelection"
+            [formControl]="fieldMappingForm"
+            [compareWith]="areMappingFieldEqual"
+            [disableControl]="!userFieldMappings.length"
+          >
+            <option [ngValue]="null"></option>
+            <option *ngFor="let fieldMapping of userFieldMappings" [ngValue]="fieldMapping">
+              {{ fieldMapping.label }}
+            </option>
+          </select>
         </div>
-        <div
-            *ngIf="formReady"
-            class="card-body"
-        >
-            <!-- Choix de la liste des nomenclatures -->
-            <form>
-                <fieldset>
-                    <div *ngIf="userFieldMappings.length > 0" class="form-group">
-                        <legend class="px-1">
-                            Choix d’un modèle d'import prédéfini
-                        </legend>
-                        <select
-                            class="form-control"
-                            id="mappingSelection"
-                            [formControl]="fieldMappingForm"
-                            [compareWith]="areMappingFieldEqual"
-                            [disableControl]="!userFieldMappings.length"
-                        >
-                            <option [ngValue]="null"> </option>
-                            <option
-                                *ngFor="let fieldMapping of userFieldMappings"
-                                [ngValue]="fieldMapping"
-                            >
-                                {{fieldMapping.label}}</option>
-                        </select>
-                    </div>
 
-                    <div class="d-flex flex-row justify-content-center mt-3">
-
-                        <div class="d-flex justify-content-center align-content-between row w-100">
-                            <button
-                                *ngIf="canRenameMapping"
-                                class="btn-sm mb-1 ml-1 col-xl-4 w-50"
-                                mat-raised-button
-                                color="primary"
-                                (click)="showRenameMappingForm()"
-                                [disabled]="!renameMappingEnabled()"
-                            >
-                                Renommer le modèle d'import
-                            </button>
-                            <button
-                                *ngIf="canDeleteMapping"
-                                class="btn-sm mb-1 ml-1 col-xl-4 w-50"
-                                mat-raised-button
-                                color="warn"
-                                (click)="openDeleteModal()"
-                                [disabled]="!deleteMappingEnabled()"
-                            >
-                                Supprimer le modèle d'import
-                            </button>
-                            <div
-                                    *ngIf="config.IMPORT.DISPLAY_CHECK_BOX_MAPPED_FIELD"
-                                    class="form-check col-xl w-75 d-flex justify-content-center align-items-start"
-                            >
-                                <input
-                                        type="checkbox"
-                                        [(ngModel)]="displayAllValues"
-                                        [ngModelOptions]="{standalone: true}"
-                                        class="mt-1 mr-1"
-                                >
-                                Afficher les champs automatiquement associés
-                            </div>
-                        </div>
-
-
-
-
-                    </div>
-
-                    <div
-                        *ngIf="createMappingFormVisible"
-                        class="d-flex flex-row justify-content-between form_group"
-                        id="newMap"
-                    >
-                        <input
-                            type="text"
-                            class="form-control mr-2"
-                            value="Inconnu"
-                            [formControl]="createOrRenameMappingForm"
-                        >
-                        <button
-                            class="d-flex justify-content-center align-content-between mr-2 button-success"
-                            mat-raised-button
-                            matTooltip="Créer un nouveau mapping"
-                            (click)="createMapping(createOrRenameMappingForm.value)"
-                            [disabled]="!createOrRenameMappingForm.valid"
-                        >
-                            <mat-icon>add</mat-icon>
-                        </button>
-                        <button
-                            class="d-flex justify-content-center align-content-between"
-                            mat-raised-button
-                            color=warn
-                            (click)="hideCreateOrRenameMappingForm()"
-                        >
-                            Annuler
-                        </button>
-                    </div>
-
-                    <div
-                        *ngIf="renameMappingFormVisible"
-                        class="d-flex flex-row justify-content-between form_group"
-                        id="updateMap"
-                    >
-                        <input
-                            type="text"
-                            class="form-control mr-2"
-                            value="Inconnu"
-                            [formControl]="createOrRenameMappingForm"
-                        >
-                        <button
-                            class="d-flex justify-content-center align-content-between mr-2 button-success"
-                            (click)="renameMapping()"
-                            mat-raised-button
-                            matTooltip="Modifier le nom du modèle d'import"
-                            [disabled]="!createOrRenameMappingForm.valid || fieldMappingForm.value.label.trim() == this.createOrRenameMappingForm.value.trim()"
-                        >
-                            <mat-icon>check</mat-icon>
-                        </button>
-                        <button
-                            matTooltip="Annuler la modification du nom du modèle d'import"
-                            class="d-flex justify-content-center align-content-between"
-                            (click)="hideCreateOrRenameMappingForm()"
-                            mat-raised-button
-                            color="warn"
-                        >
-                            Annuler
-                        </button>
-                    </div>
-
-                    <div *ngIf="fieldMappingForm.value != null">
-                        <div
-                            *ngIf="mappedTargetFields.size > 0"
-                            class="alert alert-success"
-                            role="alert"
-                            style="text-align: center;"
-                        >
-                           {{ mappedTargetFields.size }} champs cibles ont été associés à un champs source.
-                        </div>
-                        <div
-                            *ngIf="unmappedSourceFields.size == 0"
-                            class="alert alert-success"
-                            role="alert"
-                            style="text-align: center;"
-                        >
-                            L'ensemble des {{ mappedSourceFields.size }} champs du fichier d’import ont été associés à un champs cible.
-                        </div>
-                        <div
-                            *ngIf="unmappedSourceFields.size > 0"
-                            class="alert alert-warning"
-                            role="alert"
-                            style="text-align: center;"
-                        >
-                            <a data-toggle="collapse" href="#unmappedSourceFields" aria-expanded="false" aria-controls="unmappedSourceFields">
-                              {{ unmappedSourceFields.size }} champs
-                            </a> du fichier d’import ne sont actuellement associés à aucun champs cible et seront donc ignorés.
-                            <div class="collapse" id="unmappedSourceFields">
-                              <ul style="text-align: left;">
-                                <li *ngFor="let sourceField of unmappedSourceFields">{{ sourceField }}</li>
-                              </ul>
-                            </div>
-                        </div>
-                    </div>
-                </fieldset>
-            </form>
-            <form [formGroup]="syntheseForm">
-              <mat-tab-group [(selectedIndex)]="selectedIndex" animationDuration="0ms" class="entities-tab">
-                <mat-tab *ngFor="let entitythemes of targetFields" label="{{ entitythemes.entity.label }}">
-                  <div *ngFor="let themefields of entitythemes.themes" class="entities-tab__content">
-                    <fieldset>
-                        <legend class="px-1">
-                            {{themefields.theme.fr_label_theme}}
-                        </legend>
-                        <div class="row m-0">
-                            <ng-container *ngFor="let field of themefields.fields">
-                                <div
-                                    *ngIf="!getValue(field) || displayAllValues"
-                                    class="col-6"
-                                >
-                                    <div
-                                        *ngIf="!field.autogenerated"
-                                        class="form-group"
-                                    >
-                                        <small>{{field.fr_label}} :
-                                            <i
-                                                *ngIf="field.comment"
-                                                matTooltip="{{field.comment}}"
-                                                matTooltipClass="custom-tooltip"
-                                                class="fa fa-info-circle"
-                                                aria-hidden="true"
-                                            ></i>
-
-                                        </small>
-                                        <ng-select
-                                            id="{{field.name_field}}"
-                                            [items]="sourceFields"
-                                            [multiple]="field.multi"
-                                            [clearable]="true"
-                                            [virtualScroll]="true"
-                                            formControlName="{{field.name_field}}"
-                                        >
-                                            <ng-template ng-option-tmp let-item="item" let-index="index" let-search="searchTerm">
-                                                <div>
-                                                    <span
-                                                        [ngClass]="{'in_use': mappedSourceFields.has(item)}"
-                                                        class="pre-wrap"
-                                                    >
-                                                        {{ item }}
-                                                    </span>
-                                                </div>
-                                            </ng-template>
-                                        </ng-select>
-                                        <div
-                                            *ngIf="syntheseForm.controls[field.name_field].hasError('required')"
-                                            class="invalid-feedback d-block"
-                                        >Sélectionnez
-                                            {{field.name_field}}</div>
-                                        <div *ngIf="field.name_field=='WKT'">
-                                            <small>*si pas de WKT, indiquez longitude et latitude.</small>
-                                        </div>
-
-                                        <div
-                                            *ngIf="syntheseForm.controls[field.name_field].hasError('conflict')"
-                                            class="invalid-feedback d-block"
-                                        >{{ syntheseForm.controls[field.name_field].getError('conflict') }}</div>
-                                    </div>
-                                    <div
-                                        *ngIf="field.autogenerated"
-                                        class="form-group"
-                                    >
-                                        <p *ngIf="displayAlert(field)" class="text-warning text-sm">
-                                            Attention les identifiants SINP ne seront pas générés
-                                        </p>
-                                        <label for="{{field.name_field}}"> <small>{{field.fr_label}} :</small> </label>
-                                        <input
-                                            class="ml-1"
-                                            type="checkbox"
-                                            id="{{field.name_field}}"
-                                            formControlName="{{field.name_field}}"
-                                        >
-                                    </div>
-                                </div>
-                            </ng-container>
-                        </div>
-                    </fieldset>
-                  </div>
-                </mat-tab>
-                </mat-tab-group>
-                <br>
-                <div class="d-flex flex-row justify-content-between">
-                    <button
-                        mat-raised-button
-                        class="d-flex justify-content-center align-content-between"
-                        (click)="onPreviousStep()"
-                        color="primary"
-                    >
-                        <mat-icon>navigate_before</mat-icon>
-
-                        Précédent
-                    </button>
-                    <button
-                        class="d-flex justify-content-center align-content-between"
-                        mat-raised-button
-                        color="primary"
-                        [disabled]="!isNextStepAvailable()"
-                        (click)='onNextStep()'
-                    >
-                        Suivant
-                        <mat-icon>navigate_next</mat-icon>
-                    </button>
-
-                </div>
-            </form>
-
-
-        </div>
-<!-- Spinner -->
-<div
-    *ngIf="spinner"
-    class="spinner"
->
-    <mat-spinner
-        class="upload-spinner"
-        [color]="color"
-        [diameter]="150"
-        [strokeWidth]="12"
-    >
-    </mat-spinner>
-</div>
-
-
-<ng-template
-    #saveMappingModal
-    let-modal
->
-
-    <div class="modal-header">
-        <h4
-            class="modal-title"
-            id="modal-basic-title"
-        >Enregistrement du modèle</h4>
-        <button
-            type="button"
-            class="close"
-            aria-label="Close"
-            (click)="modal.dismiss('Cross click')"
-        >
-            <span aria-hidden="true">&times;</span>
-        </button>
-    </div>
-    <div class="modal-body">
-        <span *ngIf="!this.updateAvailable; else elseBlock">Souhaitez sauvegarder vos correspondances dans un modèle pour les réutiliser lors d’un futur import ?</span>
-        <ng-template #elseBlock>
-            <span>
-                Le modèle de correspondance a été modifié ; souhaitez-vous mettre à jour le modèle existant ou créer un nouveau modèle ?
-            </span>
-        </ng-template>
-        <form>
-          <div class="form-group">
-            <label for="mappingName" *ngIf="this.updateAvailable">Nom du modèle</label>
-            <input [formControl]="modalCreateMappingForm" class="form-control" id="mappingName" placeholder="Nom du modèle">
-            <span *ngIf="!modalCreateMappingForm.value" class="text-warning"> Un nom doit être renseigné pour pouvoir créer un modèle </span>
-            <span *ngIf="fieldMappingForm.value && modalCreateMappingForm.value == fieldMappingForm.value.label" class="text-warning"> Changer de nom pour pouvoir enregistrer le modèle </span>
+        <div class="d-flex flex-row justify-content-center mt-3">
+          <div class="d-flex justify-content-center align-content-between row w-100">
+            <button
+              *ngIf="canRenameMapping"
+              class="btn-sm mb-1 ml-1 col-xl-4 w-50"
+              mat-raised-button
+              color="primary"
+              (click)="showRenameMappingForm()"
+              [disabled]="!renameMappingEnabled()"
+            >
+              Renommer le modèle d'import
+            </button>
+            <button
+              *ngIf="canDeleteMapping"
+              class="btn-sm mb-1 ml-1 col-xl-4 w-50"
+              mat-raised-button
+              color="warn"
+              (click)="openDeleteModal()"
+              [disabled]="!deleteMappingEnabled()"
+            >
+              Supprimer le modèle d'import
+            </button>
+            <div
+              *ngIf="config.IMPORT.DISPLAY_CHECK_BOX_MAPPED_FIELD"
+              class="form-check col-xl w-75 d-flex justify-content-center align-items-start"
+            >
+              <input
+                type="checkbox"
+                [(ngModel)]="displayAllValues"
+                [ngModelOptions]="{ standalone: true }"
+                class="mt-1 mr-1"
+              />
+              Afficher les champs automatiquement associés
+            </div>
           </div>
-        </form>
-    </div>
-    <div class="modal-footer">
-        <button
-            type="button"
+        </div>
+
+        <div
+          *ngIf="createMappingFormVisible"
+          class="d-flex flex-row justify-content-between form_group"
+          id="newMap"
+        >
+          <input
+            type="text"
+            class="form-control mr-2"
+            value="Inconnu"
+            [formControl]="createOrRenameMappingForm"
+          />
+          <button
+            class="d-flex justify-content-center align-content-between mr-2 button-success"
             mat-raised-button
-            color="accent"
-            (click)="modal.close(); processNextStep()"
-        > Continuer sans enregistrer </button>
-        <button
-            *ngIf="this.updateAvailable"
-            type="button"
+            matTooltip="Créer un nouveau mapping"
+            (click)="createMapping(createOrRenameMappingForm.value)"
+            [disabled]="!createOrRenameMappingForm.valid"
+          >
+            <mat-icon>add</mat-icon>
+          </button>
+          <button
+            class="d-flex justify-content-center align-content-between"
             mat-raised-button
-            color="primary"
-            (click)="modal.close(); updateMapping(true)"
-        > Mettre à jour le modèle existant </button>
-        <button
-            *ngIf="this.fieldMappingForm.value == null || this.createOrRenameMappingForm.value != ''"
-            type="button"
+            color="warn"
+            (click)="hideCreateOrRenameMappingForm()"
+          >
+            Annuler
+          </button>
+        </div>
+
+        <div
+          *ngIf="renameMappingFormVisible"
+          class="d-flex flex-row justify-content-between form_group"
+          id="updateMap"
+        >
+          <input
+            type="text"
+            class="form-control mr-2"
+            value="Inconnu"
+            [formControl]="createOrRenameMappingForm"
+          />
+          <button
+            class="d-flex justify-content-center align-content-between mr-2 button-success"
+            (click)="renameMapping()"
             mat-raised-button
-            color="primary"
-            (click)="modal.close(); createMapping()"
-            [disabled]="!modalCreateMappingForm.value || fieldMappingForm.value && modalCreateMappingForm.value == fieldMappingForm.value.label"
-        > Enregistrer un nouveau modèle </button>
-    </div>
-</ng-template>
-<ng-template
-        #deleteConfirmModal
-        let-modalDelete
->
+            matTooltip="Modifier le nom du modèle d'import"
+            [disabled]="
+              !createOrRenameMappingForm.valid ||
+              fieldMappingForm.value.label.trim() == this.createOrRenameMappingForm.value.trim()
+            "
+          >
+            <mat-icon>check</mat-icon>
+          </button>
+          <button
+            matTooltip="Annuler la modification du nom du modèle d'import"
+            class="d-flex justify-content-center align-content-between"
+            (click)="hideCreateOrRenameMappingForm()"
+            mat-raised-button
+            color="warn"
+          >
+            Annuler
+          </button>
+        </div>
+
+        <div *ngIf="fieldMappingForm.value != null">
+          <div
+            *ngIf="mappedTargetFields.size > 0"
+            class="alert alert-success"
+            role="alert"
+            style="text-align: center"
+          >
+            {{ mappedTargetFields.size }} champs cibles ont été associés à un champs source.
+          </div>
+          <div
+            *ngIf="unmappedSourceFields.size == 0"
+            class="alert alert-success"
+            role="alert"
+            style="text-align: center"
+          >
+            L'ensemble des {{ mappedSourceFields.size }} champs du fichier d’import ont été associés
+            à un champs cible.
+          </div>
+          <div
+            *ngIf="unmappedSourceFields.size > 0"
+            class="alert alert-warning"
+            role="alert"
+            style="text-align: center"
+          >
+            <a
+              data-toggle="collapse"
+              href="#unmappedSourceFields"
+              aria-expanded="false"
+              aria-controls="unmappedSourceFields"
+            >
+              {{ unmappedSourceFields.size }} champs
+            </a>
+            du fichier d’import ne sont actuellement associés à aucun champs cible et seront donc
+            ignorés.
+            <div class="collapse" id="unmappedSourceFields">
+              <ul style="text-align: left">
+                <li *ngFor="let sourceField of unmappedSourceFields">{{ sourceField }}</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </form>
+    <form [formGroup]="syntheseForm">
+      <mat-tab-group [(selectedIndex)]="selectedIndex" animationDuration="0ms" class="entities-tab">
+        <mat-tab *ngFor="let entitythemes of targetFields" label="{{ entitythemes.entity.label }}">
+          <div *ngFor="let themefields of entitythemes.themes" class="entities-tab__content">
+            <fieldset>
+              <legend class="px-1">
+                {{ themefields.theme.fr_label_theme }}
+              </legend>
+              <div class="row m-0">
+                <ng-container *ngFor="let field of themefields.fields">
+                  <div *ngIf="!getValue(field) || displayAllValues" class="col-6">
+                    <div *ngIf="!field.autogenerated" class="form-group">
+                      <small
+                        >{{ field.fr_label }} :
+                        <i
+                          *ngIf="field.comment"
+                          matTooltip="{{ field.comment }}"
+                          matTooltipClass="custom-tooltip"
+                          class="fa fa-info-circle"
+                          aria-hidden="true"
+                        ></i>
+                      </small>
+                      <ng-select
+                        id="{{ field.name_field }}"
+                        [items]="sourceFields"
+                        [multiple]="field.multi"
+                        [clearable]="true"
+                        [virtualScroll]="true"
+                        formControlName="{{ field.name_field }}"
+                      >
+                        <ng-template
+                          ng-option-tmp
+                          let-item="item"
+                          let-index="index"
+                          let-search="searchTerm"
+                        >
+                          <div>
+                            <span
+                              [ngClass]="{ in_use: mappedSourceFields.has(item) }"
+                              class="pre-wrap"
+                            >
+                              {{ item }}
+                            </span>
+                          </div>
+                        </ng-template>
+                      </ng-select>
+                      <div
+                        *ngIf="syntheseForm.controls[field.name_field].hasError('required')"
+                        class="invalid-feedback d-block"
+                      >
+                        Sélectionnez {{ field.name_field }}
+                      </div>
+                      <div *ngIf="field.name_field == 'WKT'">
+                        <small>*si pas de WKT, indiquez longitude et latitude.</small>
+                      </div>
+
+                      <div
+                        *ngIf="syntheseForm.controls[field.name_field].hasError('conflict')"
+                        class="invalid-feedback d-block"
+                      >
+                        {{ syntheseForm.controls[field.name_field].getError('conflict') }}
+                      </div>
+                    </div>
+                    <div *ngIf="field.autogenerated" class="form-group">
+                      <p *ngIf="displayAlert(field)" class="text-warning text-sm">
+                        Attention les identifiants SINP ne seront pas générés
+                      </p>
+                      <label for="{{ field.name_field }}">
+                        <small>{{ field.fr_label }} :</small>
+                      </label>
+                      <input
+                        class="ml-1"
+                        type="checkbox"
+                        id="{{ field.name_field }}"
+                        formControlName="{{ field.name_field }}"
+                      />
+                    </div>
+                  </div>
+                </ng-container>
+              </div>
+            </fieldset>
+          </div>
+        </mat-tab>
+      </mat-tab-group>
+      <br />
+      <div class="d-flex flex-row justify-content-between">
+        <button
+          mat-raised-button
+          class="d-flex justify-content-center align-content-between"
+          (click)="onPreviousStep()"
+          color="primary"
+        >
+          <mat-icon>navigate_before</mat-icon>
+
+          Précédent
+        </button>
+        <button
+          class="d-flex justify-content-center align-content-between"
+          mat-raised-button
+          color="primary"
+          [disabled]="!isNextStepAvailable()"
+          (click)="onNextStep()"
+        >
+          Suivant
+          <mat-icon>navigate_next</mat-icon>
+        </button>
+      </div>
+    </form>
+  </div>
+  <!-- Spinner -->
+  <div *ngIf="spinner" class="spinner">
+    <mat-spinner class="upload-spinner" [color]="color" [diameter]="150" [strokeWidth]="12">
+    </mat-spinner>
+  </div>
+
+  <ng-template #saveMappingModal let-modal>
     <div class="modal-header">
-        Confirmation
+      <h4 class="modal-title" id="modal-basic-title">Enregistrement du modèle</h4>
+      <button type="button" class="close" aria-label="Close" (click)="modal.dismiss('Cross click')">
+        <span aria-hidden="true">&times;</span>
+      </button>
     </div>
     <div class="modal-body">
-    Voulez vous supprimer le modèle ?
+      <span *ngIf="!this.updateAvailable; else elseBlock"
+        >Souhaitez sauvegarder vos correspondances dans un modèle pour les réutiliser lors d’un
+        futur import ?</span
+      >
+      <ng-template #elseBlock>
+        <span>
+          Le modèle de correspondance a été modifié ; souhaitez-vous mettre à jour le modèle
+          existant ou créer un nouveau modèle ?
+        </span>
+      </ng-template>
+      <form>
+        <div class="form-group">
+          <label for="mappingName" *ngIf="this.updateAvailable">Nom du modèle</label>
+          <input
+            [formControl]="modalCreateMappingForm"
+            class="form-control"
+            id="mappingName"
+            placeholder="Nom du modèle"
+          />
+          <span *ngIf="!modalCreateMappingForm.value" class="text-warning">
+            Un nom doit être renseigné pour pouvoir créer un modèle
+          </span>
+          <span
+            *ngIf="
+              fieldMappingForm.value && modalCreateMappingForm.value == fieldMappingForm.value.label
+            "
+            class="text-warning"
+          >
+            Changer de nom pour pouvoir enregistrer le modèle
+          </span>
+        </div>
+      </form>
     </div>
     <div class="modal-footer">
-        <button
-                type="button"
-                mat-raised-button
-                color="accent"
-                (click)="modalDelete.close()"
-        > Annuler </button>
-        <button
-                type="button"
-                mat-raised-button
-                color="warn"
-                (click)="modalDelete.close(); deleteMapping()"
-        > Supprimer le modèle </button>
+      <button
+        type="button"
+        mat-raised-button
+        color="accent"
+        (click)="modal.close(); processNextStep()"
+      >
+        Continuer sans enregistrer
+      </button>
+      <button
+        *ngIf="this.updateAvailable"
+        type="button"
+        mat-raised-button
+        color="primary"
+        (click)="modal.close(); updateMapping(true)"
+      >
+        Mettre à jour le modèle existant
+      </button>
+      <button
+        *ngIf="this.fieldMappingForm.value == null || this.createOrRenameMappingForm.value != ''"
+        type="button"
+        mat-raised-button
+        color="primary"
+        (click)="modal.close(); createMapping()"
+        [disabled]="
+          !modalCreateMappingForm.value ||
+          (fieldMappingForm.value && modalCreateMappingForm.value == fieldMappingForm.value.label)
+        "
+      >
+        Enregistrer un nouveau modèle
+      </button>
     </div>
-
-</ng-template>
+  </ng-template>
+  <ng-template #deleteConfirmModal let-modalDelete>
+    <div class="modal-header">Confirmation</div>
+    <div class="modal-body">Voulez vous supprimer le modèle ?</div>
+    <div class="modal-footer">
+      <button type="button" mat-raised-button color="accent" (click)="modalDelete.close()">
+        Annuler
+      </button>
+      <button
+        type="button"
+        mat-raised-button
+        color="warn"
+        (click)="modalDelete.close(); deleteMapping()"
+      >
+        Supprimer le modèle
+      </button>
+    </div>
+  </ng-template>
+</div>

--- a/frontend/src/app/modules/imports/components/import_process/fields-mapping-step/fields-mapping-step.component.html
+++ b/frontend/src/app/modules/imports/components/import_process/fields-mapping-step/fields-mapping-step.component.html
@@ -168,9 +168,9 @@
                 </fieldset>
             </form>
             <form [formGroup]="syntheseForm">
-                <div *ngFor="let entitythemes of targetFields">
-                  <h3>{{ entitythemes.entity.label }}</h3><!-- TODO: convert to tabs -->
-                  <div *ngFor="let themefields of entitythemes.themes">
+              <mat-tab-group [(selectedIndex)]="selectedIndex" animationDuration="0ms" class="entities-tab">
+                <mat-tab *ngFor="let entitythemes of targetFields" label="{{ entitythemes.entity.label }}">
+                  <div *ngFor="let themefields of entitythemes.themes" class="entities-tab__content">
                     <fieldset>
                         <legend class="px-1">
                             {{themefields.theme.fr_label_theme}}
@@ -205,7 +205,7 @@
                                         >
                                             <ng-template ng-option-tmp let-item="item" let-index="index" let-search="searchTerm">
                                                 <div>
-                                                    <span 
+                                                    <span
                                                         [ngClass]="{'in_use': mappedSourceFields.has(item)}"
                                                         class="pre-wrap"
                                                     >
@@ -248,7 +248,8 @@
                         </div>
                     </fieldset>
                   </div>
-                </div>
+                </mat-tab>
+                </mat-tab-group>
                 <br>
                 <div class="d-flex flex-row justify-content-between">
                     <button

--- a/frontend/src/app/modules/imports/components/import_process/fields-mapping-step/fields-mapping-step.component.scss
+++ b/frontend/src/app/modules/imports/components/import_process/fields-mapping-step/fields-mapping-step.component.scss
@@ -94,3 +94,20 @@ ng-select span.in_use {
   color: #787878;
   font-style: italic;
 }
+
+.entities-tab {
+  border: silver solid 1px;
+  border-radius: 4px;
+
+  mat-tab-header {
+    border-bottom: 1px solid #673ab722;
+  }
+
+  .mdc-tab__text-label {
+    text-transform: uppercase;
+  }
+
+  &__content {
+    padding: 1em;
+  }
+}

--- a/frontend/src/app/modules/imports/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
+++ b/frontend/src/app/modules/imports/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
@@ -55,6 +55,8 @@ export class FieldsMappingStepComponent implements OnInit {
   @ViewChild('saveMappingModal') saveMappingModal;
   @ViewChild('deleteConfirmModal') deleteConfirmModal;
 
+  public selectedIndex: number = null;
+
   constructor(
     private _ds: DataService,
     private _fm: FieldMappingService,


### PR DESCRIPTION
[Issue github](https://github.com/orgs/PnX-SI/projects/13/views/15?filterQuery=onglet&pane=issue&itemId=47859830)

[Perimètre] Afficher les entités dans des onglets

Les entités à paramétrer à l'étape 3 (field mapping) de l'import multidestination était affichées les unes à la suite des autres. Le but est de les affichers dans des onglets. 

![image](https://github.com/PnX-SI/GeoNature/assets/150020787/00d9bedb-ecd7-4c90-983b-a3a0f02f02c5)
