### PR TITLE
[IMPORT][FRONTEND] fix: upload-file-step doesn't load a dataset automaticaly

### DIFF
--- a/frontend/src/app/modules/imports/components/import_process/upload-file-step/upload-file-step.component.ts
+++ b/frontend/src/app/modules/imports/components/import_process/upload-file-step/upload-file-step.component.ts
@@ -50,9 +50,7 @@ export class UploadFileStepComponent implements OnInit {
     this.setupDatasetSelect();
     this.step = this.route.snapshot.data.step;
     this.importData = this.importProcessService.getImportData();
-    if (this.importData === null) {
-      this.uploadForm.patchValue({ dataset: +this.route.snapshot.queryParams['datasetId'] });
-    } else {
+    if (this.importData) {
       this.uploadForm.patchValue({ dataset: this.importData.id_dataset });
       this.fileName = this.importData.full_file_name;
     }


### PR DESCRIPTION
Issue: [https://github.com/orgs/PnX-SI/projects/13/views/6?pane=issue&itemId=60872439](https://github.com/orgs/PnX-SI/projects/13/views/6?pane=issue&itemId=60872439)

[Description du problème]
Sur la première page du formulaire d'import, juste après la sélection du module de destination, le champs "jdd" du formulaire est prérempli avec une valeur qui n'existe pas, et crée un état indéterminé. Ce comportement empêche notamment le marquage visuel du champ comme obligatoire (bandeau rouge) ou la sélection automatique du premier jdd s'il éxiste
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/e9eff148-8bb4-424c-85f7-b21f00621560)

[Solution]
Je pense qu'il s'ait d'un comportement hérité de la version précédente, qui pré-supposait la définition d'un dataset à l'ouverture de cette page.
J'ai ici simplement supprimé les lignes qui initialise ce champs lors d'une nouvel import. 
Je l'ai par contre conservé lorsque l'on ouvre un import existant. 

- Pas de dataset associé au module
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/8bf29d7d-789c-404d-88c7-2e7422adc08a)

- Au moins un dataset associé au module
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/b3510835-ed44-4e27-bba4-293bfc9cbc9a)
