### PR TITLE
Fix redirection from synthese to the data source module

### DIFF
--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -148,8 +148,9 @@ def get_observations_for_web(permissions):
 
     # Get Column Frontend parameter to return only the needed columns
     param_column_list = {
-        col["prop"] for col in current_app.config["SYNTHESE"]["LIST_COLUMNS_FRONTEND"]
-    }
+        col["prop"] for col in (current_app.config["SYNTHESE"]["LIST_COLUMNS_FRONTEND"])
+    } + {"entity_source_pk_value"}
+
     # Init with compulsory columns
     columns = [
         "id",


### PR DESCRIPTION
This PR fix the issue of bad redirection from a synthese observation to its source module (for instance Occtax). 