### PR TITLE
[IMPORT] feat: group field by entity in report

### DIFF
--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.html
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.html
@@ -72,15 +72,16 @@
           <h6>Champs ({{ (importData?.fieldmapping || {} | keyvalue).length }})</h6>
         </mat-panel-title>
         </mat-expansion-panel-header>
-        <table class="table table-striped table-bordered">
-        <thead>
+        <table *ngFor="let entity of tableFieldsCorresp" class="table table-striped table-bordered">
+        <caption>{{ entity.entityLabel }}</caption>
+          <thead>
           <tr>
           <th>Champ source</th>
           <th>Champ cible</th>
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let field of importData?.fieldmapping | keyvalue ">
+          <tr *ngFor="let field of entity?.themes | keyvalue">
           <td>{{ field.value }}</td>
           <td>{{ field.key }}</td>
           </tr>

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.scss
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.scss
@@ -75,3 +75,8 @@ img {
     padding-right: 140px;
   }
 }
+
+table caption {
+  caption-side: top;
+  border-collapse: collapse;
+}

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.ts
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.ts
@@ -8,14 +8,18 @@ import { MapService } from '@geonature_common/map/map.service';
 import { DataService } from '../../services/data.service';
 import { ImportProcessService } from '../import_process/import-process.service';
 import {
+  EntitiesThemesFields,
+  Field,
   Import,
   ImportError,
   Nomenclature,
   NomenclatureType,
   TaxaDistribution,
+  ThemesFields,
 } from '../../models/import.model';
 import { ConfigService } from '@geonature/services/config.service';
 import { CsvExportService } from '../../services/csv-export.service';
+import { FieldMappingValues } from '../../models/mapping.model';
 
 interface MatchedNomenclature {
   source: Nomenclature;
@@ -42,6 +46,7 @@ export class ImportReportComponent implements OnInit {
     'group2_inpn',
   ];
   public importData: Import | null;
+  public tableFieldsCorresp: Array<FieldMappingValues> = [];
   public expansionPanelHeight: string = '60px';
   public validBbox: any;
   public taxaDistribution: Array<TaxaDistribution> = [];
@@ -92,6 +97,9 @@ export class ImportReportComponent implements OnInit {
     // show line per line...
     this.loadErrors();
     this.setImportStatus();
+    this._dataService.getBibFields().subscribe((fields) => {
+      this.tableFieldsCorresp = this.mapFields(fields, this.importData.fieldmapping);
+    });
     this._dataService.getNomenclatures().subscribe((nomenclatures) => {
       this.nomenclatures = nomenclatures;
     });
@@ -257,5 +265,32 @@ export class ImportReportComponent implements OnInit {
   }
   navigateToImportList() {
     this._router.navigate([this.config.IMPORT.MODULE_URL]);
+  }
+
+  mapFields(fields: EntitiesThemesFields[], fieldMapping: FieldMappingValues) {
+    const tableFieldsCorresp = [];
+    fields.forEach((field) => {
+      const entityMapping = {
+        entityLabel: field.entity.label,
+        themes: this.mapThemes(field.themes, fieldMapping),
+      };
+      tableFieldsCorresp.push(entityMapping);
+    });
+    return tableFieldsCorresp;
+  }
+
+  mapThemes(themes: ThemesFields[], fieldMapping: FieldMappingValues) {
+    const mappedThemes = themes.map((theme) => this.mapField(theme.fields, fieldMapping));
+    return Object.assign({}, ...mappedThemes);
+  }
+
+  mapField(listField: Field[], fieldMapping: FieldMappingValues) {
+    const mappedFields = {};
+    listField.forEach((field) => {
+      if (Object.keys(fieldMapping).includes(field.name_field)) {
+        mappedFields[field.name_field] = fieldMapping[field.name_field];
+      }
+    });
+    return mappedFields;
   }
 }

--- a/frontend/src/app/modules/imports/models/import.model.ts
+++ b/frontend/src/app/modules/imports/models/import.model.ts
@@ -112,7 +112,7 @@ interface Theme {
   desc_theme: string;
 }
 
-interface Field {
+export interface Field {
   id_field: number;
   name_field: string;
   fr_label: string;
@@ -123,7 +123,7 @@ interface Field {
   comment: string;
 }
 
-interface ThemesFields {
+export interface ThemesFields {
   theme: Theme;
   fields: [Field];
 }


### PR DESCRIPTION
[Lien Issue](https://github.com/orgs/PnX-SI/projects/13/views/12?pane=issue&itemId=47862422)

- [x] Call getBibField
- [x] Match Import Data fields with response from getBibField 
- [x] Create function to match object
- [x] Add one level of directive ngFor to create table as many as entity exists 
- [x] Use existing type in match object function

A discuter : est ce qu'on affiche le titre du tableau de cette manière : `Entité:....` ou affichage d'une autre manière

Image du rendu coté frontend
![image](https://github.com/PnX-SI/GeoNature/assets/111564663/131da265-3bcf-4804-a8af-17482ebd65d8)


Reviewed-by: andriacap