### PR TITLE
chore(create_app.py): remove outdated comment for `load_current_user`

### DIFF
--- a/backend/geonature/app.py
+++ b/backend/geonature/app.py
@@ -156,7 +156,6 @@ def create_app(with_external_mods=True):
             if change == "delete" and hasattr(obj, "__before_commit_delete__"):
                 obj.__before_commit_delete__()
 
-    # setting g.current_user on each request
     @app.before_request
     def load_current_user():
         g._permissions_by_user = {}


### PR DESCRIPTION
# DESCRIPTION

Outdated comment `# setting g.current_user on each request` for `load_current_user` before_request function, since `g.current_user` is no longer set by this function.