### PR TITLE
[FIX] Redirection du bouton `Accueil` dans la page d'accueil de GeoNature

### DIFF
--- a/frontend/src/app/components/nav-home/nav-home.component.ts
+++ b/frontend/src/app/components/nav-home/nav-home.component.ts
@@ -44,6 +44,7 @@ export class NavHomeComponent implements OnInit, OnDestroy {
 
     // Set the current module name in the navbar
     this.onModuleChange();
+    
 
     // Init the sidenav instance in sidebar service
     this.sideNavService.setSideNav(this.sidenav);
@@ -80,6 +81,7 @@ export class NavHomeComponent implements OnInit, OnDestroy {
   private onModuleChange() {
     this._moduleService.currentModule$.subscribe((module) => {
       if (!module) {
+        // If in Home Page
         module = this.sideNavService.getHomeItem();
         module.module_doc_url = this._moduleService.geoNatureModule.module_doc_url;
       }

--- a/frontend/src/app/components/nav-home/nav-home.component.ts
+++ b/frontend/src/app/components/nav-home/nav-home.component.ts
@@ -44,7 +44,6 @@ export class NavHomeComponent implements OnInit, OnDestroy {
 
     // Set the current module name in the navbar
     this.onModuleChange();
-    
 
     // Init the sidenav instance in sidebar service
     this.sideNavService.setSideNav(this.sidenav);

--- a/frontend/src/app/components/sidenav-items/sidenav-service.ts
+++ b/frontend/src/app/components/sidenav-items/sidenav-service.ts
@@ -31,12 +31,19 @@ export class SideNavService {
     return this.currentModule;
   }
 
-  getHomeItem() : Module {
+  getHomeItem(): Module {
     let abs_path = '/';
-    if (window.location.pathname) { // for GeoNature URL like https://demo.geonature.fr/geonature/
+    if (window.location.pathname) {
+      // for GeoNature URL like https://demo.geonature.fr/geonature/
       abs_path = window.location.pathname;
     }
-    return { module_url: abs_path, module_label: 'Accueil', module_picto: 'fa-home', id_module: 1, module_path: "/geonature"};
+    return {
+      module_url: abs_path,
+      module_label: 'Accueil',
+      module_picto: 'fa-home',
+      id_module: 1,
+      module_path: '/geonature',
+    };
   }
 
   toggleSideNav() {

--- a/frontend/src/app/components/sidenav-items/sidenav-service.ts
+++ b/frontend/src/app/components/sidenav-items/sidenav-service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { MatSidenav } from '@angular/material/sidenav';
+import { Module } from '@geonature/models/module.model';
 import { Subject } from 'rxjs';
 
 @Injectable()
@@ -30,8 +31,12 @@ export class SideNavService {
     return this.currentModule;
   }
 
-  getHomeItem() {
-    return { module_url: '/', module_label: 'Accueil', module_picto: 'fa-home', id: '1' };
+  getHomeItem() : Module {
+    let abs_path = '/';
+    if (window.location.pathname) { // for GeoNature URL like https://demo.geonature.fr/geonature/
+      abs_path = window.location.pathname;
+    }
+    return { module_url: abs_path, module_label: 'Accueil', module_picto: 'fa-home', id_module: 1, module_path: "/geonature"};
   }
 
   toggleSideNav() {

--- a/frontend/src/app/models/module.model.ts
+++ b/frontend/src/app/models/module.model.ts
@@ -1,0 +1,8 @@
+export interface Module{
+    id_module: number;
+    module_label: string;
+    module_picto?: string;
+    module_path:string;
+    module_doc_url?: string;
+    module_url?: string;
+}

--- a/frontend/src/app/models/module.model.ts
+++ b/frontend/src/app/models/module.model.ts
@@ -1,8 +1,8 @@
-export interface Module{
-    id_module: number;
-    module_label: string;
-    module_picto?: string;
-    module_path:string;
-    module_doc_url?: string;
-    module_url?: string;
+export interface Module {
+  id_module: number;
+  module_label: string;
+  module_picto?: string;
+  module_path: string;
+  module_doc_url?: string;
+  module_url?: string;
 }


### PR DESCRIPTION
Lorsque GeoNature est accessible depuis une URL avec un suffixe (demo.geonature.fr/geonature), la redirection du bouton `Accueil` de la page d’accueil ignore ce dernier (demo.geonature.fr/).

Cette PR propose un fix.

Issue à l'origine #2934