### PR TITLE
fix(mtd, sentry): get `current_user` from `flask_login` not `g`

### DIFF
--- a/backend/geonature/app.py
+++ b/backend/geonature/app.py
@@ -162,22 +162,23 @@ def create_app(with_external_mods=True):
         g._permissions_by_user = {}
         g._permissions = {}
 
-    # FIXME : order of @app.before_request is random thus g.current_user can be empty...
-    # if config.get("SENTRY_DSN"):
-    #     from sentry_sdk import set_tag, set_user
+    if config.get("SENTRY_DSN"):
+        from sentry_sdk import set_tag, set_user
 
-    #     @app.before_request
-    #     def set_sentry_context():
-    #         if "FLASK_REQUEST_ID" in request.environ:
-    #             set_tag("request.id", request.environ["FLASK_REQUEST_ID"])
-    #         if g.current_user:
-    #             set_user(
-    #                 {
-    #                     "id": g.current_user.id_role,
-    #                     "username": g.current_user.identifiant,
-    #                     "email": g.current_user.email,
-    #                 }
-    #             )
+        @app.before_request
+        def set_sentry_context():
+            from flask_login import current_user
+
+            if "FLASK_REQUEST_ID" in request.environ:
+                set_tag("request.id", request.environ["FLASK_REQUEST_ID"])
+            if current_user.is_authenticated:
+                set_user(
+                    {
+                        "id": current_user.id_role,
+                        "username": current_user.identifiant,
+                        "email": current_user.email,
+                    }
+                )
 
     admin.init_app(app)
 

--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -80,10 +80,13 @@ if config["CAS_PUBLIC"]["CAS_AUTHENTIFICATION"]:
     @routes.before_request
     def synchronize_mtd():
         if request.endpoint in ["gn_meta.get_datasets", "gn_meta.get_acquisition_frameworks_list"]:
-            try:
-                sync_af_and_ds_by_user(id_role=g.current_user.id_role)
-            except Exception as e:
-                log.exception("Error while get JDD via MTD")
+            from flask_login import current_user
+
+            if current_user.is_authenticated:
+                try:
+                    sync_af_and_ds_by_user(id_role=current_user.id_role)
+                except Exception as e:
+                    log.exception("Error while get JDD via MTD")
 
 
 @routes.route("/datasets", methods=["GET", "POST"])


### PR DESCRIPTION
# REGRESSION

With release 2.14.0 ; and upgrade of Flask from version 2 to 3 ; order of execution for `Flask.before_request` functions calls is no longer well controlled. Besides, setting of the variable `g.current_user` is now made in a `before_request` function. Thus, use of `g.current_user` variable from within another `before_request` function may sometimes not work: this is what prevents the 2 `before-request` functions `set_sentry_context`; in `backend/geonature/app.py`; and `synchronize_mtd`; in `backend/geonature/core/gn_meta/routes.py`; from working properly.

# FIX

To fix the 2 `before_request` functions, mentioned above, `flask_login.current_user` is used instead of `g.current_user` : 
- Used in `set_sentry_context` to set the user ; ID, username and email ; for Sentry context, if a user is authenticated
- Used in `synchronize_mtd` to perform an user MTD synchronization ; providing the ID of the user ; before requests `get_datasets` and `get_acquisition_frameworks_list`, if a user is authenticated