### PR TITLE
Feat(areas) add param to remove geom from query

### DIFF
--- a/backend/geonature/tests/benchmarks/test_benchmark_ref_geo.py
+++ b/backend/geonature/tests/benchmarks/test_benchmark_ref_geo.py
@@ -1,0 +1,38 @@
+import logging
+import pytest
+from geonature.tests.benchmarks import *
+
+from .benchmark_generator import BenchmarkTest, CLater
+
+from .utils import activate_profiling_sql
+
+logging.basicConfig()
+logger = logging.getLogger("logger-name")
+logger.setLevel(logging.DEBUG)
+
+from .utils import CLIENT_GET
+
+
+@pytest.mark.benchmark(group="ref_geo")
+@pytest.mark.usefixtures("client_class", "temporary_transaction", "activate_profiling_sql")
+class TestBenchmarkRefGeo:
+
+    test_get_areas_with_geom = BenchmarkTest(
+        CLIENT_GET,
+        [
+            CLater(
+                """url_for("ref_geo.get_areas", without_geom="false", type_code=["REG", "DEP", "COM"])"""
+            )
+        ],
+        dict(user_profile="admin_user", fixtures=[]),
+    )()
+
+    test_get_areas_without_geom = BenchmarkTest(
+        CLIENT_GET,
+        [
+            CLater(
+                """url_for("ref_geo.get_areas", without_geom="true", type_code=["REG", "DEP", "COM"])"""
+            )
+        ],
+        dict(user_profile="admin_user", fixtures=[]),
+    )()

--- a/frontend/src/app/GN2CommonModule/form/areas/areas.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/areas/areas.component.ts
@@ -52,6 +52,10 @@ export class AreasComponent extends GenericFormComponent implements OnInit {
    */
   @Input() typeCodes: Array<string> = []; // Areas type_code
   /**
+   * Do not get the geom from the getArea call, for performances
+   */
+  @Input() withoutGeom: Boolean = false;
+  /**
    * Nom du champ à utiliser pour déterminer la valeur à utiliser pour le
    * contenu du `FormControl`.
    * Si vous souhaitez forcer le maintient dans `parentFormControl` d'un
@@ -90,6 +94,7 @@ export class AreasComponent extends GenericFormComponent implements OnInit {
   areas_input$ = new Subject<string>();
   areas: Observable<any>;
   loading = false;
+  params = {};
 
   constructor(private dataService: DataFormService) {
     super();
@@ -97,6 +102,8 @@ export class AreasComponent extends GenericFormComponent implements OnInit {
 
   ngOnInit() {
     super.ngOnInit();
+    this.params['type_code'] = this.typeCodes;
+    this.params['without_geom'] = this.withoutGeom;
     this.valueFieldName = this.valueFieldName === undefined ? 'id_area' : this.valueFieldName;
 
     this.getAreas();
@@ -105,9 +112,9 @@ export class AreasComponent extends GenericFormComponent implements OnInit {
   /**
    * Merge initial 100 areas + default values (for update)
    */
-  initalAreas(): Observable<any> {
+  initialAreas(): Observable<any> {
     return zip(
-      this.dataService.getAreas(this.typeCodes).pipe(map((data) => this.formatAreas(data))), // Default items
+      this.dataService.getAreas(this.params).pipe(map((data) => this.formatAreas(data))), // Default items
       of(this.defaultItems) // Default items in update mode
     ).pipe(
       map((areasArrays) => {
@@ -130,14 +137,15 @@ export class AreasComponent extends GenericFormComponent implements OnInit {
 
   getAreas() {
     this.areas = concat(
-      this.initalAreas(),
+      this.initialAreas(),
       this.areas_input$.pipe(
         debounceTime(200),
         distinctUntilChanged(),
         tap(() => (this.loading = true)),
         switchMap((term) => {
+          this.params['area_name'] = term;
           return term && term.length >= 2
-            ? this.dataService.getAreas(this.typeCodes, term).pipe(
+            ? this.dataService.getAreas(this.params).pipe(
                 map((data) => this.formatAreas(data)),
                 catchError(() => of([])), // Empty list on error
                 tap(() => (this.loading = false))

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -316,18 +316,18 @@ export class DataFormService {
     });
   }
 
-  getAreas(area_type_list: Array<string>, area_name?) {
-    let params: HttpParams = new HttpParams();
+  getAreas(params: {}) {
+    let queryString: HttpParams = new HttpParams();
 
-    area_type_list.forEach((id_type) => {
-      params = params.append('type_code', id_type.toString());
-    });
-
-    if (area_name) {
-      params = params.set('area_name', area_name);
+    for (let key in params) {
+      let param = params[key];
+      if (Array.isArray(param)) {
+        param = param.join(',');
+      }
+      queryString = queryString.set(key, param);
     }
 
-    return this._http.get<any>(`${this.config.API_ENDPOINT}/geo/areas`, { params: params });
+    return this._http.get<any>(`${this.config.API_ENDPOINT}/geo/areas`, { params: queryString });
   }
 
   getAreasTypes() {

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.component.html
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.component.html
@@ -306,6 +306,7 @@
           [parentFormControl]="area.control"
           [label]="area.label"
           [typeCodes]="area.type_code_array"
+          [withoutGeom]="true"
         ></pnx-areas>
       </div>
     </div>


### PR DESCRIPTION
## DESCRIPTION
Add a parameter to remove the geom from the areas query in synthese to gain performances.

## RESULT
By testing with the benchmark tests, the difference was not significative, so i tested with a frontend to see if the serialization of the geoms could take a long time : 

![Capture d’écran du 2024-04-03 14-32-39](https://github.com/PnX-SI/GeoNature/assets/29949883/6a2f0c00-0d60-4022-b2cb-6c2363a0d026)

As we can see with a frontend, the serialization takes a lot of time, with those modifications, the process of loading the areas is 3 times faster. The frontend and the backend where both on local, maybe the difference is even bigger on a live instance.