### PR TITLE
[IMPORT][SYNTHESE] Feat import/use area 4326 instead of sttransform

### DIFF
--- a/backend/geonature/core/gn_monitoring/routes.py
+++ b/backend/geonature/core/gn_monitoring/routes.py
@@ -82,6 +82,7 @@ def get_site_areas(id_site):
     params = request.args
 
     query = (
+        # TODO@LAreas.geom_4326
         select(corSiteArea, func.ST_Transform(LAreas.geom, 4326))
         .join(LAreas, LAreas.id_area == corSiteArea.c.id_area)
         .where(corSiteArea.c.id_base_site == id_site)

--- a/backend/geonature/core/gn_synthese/imports/geo.py
+++ b/backend/geonature/core/gn_synthese/imports/geo.py
@@ -19,7 +19,7 @@ def set_geom_from_area_code(
             transient_table.c.line_no,
             LAreas.id_area,
             LAreas.geom,
-            # TODO: add LAreas.geom_4326
+            LAreas.geom_4326,
         )
         .select_from(
             join(transient_table, LAreas, source_column == LAreas.area_code).join(BibAreasTypes)
@@ -36,9 +36,7 @@ def set_geom_from_area_code(
             {
                 transient_table.c.id_area_attachment: cte.c.id_area,
                 transient_table.c[geom_local_col]: cte.c.geom,
-                transient_table.c[geom_4326_col]: ST_Transform(
-                    cte.c.geom, 4326
-                ),  # TODO: replace with cte.c.geom_4326
+                transient_table.c[geom_4326_col]: cte.c.geom_4326,
             }
         )
         .where(transient_table.c.id_import == cte.c.id_import)

--- a/backend/geonature/core/gn_synthese/utils/blurring.py
+++ b/backend/geonature/core/gn_synthese/utils/blurring.py
@@ -76,6 +76,7 @@ def build_blurred_precise_geom_queries(
     CorAreaSyntheseAlias = aliased(CorAreaSynthese)
     LAreasAlias = aliased(LAreas)
     BibAreasTypesAlias = aliased(BibAreasTypes)
+    # TODO@LAreas.geom_4326
     geom = LAreasAlias.geom.st_transform(4326).label("geom")
     # In SyntheseQuery below :
     # - query_joins parameter is needed to bypass


### PR DESCRIPTION
#### :warning: Traiter la PR #2898 avant: `https://github.com/PnX-SI/GeoNature/pull/2898` :warning: 


Les traitements recommandés dans les deux lignes "todos" ont été appliqués, et les tests sont ok. 

Il me semble que ça suffit à dire que c'est ok.

J'ai rajouté un commit dropable d'ajout de deux todos, en dehors du scope de l'import multi destination, qui me semble du même registre. 

