### PR TITLE
[IMPORT] [OCCHAB]  Add constraint on t_habitats.id_nomenclature_community_interest

### DIFF
--- a/contrib/gn_module_occhab/backend/gn_module_occhab/migrations/fcf1e091b636_add_constraint_to_th_id_nci_.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/migrations/fcf1e091b636_add_constraint_to_th_id_nci_.py
@@ -1,0 +1,38 @@
+"""add constraint to t_habitats.id_nomenclature_community_interest content type
+
+Revision ID: fcf1e091b636
+Revises: 167d69b42d25
+Create Date: 2024-02-07 16:33:41.381934
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "fcf1e091b636"
+down_revision = "167d69b42d25"
+branch_labels = None
+depends_on = None
+
+table = "pr_occhab.t_habitats"
+constraint = "check_t_habitats_community_interest"
+check = "(ref_nomenclatures.check_nomenclature_type_by_mnemonique(id_nomenclature_community_interest, 'HAB_INTERET_COM'::character varying))"
+
+
+def upgrade():
+    op.execute(
+        f"""
+        ALTER TABLE ONLY {table}
+        ADD CONSTRAINT {constraint} CHECK {check} NOT VALID
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        f"""
+        ALTER TABLE {table}
+        DROP CONSTRAINT {constraint};
+        """
+    )


### PR DESCRIPTION
Closes [issue](https://github.com/orgs/PnX-SI/projects/13/views/6?pane=issue&itemId=50172839)

Une révision a été ajoutée au module occhab afin d'ajouter une contrainte manquante `check_t_habitats_id_nomenclature_community_interest` sur le champs `id_nomenclature_community_interest` de la table `pr_occhab.t_habitats`.

Ce dernier doit être de type `HAB_INTERET_COM`.

Cette révision devra surement être squashée avec celle de l'import multi-destination.