### PR TITLE
[IMPORT][FRONTEND] feat: add "description" column in Correspondances > Champs array

### DIFF
--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.html
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.html
@@ -146,12 +146,14 @@
                 <tr>
                   <th>Champ source</th>
                   <th>Champ cible</th>
+                  <th>Description</th>
                 </tr>
               </thead>
               <tbody>
-                <tr *ngFor="let field of entity?.themes | keyvalue">
-                  <td>{{ field.value }}</td>
-                  <td>{{ field.key }}</td>
+                <tr *ngFor="let field of entity?.themes">
+                  <td>{{ field.source }}</td>
+                  <td>{{ field.destination }}</td>
+                  <td>{{ field.description }}</td>
                 </tr>
               </tbody>
             </table>

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.scss
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.scss
@@ -76,7 +76,21 @@ img {
   }
 }
 
+table {
+  display: block;
+  overflow-x: auto;
+}
+
 table caption {
   caption-side: top;
   border-collapse: collapse;
+}
+
+mat-panel-title {
+  justify-content: space-between;
+  align-items: center !important;
+  column-gap: 0.5rem;
+  h6 {
+    margin: 0 !important;
+  }
 }

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.ts
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.ts
@@ -24,6 +24,12 @@ import { FieldMappingValues } from '../../models/mapping.model';
 import { HttpClient } from '@angular/common/http';
 import { finalize } from 'rxjs/operators';
 
+interface CorrespondancesField {
+  source: string;
+  description: string;
+  destination: string | string[];
+}
+
 @Component({
   selector: 'pnx-import-report',
   templateUrl: 'import_report.component.html',
@@ -256,17 +262,18 @@ export class ImportReportComponent implements OnInit {
     return tableFieldsCorresp;
   }
 
-  mapThemes(themes: ThemesFields[], fieldMapping: FieldMappingValues) {
+  mapThemes(themes: ThemesFields[], fieldMapping: FieldMappingValues): Array<CorrespondancesField> {
     const mappedThemes = themes.map((theme) => this.mapField(theme.fields, fieldMapping));
-    return Object.assign({}, ...mappedThemes);
+    return mappedThemes.flat();
   }
 
-  mapField(listField: Field[], fieldMapping: FieldMappingValues) {
-    const mappedFields = {};
-    listField.forEach((field) => {
-      if (Object.keys(fieldMapping).includes(field.name_field)) {
-        mappedFields[field.name_field] = fieldMapping[field.name_field];
-      }
+  mapField(listField: Field[], fieldMapping: FieldMappingValues): Array<CorrespondancesField> {
+    const mappedFields: Array<CorrespondancesField> = listField.map((field) => {
+      return {
+        source: field.name_field,
+        description: field.comment,
+        destination: fieldMapping[field.name_field],
+      };
     });
     return mappedFields;
   }


### PR DESCRIPTION
Cette PR porte sur l'issue #3039 

Elle traite la partie 
> Il est nécessaire d'ajouter dans le tableau la correspondance avec le nom standard SINP pour s'assurer que le mapping est correcte car les champs en base ne sont pas toujours clairs -=(count_min, count_max).

## Solution fonctionnelle

Afin de remplir ce besoin fonctionnel, cette PR propose de rajouter une colonne qui affiche le contenu du champs commentaire dans Import > Report > Correspondances > Champs

![image](https://github.com/PnX-SI/GeoNature/assets/150020787/239d7d2f-fc8f-48ec-84aa-a5cd136efb77)

Cette solution a été discutée ici
https://matrix.to/#/!EqtcZxjaNkyMQFGHgg:matrix.org/$GmoLRnJKmRytsaUPCnaQvxLt_Qky1d3kFxI2ViPoWQE?via=matrix.org&via=sdfa3.org

## Solution technique

La seule subtilité porte sur la structure de donnée affichée, qui a été transformée d'un dictionnaire: source -> destination en un tableau d'un objet comprenant source, destination et commentaire