### PR TITLE
Feat/self hosted ci

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -14,8 +14,10 @@ jobs:
           - debian-version: "11"
             python-version: "3.9"
             postgres-version: "13"
+            host-port: "5444"
             postgis-version: "3.2"
           - debian-version: "12"
+            host-port: "5444"
             python-version: "3.11"
             postgres-version: "15"
             postgis-version: "3.3"
@@ -30,7 +32,7 @@ jobs:
           POSTGRES_PASSWORD: geonatpasswd
           POSTGRES_USER: geonatadmin
         ports:
-          - 5444:5444
+          - ${{ matrix.host-port }}:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -43,9 +45,11 @@ jobs:
           submodules: true
       - name: Add database extensions
         run: |
-          psql -h localhost -U geonatadmin -d geonature2db -f install/assets/db/add_pg_extensions.sql
+          psql -p ${{ matrix.host-port }} -h localhost -U geonatadmin -d geonature2db -f install/assets/db/add_pg_extensions.sql
         env:
           PGPASSWORD: geonatpasswd
+      - name: Change geonature config
+        run: sed -i "s|^SQLALCHEMY_DATABASE_URI = .*$|SQLALCHEMY_DATABASE_URI = \"postgresql:\/\/geonatadmin:geonatpasswd@127.0.0.1:${{ matrix.host-port }}\/geonature2db\"|" config/test_config.toml
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -9,16 +9,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        debian-version: ['11', '12']
+        debian-version: ["11", "12"]
         include:
-          - debian-version: '11'
-            python-version: '3.9'
-            postgres-version: '13'
-            postgis-version: '3.2'
-          - debian-version: '12'
-            python-version: '3.11'
-            postgres-version: '15'
-            postgis-version: '3.3'
+          - debian-version: "11"
+            python-version: "3.9"
+            postgres-version: "13"
+            postgis-version: "3.2"
+          - debian-version: "12"
+            python-version: "3.11"
+            postgres-version: "15"
+            postgis-version: "3.3"
 
     name: Debian ${{ matrix.debian-version }}
 
@@ -30,7 +30,7 @@ jobs:
           POSTGRES_PASSWORD: geonatpasswd
           POSTGRES_USER: geonatadmin
         ports:
-          - 5432:5432
+          - 5444:5444
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -50,7 +50,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
       - name: Install GDAL
         run: |
           sudo apt update
@@ -78,6 +78,7 @@ jobs:
           geonature db status --dependencies
         env:
           GEONATURE_CONFIG_FILE: config/test_config.toml
+          SQLALCHEMY_DATABASE_URI: "postgresql://geonatadmin:geonatpasswd@127.0.0.1:5444/geonature2db"
       # - name: Restore database
       #   run: |
       #     # wget https://www.dropbox.com/scl/fi/17gsthsftfg59mxwmbbre/export_geonature_10000.zip?rlkey=33choleag4xw60wadm802c3oh&dl=1 -O 10kDump.zip
@@ -92,6 +93,7 @@ jobs:
           install/03b_populate_db.sh
         env:
           GEONATURE_CONFIG_FILE: config/test_config.toml
+          SQLALCHEMY_DATABASE_URI: "postgresql://geonatadmin:geonatpasswd@127.0.0.1:5444/geonature2db"
           srid_local: 2154
           install_bdc_statuts: true
           add_sample_data: true
@@ -104,6 +106,7 @@ jobs:
           geonature db status
         env:
           GEONATURE_CONFIG_FILE: config/test_config.toml
+          SQLALCHEMY_DATABASE_URI: "postgresql://geonatadmin:geonatpasswd@127.0.0.1:5444/geonature2db"
 
       - name: Install core modules backend
         run: |
@@ -115,16 +118,19 @@ jobs:
           geonature db status
         env:
           GEONATURE_CONFIG_FILE: config/test_config.toml
+          SQLALCHEMY_DATABASE_URI: "postgresql://geonatadmin:geonatpasswd@127.0.0.1:5444/geonature2db"
       - name: Install core modules database
         run: |
           geonature upgrade-modules-db
         env:
           GEONATURE_CONFIG_FILE: config/test_config.toml
+          SQLALCHEMY_DATABASE_URI: "postgresql://geonatadmin:geonatpasswd@127.0.0.1:5444/geonature2db"
       - name: Show database status
         run: |
           geonature db status --dependencies
         env:
           GEONATURE_CONFIG_FILE: config/test_config.toml
+          SQLALCHEMY_DATABASE_URI: "postgresql://geonatadmin:geonatpasswd@127.0.0.1:5444/geonature2db"
       - name: Load benchmark stable data
         run: |
           wget https://geonature.fr/data/benchmark_history/benchmark_stable.json -O benchmark_stable.json
@@ -134,4 +140,5 @@ jobs:
           pytest --benchmark-only --benchmark-compare-fail="mean:0.1" --benchmark-compare=benchmark_stable.json
         env:
           GEONATURE_CONFIG_FILE: config/test_config.toml
+          SQLALCHEMY_DATABASE_URI: "postgresql://geonatadmin:geonatpasswd@127.0.0.1:5444/geonature2db"
         # https://stackoverflow.com/a/64126737 For posting results on GitHub Pull Requests


### PR DESCRIPTION
## DESCRIPTION
Added self-hosted CI for performance testing. After a lot of testing on debian it doesn't seem easily possible to deploy a runner to run the CI on a debian, we must instead use a ubuntu. I also modified the workflow to have a configurable port for postgre in case something else on the server is running