### PR TITLE
Fix Occhab for restricted permissions

### DIFF
--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -219,16 +219,25 @@ def users(app):
         int
             scope
         """
-        scope = scope if scope != 3 else None
+        parse_scope = lambda scope: scope if scope != 3 else None
+        scope = parse_scope(scope)
         if not module_code in detailed_scopes:
-            return scope
-        if not action in detailed_scopes[module_code]:
+            # if detailed scope indicate a global scope for an action
+            if action in detailed_scopes:
+                return parse_scope(detailed_scopes[action])
+            # else return the default scope
             return scope
 
-        detailed_scope = detailed_scopes[module_code][action]
-        if isinstance(detailed_scope, int) and 0 < detailed_scope < 3:
-            return detailed_scope
-        return scope
+        # If not action indicated in the module detailed scope
+        if not action in detailed_scopes[module_code]:
+            # If a default scope is defined for the given action
+            if action in detailed_scopes:
+                return parse_scope(detailed_scopes[action])
+            # return the default scope
+            return scope
+
+        # if a scope is defined for the given action and modules, return the value
+        return parse_scope(detailed_scopes[module_code][action])
 
     def create_user(
         username,
@@ -324,7 +333,7 @@ def users(app):
                 2,
                 False,
                 [],
-                {"OCCHAB": {"C": 3, "R": 3, "U": 1, "E": 3, "D": 1}},
+                {"C": 2, "OCCHAB": {"R": 2, "U": 1, "E": 2, "D": 1}},
             ),
             {},
         ),

--- a/backend/geonature/tests/test_pr_occhab.py
+++ b/backend/geonature/tests/test_pr_occhab.py
@@ -1,6 +1,7 @@
 from io import BytesIO, StringIO
 from typing import List
 from geonature.core.gn_meta.models import TDatasets
+from pypnusershub.db.models import User, UserApplicationRight
 import pytest
 from copy import deepcopy
 import json

--- a/backend/geonature/tests/utils.py
+++ b/backend/geonature/tests/utils.py
@@ -1,11 +1,22 @@
 from flask import url_for
-
+from geonature.core.gn_commons.models.base import TModules
+from geonature.core.gn_permissions.models import PermAction, PermObject, Permission
+from geonature.utils.env import db
+from pypnusershub.db.models import (
+    User,
+    Organisme,
+    Application,
+    Profils as Profil,
+    UserApplicationRight,
+)
 from pypnusershub.tests.utils import (
     set_logged_user,
     unset_logged_user,
     logged_user,
     logged_user_headers,
 )
+
+from sqlalchemy import select
 
 
 def login(client, username="admin", password=None):
@@ -15,6 +26,79 @@ def login(client, username="admin", password=None):
     }
     response = client.post(url_for("auth.login"), json=data)
     assert response.status_code == 200
+
+
+def get_scope(scope, detailed_scopes, module_code, action):
+    scope = scope if scope != 3 else None
+    if not module_code in detailed_scopes:
+        return scope
+    if not action in detailed_scopes[module_code]:
+        return scope
+
+    detailed_scope = detailed_scopes[action][module_code]
+    if isinstance(detailed_scope, int) and 0 < detailed_scope < 3:
+        return detailed_scope
+    return scope
+
+
+def create_user(
+    username,
+    organisme=None,
+    scope=None,
+    sensitivity_filter=False,
+    modules_codes=[],
+    detailed_scopes={},
+    **kwargs
+):
+    app = db.session.execute(
+        select(Application).where(Application.code_application == "GN")
+    ).scalar_one()
+
+    profil = db.session.execute(select(Profil).where(Profil.nom_profil == "Lecteur")).scalar_one()
+
+    modules_query = select(TModules)
+    if len(modules_codes) > 0:
+        modules_query = modules_query.where(TModules.module_code.in_(modules_codes))
+
+    modules = db.session.scalars(modules_query).all()
+
+    actions = {
+        code: db.session.execute(select(PermAction).filter_by(code_action=code)).scalar_one()
+        for code in "CRUVED"
+    }
+
+    # do not commit directly on current transaction, as we want to rollback all changes at the end of tests
+    with db.session.begin_nested():
+        user = User(groupe=False, active=True, identifiant=username, password=username, **kwargs)
+        db.session.add(user)
+        user.organisme = organisme
+    # user must have been commited for user.id_role to be defined
+    with db.session.begin_nested():
+        # login right
+        right = UserApplicationRight(
+            id_role=user.id_role, id_application=app.id_application, id_profil=profil.id_profil
+        )
+        db.session.add(right)
+        if scope > 0 or detailed_scopes:
+            object_all = db.session.execute(
+                select(PermObject).filter_by(code_object="ALL")
+            ).scalar_one()
+            for action in actions.values():
+                for module in modules:
+                    for obj in [object_all] + module.objects:
+                        scope_value = scope
+                        permission = Permission(
+                            action=action,
+                            module=module,
+                            object=obj,
+                            scope_value=get_scope(
+                                scope, detailed_scopes, module.module_code, action.code_action
+                            ),
+                            sensitivity_filter=sensitivity_filter,
+                        )
+                        db.session.add(permission)
+                        permission.role = user
+    return user
 
 
 jsonschema_definitions = {

--- a/backend/geonature/tests/utils.py
+++ b/backend/geonature/tests/utils.py
@@ -1,22 +1,11 @@
 from flask import url_for
-from geonature.core.gn_commons.models.base import TModules
-from geonature.core.gn_permissions.models import PermAction, PermObject, Permission
-from geonature.utils.env import db
-from pypnusershub.db.models import (
-    User,
-    Organisme,
-    Application,
-    Profils as Profil,
-    UserApplicationRight,
-)
+
 from pypnusershub.tests.utils import (
     set_logged_user,
     unset_logged_user,
     logged_user,
     logged_user_headers,
-)
-
-from sqlalchemy import select
+)  # Do not remove, used by other test files
 
 
 def login(client, username="admin", password=None):
@@ -26,79 +15,6 @@ def login(client, username="admin", password=None):
     }
     response = client.post(url_for("auth.login"), json=data)
     assert response.status_code == 200
-
-
-def get_scope(scope, detailed_scopes, module_code, action):
-    scope = scope if scope != 3 else None
-    if not module_code in detailed_scopes:
-        return scope
-    if not action in detailed_scopes[module_code]:
-        return scope
-
-    detailed_scope = detailed_scopes[action][module_code]
-    if isinstance(detailed_scope, int) and 0 < detailed_scope < 3:
-        return detailed_scope
-    return scope
-
-
-def create_user(
-    username,
-    organisme=None,
-    scope=None,
-    sensitivity_filter=False,
-    modules_codes=[],
-    detailed_scopes={},
-    **kwargs
-):
-    app = db.session.execute(
-        select(Application).where(Application.code_application == "GN")
-    ).scalar_one()
-
-    profil = db.session.execute(select(Profil).where(Profil.nom_profil == "Lecteur")).scalar_one()
-
-    modules_query = select(TModules)
-    if len(modules_codes) > 0:
-        modules_query = modules_query.where(TModules.module_code.in_(modules_codes))
-
-    modules = db.session.scalars(modules_query).all()
-
-    actions = {
-        code: db.session.execute(select(PermAction).filter_by(code_action=code)).scalar_one()
-        for code in "CRUVED"
-    }
-
-    # do not commit directly on current transaction, as we want to rollback all changes at the end of tests
-    with db.session.begin_nested():
-        user = User(groupe=False, active=True, identifiant=username, password=username, **kwargs)
-        db.session.add(user)
-        user.organisme = organisme
-    # user must have been commited for user.id_role to be defined
-    with db.session.begin_nested():
-        # login right
-        right = UserApplicationRight(
-            id_role=user.id_role, id_application=app.id_application, id_profil=profil.id_profil
-        )
-        db.session.add(right)
-        if scope > 0 or detailed_scopes:
-            object_all = db.session.execute(
-                select(PermObject).filter_by(code_object="ALL")
-            ).scalar_one()
-            for action in actions.values():
-                for module in modules:
-                    for obj in [object_all] + module.objects:
-                        scope_value = scope
-                        permission = Permission(
-                            action=action,
-                            module=module,
-                            object=obj,
-                            scope_value=get_scope(
-                                scope, detailed_scopes, module.module_code, action.code_action
-                            ),
-                            sensitivity_filter=sensitivity_filter,
-                        )
-                        db.session.add(permission)
-                        permission.role = user
-    return user
 
 
 jsonschema_definitions = {

--- a/contrib/gn_module_occhab/backend/gn_module_occhab/blueprint.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/blueprint.py
@@ -113,7 +113,8 @@ def get_station(id_station, scope):
     """
     joinedload_when_scope = []
     if scope != 0:
-        # Required when a scope is defined. The following enable the restricted user to access one (or more) stations' datasets information
+        # Required when a scope is defined.
+        # The following enable the restricted user to access one (or more) stations' datasets information
         joinedload_when_scope = [
             joinedload(TDatasets.cor_dataset_actor).options(joinedload(CorDatasetActor.role)),
             joinedload(TDatasets.acquisition_framework).options(


### PR DESCRIPTION
This PR answers the issue on Occhab when a restricted user tries to modify its own station/habitats.

In addition, this PR change the `create_user()` to enable the creation of test user with detailed scope on one or more actions for a module (or all modules).

Link to the issue : https://github.com/PnX-SI/GeoNature/issues/2909