### PR TITLE
[IMPORT][RAPPORT PDF] Fix/stats labels pdf report

### DIFF
--- a/backend/geonature/core/imports/routes/imports.py
+++ b/backend/geonature/core/imports/routes/imports.py
@@ -644,7 +644,15 @@ def export_pdf(scope, imprt):
     """
     if not imprt.has_instance_permission(scope):
         raise Forbidden
-    ctx = imprt.as_dict(fields=["errors", "errors.type", "errors.entity", "dataset.dataset_name"])
+    ctx = imprt.as_dict(
+        fields=[
+            "errors",
+            "errors.type",
+            "errors.entity",
+            "dataset.dataset_name",
+            "destination.statistics_labels",
+        ]
+    )
 
     ctx["map"] = request.form.get("map")
     ctx["chart"] = request.form.get("chart")
@@ -656,6 +664,14 @@ def export_pdf(scope, imprt):
         "report",
     ]
     ctx["url"] = "/".join(url_list)
+
+    ctx["statistics_formated"] = {}
+
+    for label_dict in ctx["destination"]["statistics_labels"]:
+        key = label_dict["value"]
+        if label_dict["key"] in ctx["statistics"]:
+            ctx["statistics_formated"][key] = ctx["statistics"][label_dict["key"]]
+
     pdf_file = generate_pdf_from_template("import_template_pdf.html", ctx)
     return send_file(
         BytesIO(pdf_file),

--- a/backend/geonature/core/imports/templates/import_template_pdf.html
+++ b/backend/geonature/core/imports/templates/import_template_pdf.html
@@ -46,7 +46,7 @@
         </tr>
       </thead>
       <tbody>
-        {% for key, value in data.statistics.items() %}
+        {% for key, value in data.statistics_formated.items() %}
         <tr>
           <td>{{ key|capitalize }}</td>
           <td>{{ value }}</td>


### PR DESCRIPTION
Les labels des statistics créés dans une property du model `Destination` n'étaient pas utilisés dans le rapport PDF. 
Cette PR permet de s'appuyer cette property `statistics_labels`

Reviewed-by: andriacap