### PR TITLE
[Lint] Extend frontend linting to html and scss files

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -4,3 +4,4 @@ dist
 coverage
 dependencies
 external_modules
+.angular

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -6,5 +6,7 @@
   "semi": true,
   "bracketSpacing": true,
   "trailingComma": "es5",
-  "singleAttributePerLine": true
+  "singleAttributePerLine": true,
+  "bracketSameLine": false,
+  "htmlWhitespaceSensitivity": "ignore"
 }

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -5,5 +5,6 @@
   "tabWidth": 2,
   "semi": true,
   "bracketSpacing": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "singleAttributePerLine": true
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11979,9 +11979,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,8 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "format": "prettier --config .prettierrc --ignore-path .prettierignore --write '**/*.ts' '../contrib/*/frontend/**/*.ts'",
-    "format:check": "prettier --config .prettierrc --ignore-path .prettierignore --check '**/*.ts' '../contrib/*/frontend/**/*.ts'",
+    "format": "prettier --config .prettierrc --ignore-path .prettierignore --write '**/*.{ts,html,scss}' '../contrib/*/frontend/**/*.{ts,html,scss}'",
+    "format:check": "prettier --config .prettierrc --ignore-path .prettierignore --check '**/*.{ts,html,scss}' '../contrib/*/frontend/**/*.{ts,html,scss}'",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "docBuild": "npx compodoc -p tsconfig.doc.json -d ../docs/external_doc/documentation_js"


### PR DESCRIPTION
Closes #2890 

[Périmètre]
Inclure les fichiers html et scss aux vérifications de formattage et formattage.

L'objectif est aussi de trouver un format de sortie à peu près satisfaisant.

- Ajout de règles de lint à la config prettier
- Ajout du repertoire .angular aux contenus ignorés par prettier
- Ajout des fichiers html et scss aux commandes npm de formatages