### PR TITLE
[Frontend] - intro/footer - ajout du pipe safeHTML pour prise en compte des attributs style

### DIFF
--- a/frontend/src/app/components/footer/footer.component.html
+++ b/frontend/src/app/components/footer/footer.component.html
@@ -1,1 +1,1 @@
-<div [innerHTML]="config.HOME.FOOTER"></div>
+<div [innerHTML]="(config.HOME.FOOTER) | safeHTML"></div>

--- a/frontend/src/app/components/introduction/introduction.component.html
+++ b/frontend/src/app/components/introduction/introduction.component.html
@@ -7,7 +7,7 @@
       ></div>
       <div
         class="panel-body"
-        [innerHTML]="config.HOME.INTRODUCTION"
+        [innerHTML]="(config.HOME.INTRODUCTION) | safeHTML"
       ></div>
     </div>
   </div>


### PR DESCRIPTION
A défaut de fichiers css associés (ou a moins qu'il faille indiquer les classes CSS dans le fichier custom/css/frontend.css) l'ajout du pipe safeHTML permet de prendre en compte les attributs styles indiqués dans la config du contenu de l'introduction et du footer. 