### PR TITLE
[IMPORT] [FRONTEND] [PROPOSITION] Modification du layout du rapport d'import

### DIFF
--- a/frontend/src/app/modules/imports/components/import_list/import-list.component.html
+++ b/frontend/src/app/modules/imports/components/import_list/import-list.component.html
@@ -3,8 +3,8 @@
   data-qa="import-list"
 >
   <div class="card">
-    <div class="card-header">
-      <h5 class="card-title mb-0">Liste des imports</h5>
+    <div class="card-header d-flex flex-column justify-content-center ImportList__title">
+      <h5 class="card-title">Liste des imports</h5>
     </div>
     <div class="card-body">
       <div *ngIf="!empty; else emptyBlock">

--- a/frontend/src/app/modules/imports/components/import_list/import-list.component.scss
+++ b/frontend/src/app/modules/imports/components/import_list/import-list.component.scss
@@ -7,6 +7,12 @@ $icon-size: 19px;
 }
 
 .ImportList {
+  &__title {
+    h5 {
+      margin: 0;
+    }
+  }
+
   .Toolbar {
     display: flex;
     flex-flow: row wrap;
@@ -23,12 +29,35 @@ $icon-size: 19px;
     &__destinations {
       max-width: 200px;
     }
+
     &__search {
       input {
         max-height: 36px;
+
         &::placeholder {
-          color: #999; /* default theme ng-placehodler color */
+          color: #999;
+          /* default theme ng-placehodler color */
         }
+      }
+    }
+
+    .card-header {
+      height: 64px;
+
+      h5 {
+        margin: 0;
+      }
+    }
+
+    .button {
+      margin-top: -0.5 * $line-tb-padding !important;
+      padding: 0 !important;
+      height: 2 * $icon-size !important;
+      width: 2 * $icon-size !important;
+
+      mat-icon {
+        font-size: $icon-size !important;
+        margin: auto;
       }
     }
   }
@@ -39,6 +68,7 @@ $icon-size: 19px;
     ::ng-deep .datatable-header-cell,
     ::ng-deep .datatable-body-cell {
       padding: $line-tb-padding $line-tb-padding * 0.5 !important;
+
       .datatable-body-cell-label,
       .datatable-body-cell-label p {
         overflow-y: hidden;
@@ -56,6 +86,7 @@ $icon-size: 19px;
       ::ng-deep .datatable-row-left {
         background-color: rgb(238, 238, 238) !important;
       }
+
       ::ng-deep .datatable-row-right {
         background-color: rgb(238, 238, 238) !important;
       }
@@ -63,14 +94,17 @@ $icon-size: 19px;
 
     ::ng-deep .datatable-row-left {
       background-color: #fff;
+
       .datatable-body-cell {
         text-align: left;
       }
     }
+
     ::ng-deep .datatable-row-right {
       .datatable-body-cell {
         background-color: inherit;
-        transform: translate3d(12px, 0px, 0px); /* trick to remove extra space on the right */
+        transform: translate3d(12px, 0px, 0px);
+        /* trick to remove extra space on the right */
         text-align: right;
         padding: 0 !important;
         margin: auto !important;
@@ -82,15 +116,18 @@ $icon-size: 19px;
       padding: $icon-size / 4;
       height: 2 * $icon-size !important;
       width: 2 * $icon-size !important;
+
       mat-icon {
         font-size: $icon-size !important;
       }
+
       &:disabled {
         color: rgba(0, 0, 0, $button-disabled-opacity) !important;
       }
 
       &Tooltip {
         filter: opacity(0.6);
+
         &--disabled {
           filter: opacity($button-disabled-opacity);
         }

--- a/frontend/src/app/modules/imports/components/import_process/import-step/import-step.component.html
+++ b/frontend/src/app/modules/imports/components/import_process/import-step/import-step.component.html
@@ -41,8 +41,8 @@
     data-qa="import-recapitulatif"
   >
     <h3 class="title mb-0">Récapitulatif avant import</h3>
-    <div class="card">
-      <h4 class="card-header">
+    <div class="card card-margin">
+      <h4 class="card-header card-margin">
         <mat-icon>build</mat-icon>
         Rapports
       </h4>

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.html
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.html
@@ -1,48 +1,38 @@
-<div class="card main">
-  <button
-    mat-raised-button
-    class="back-button"
-    (click)="navigateToImportList()"
-    data-qa="import-report-back"
-  >
-    <mat-icon>keyboard_arrow_left</mat-icon>
-    Retour
-  </button>
-  <div
-    class="card-body mb-2 text-center"
-    data-qa="import-report"
-  >
-    <div class="card content">
-      <div class="row import-info align-content-center align-items-center">
-        <div class="col-sm-10">
-          <h3>
-            <b>Rapport d'import:</b>
-            {{ importData?.id_import }}
-          </h3>
-        </div>
-        <div
-          class="col-sm-2 d-flex align-items-center justify-content-center import-status"
-          [ngClass]="importStatusClass"
+<div class="container-fluid ImportReport">
+  <div class="card">
+    <div class="card-header ImportReport__title">
+      <div class="col-sm-2 BackButton">
+        <button
+          mat-raised-button
+          (click)="navigateToImportList()"
+          data-qa="import-report-back"
         >
-          {{ importStatus }}
-        </div>
+          <mat-icon>keyboard_arrow_left</mat-icon>
+          Retour
+        </button>
       </div>
+      <h5 class="col-sm-8">
+        Rapport d'import:
+        <b>{{ importData?.id_import }}</b>
+      </h5>
+      <h5
+        class="col-sm-2 Status"
+        [ngClass]="importStatusClass"
+      >
+        {{ importStatus }}
+      </h5>
     </div>
-  </div>
-  <div class="card-body">
-    <mat-expansion-panel
-      class="card content"
-      [expanded]="true"
+    <div
+      class="card-body ImportReport__content"
+      data-qa="import-report"
     >
-      <mat-expansion-panel-header class="card-header">
-        <mat-panel-title>
+      <div class="card card-margin mb-2">
+        <div class="card-header">
           <mat-icon>info</mat-icon>
-          Description de l'import
-        </mat-panel-title>
-      </mat-expansion-panel-header>
-      <div class="card-body">
-        <div class="row">
-          <div class="col-sm-4">
+          <h6>Description de l'import</h6>
+        </div>
+        <div class="card-body row">
+          <div class="col-sm-5">
             <p>
               <b>Jeu de données :</b>
               <a
@@ -70,7 +60,7 @@
               {{ importData?.authors_name }}
             </p>
           </div>
-          <div class="col-sm-4">
+          <div class="col-sm-5">
             <p>
               <b>SRID :</b>
               {{ importData?.srid }}
@@ -98,7 +88,7 @@
               </div>
             </div>
           </div>
-          <div class="col-sm-4 d-flex flex-column justify-content-center">
+          <div class="col-sm-2 d-flex flex-column align-self-start">
             <button
               mat-raised-button
               color="primary"
@@ -118,150 +108,140 @@
           </div>
         </div>
       </div>
-    </mat-expansion-panel>
 
-    <mat-expansion-panel
-      class="card content"
-      [expanded]="true"
-    >
-      <mat-expansion-panel-header class="card-header">
-        <mat-panel-title>
+      <div class="card card-margin mb-2">
+        <div class="card-header">
           <mat-icon>compare_arrows</mat-icon>
-          Correspondances
-        </mat-panel-title>
-      </mat-expansion-panel-header>
-      <div class="card-body row">
-        <div class="col-sm-8 d-flex flex-column">
-          <mat-expansion-panel>
-            <mat-expansion-panel-header [collapsedHeight]="expansionPanelHeight">
-              <mat-panel-title>
-                <h6>Champs ({{ (importData?.fieldmapping || {} | keyvalue).length }})</h6>
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-            <table
-              *ngFor="let entity of tableFieldsCorresp"
-              class="table table-striped table-bordered"
-            >
-              <caption>{{ entity.entityLabel }}</caption>
-              <thead>
-                <tr>
-                  <th>Champ source</th>
-                  <th>Champ cible</th>
-                  <th>Description</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr *ngFor="let field of filterMappingWithoutValue(entity?.themes)">
-                  <td>{{ field.source }}</td>
-                  <td>{{ field.destination }}</td>
-                  <td>{{ field.description }}</td>
-                </tr>
-              </tbody>
-            </table>
-          </mat-expansion-panel>
+          <h6>Correspondances</h6>
         </div>
-        <div class="col-sm-4 d-flex justify-content-center report-button">
-          <button
-            mat-raised-button
-            color="primary"
-            [disabled]="!importData?.fieldmapping"
-            (click)="exportFieldMapping()"
-            class="align-self-center"
-          >
-            Exporter
-          </button>
-        </div>
-        <div class="col-sm-8 d-flex flex-column">
-          <mat-expansion-panel>
-            <mat-expansion-panel-header [collapsedHeight]="expansionPanelHeight">
-              <mat-panel-title>
-                <h6>
-                  Nomenclatures ({{ (importData?.contentmapping || {} | keyvalue).length }}
-                  type(s))
-                </h6>
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-            <table class="table table-striped table-bordered">
-              <thead>
-                <tr>
-                  <th>Valeur source</th>
-                  <th>Nomenclature</th>
-                </tr>
-              </thead>
-              <tbody>
-                <ng-container
-                  *ngFor="let nomenclature_type of importData?.contentmapping | keyvalue"
-                >
+        <div class="card-body row">
+          <div class="col-sm-10 d-flex flex-column mb-1">
+            <mat-expansion-panel>
+              <mat-expansion-panel-header [collapsedHeight]="expansionPanelHeight">
+                <mat-panel-title>
+                  <h6>Champs ({{ (importData?.fieldmapping || {} | keyvalue).length }})</h6>
+                </mat-panel-title>
+              </mat-expansion-panel-header>
+              <table
+                *ngFor="let entity of tableFieldsCorresp"
+                class="table table-striped table-bordered"
+              >
+                <caption>{{ entity.entityLabel }}</caption>
+                <thead>
                   <tr>
-                    <th colspan="2">
-                      <ng-container
-                        *ngIf="
-                          nomenclatures && nomenclatures.hasOwnProperty(nomenclature_type.key);
-                          then nomenclature_type_label;
-                          else nomenclature_type_mnemonique
-                        "
-                      ></ng-container>
-                      <ng-template #nomenclature_type_label>
-                        {{ nomenclatures[nomenclature_type.key].nomenclature_type.label_default }}
-                      </ng-template>
-                      <ng-template #nomenclature_type_mnemonique>
-                        {{ nomenclature_type.key }}
-                      </ng-template>
-                    </th>
+                    <th>Champ source</th>
+                    <th>Champ cible</th>
+                    <th>Description</th>
                   </tr>
-                  <tr *ngFor="let mapping of nomenclature_type.value | keyvalue">
-                    <td>{{ mapping.key }}</td>
-                    <td>
-                      <ng-container
-                        *ngIf="
-                          nomenclatures && nomenclatures.hasOwnProperty(nomenclature_type.key);
-                          then nomenclature_label;
-                          else nomenclature_code
-                        "
-                      ></ng-container>
-                      <ng-template #nomenclature_label>
-                        {{
-                          nomenclatures[nomenclature_type.key].nomenclatures[mapping.value]
-                            .label_default
-                        }}
-                      </ng-template>
-                      <ng-template #nomenclature_code>{{ mapping.value }}</ng-template>
-                    </td>
+                </thead>
+                <tbody>
+                  <tr *ngFor="let field of entity?.themes">
+                    <td>{{ field.source }}</td>
+                    <td>{{ field.destination }}</td>
+                    <td>{{ field.description }}</td>
                   </tr>
-                </ng-container>
-              </tbody>
-            </table>
-          </mat-expansion-panel>
-        </div>
-        <div class="col-sm-4 d-flex justify-content-center report-button">
-          <button
-            mat-raised-button
-            color="primary"
-            [disabled]="!importData?.contentmapping"
-            (click)="exportContentMapping()"
-            class="align-self-center"
-          >
-            Exporter
-          </button>
+                </tbody>
+              </table>
+            </mat-expansion-panel>
+          </div>
+          <div class="col-sm-2 d-flex justify-content-center align-self-start mt-2">
+            <button
+              mat-raised-button
+              color="primary"
+              [disabled]="!importData?.fieldmapping"
+              (click)="exportFieldMapping()"
+              class="align-self-center"
+            >
+              Exporter
+            </button>
+          </div>
+          <div class="col-sm-10 d-flex flex-column">
+            <mat-expansion-panel>
+              <mat-expansion-panel-header [collapsedHeight]="expansionPanelHeight">
+                <mat-panel-title>
+                  <h6>
+                    Nomenclatures ({{ (importData?.contentmapping || {} | keyvalue).length }}
+                    type(s))
+                  </h6>
+                </mat-panel-title>
+              </mat-expansion-panel-header>
+              <table class="table table-striped table-bordered">
+                <thead>
+                  <tr>
+                    <th>Valeur source</th>
+                    <th>Nomenclature</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <ng-container
+                    *ngFor="let nomenclature_type of importData?.contentmapping | keyvalue"
+                  >
+                    <tr>
+                      <th colspan="2">
+                        <ng-container
+                          *ngIf="
+                            nomenclatures && nomenclatures.hasOwnProperty(nomenclature_type.key);
+                            then nomenclature_type_label;
+                            else nomenclature_type_mnemonique
+                          "
+                        ></ng-container>
+                        <ng-template #nomenclature_type_label>
+                          {{ nomenclatures[nomenclature_type.key].nomenclature_type.label_default }}
+                        </ng-template>
+                        <ng-template #nomenclature_type_mnemonique>
+                          {{ nomenclature_type.key }}
+                        </ng-template>
+                      </th>
+                    </tr>
+                    <tr *ngFor="let mapping of nomenclature_type.value | keyvalue">
+                      <td>{{ mapping.key }}</td>
+                      <td>
+                        <ng-container
+                          *ngIf="
+                            nomenclatures && nomenclatures.hasOwnProperty(nomenclature_type.key);
+                            then nomenclature_label;
+                            else nomenclature_code
+                          "
+                        ></ng-container>
+                        <ng-template #nomenclature_label>
+                          {{
+                            nomenclatures[nomenclature_type.key].nomenclatures[mapping.value]
+                              .label_default
+                          }}
+                        </ng-template>
+                        <ng-template #nomenclature_code>{{ mapping.value }}</ng-template>
+                      </td>
+                    </tr>
+                  </ng-container>
+                </tbody>
+              </table>
+            </mat-expansion-panel>
+          </div>
+          <div class="col-sm-2 d-flex justify-content-center align-self-start mt-2">
+            <button
+              mat-raised-button
+              color="primary"
+              [disabled]="!importData?.contentmapping"
+              (click)="exportContentMapping()"
+              class="align-self-center"
+            >
+              Exporter
+            </button>
+          </div>
         </div>
       </div>
-    </mat-expansion-panel>
-    <mat-expansion-panel
-      class="card content"
-      [expanded]="true"
-    >
-      <mat-expansion-panel-header class="card-header">
-        <div class="d-flex justify-content-start">
-          <mat-panel-title>
-            <mat-icon>warning</mat-icon>
-            Données invalides
-          </mat-panel-title>
+
+      <div class="card card-margin mb-2">
+        <div class="card-header">
+          <mat-icon>warning</mat-icon>
+          <h6>Données invalides</h6>
         </div>
-      </mat-expansion-panel-header>
-      <div class="card-body">
-        <div class="row">
-          <div [ngClass]="nbTotalErrors !== 0 ? 'col-sm-8' : 'col-sm-12'">
-            <mat-expansion-panel>
+        <div class="card-body row">
+          <div [ngClass]="nbTotalErrors !== 0 ? 'col-sm-10' : 'col-sm-12'">
+            <mat-expansion-panel
+              class="mb-1"
+              [disabled]="!importErrors.length"
+            >
               <mat-expansion-panel-header [collapsedHeight]="expansionPanelHeight">
                 <mat-panel-title>
                   <h6 data-qa="import-report-errors-title">{{ importErrors.length }} erreur(s)</h6>
@@ -299,7 +279,7 @@
                         {{
                           error.rows.slice(0, maxErrorsLines).join(
                             ',
-            '
+                        '
                           )
                         }}
                         ...
@@ -330,7 +310,7 @@
                 </tbody>
               </table>
             </mat-expansion-panel>
-            <mat-expansion-panel>
+            <mat-expansion-panel [disabled]="!importWarnings.length">
               <mat-expansion-panel-header [collapsedHeight]="expansionPanelHeight">
                 <mat-panel-title>
                   <h6>{{ importWarnings.length }} alerte(s)</h6>
@@ -368,7 +348,7 @@
                         {{
                           error.rows.slice(0, maxErrorsLines).join(
                             ',
-            '
+                        '
                           )
                         }}
                         ...
@@ -401,7 +381,7 @@
             </mat-expansion-panel>
           </div>
           <div
-            class="col-sm-4 d-flex justify-content-center align-items-center report-button"
+            class="col-sm-2 d-flex justify-content-center align-items-center align-self-start"
             *ngIf="nbTotalErrors !== 0"
           >
             <button
@@ -411,56 +391,49 @@
               (click)="_csvExport.onCSV(importData?.id_import)"
               data-qa="import-report-errors-csv"
             >
-              Exporter vos {{ nbTotalErrors }} lignes invalides
+              <div class="ButtonContent">Exporter vos {{ nbTotalErrors }} lignes invalides</div>
             </button>
           </div>
         </div>
       </div>
-    </mat-expansion-panel>
-    <mat-expansion-panel
-      class="card content row"
-      [expanded]="true"
-      *ngIf="importStatus == 'TERMINE'"
-    >
-      <mat-expansion-panel-header class="card-header">
-        <div class="d-flex justify-content-start">
-          <mat-panel-title>
-            <mat-icon>location_on</mat-icon>
-            Données importées
-          </mat-panel-title>
+
+      <div class="card card-margin mb-2">
+        <div class="card-header">
+          <mat-icon>location_on</mat-icon>
+          <h6>Données importées</h6>
         </div>
-      </mat-expansion-panel-header>
-      <div class="row">
-        <div
-          *ngIf="validBbox"
-          class="col-sm-6 d-flex flex-column"
-        >
-          <h5 class="card-title mt-1">Périmètre géographique des données importées</h5>
-          <pnx-map
-            height="40vh"
-            searchBar="false"
-            data-qa="import-report-map"
+        <div class="card-body row">
+          <div
+            *ngIf="validBbox"
+            class="col-sm-6 d-flex flex-column"
           >
-            <pnx-geojson
-              [geojson]="validBbox"
-              [zoomOnFirstTime]="true"
-            ></pnx-geojson>
-          </pnx-map>
-          <button
-            mat-raised-button
-            class="align-self-center"
-            color="primary"
-            [disabled]="importData?.date_end_import === null"
-            (click)="goToSynthese(importData?.id_dataset)"
-          >
-            Afficher dans la synthèse
-          </button>
+            <h5 class="card-title mt-1">Périmètre géographique des données importées</h5>
+            <pnx-map
+              height="40vh"
+              searchBar="false"
+              data-qa="import-report-map"
+            >
+              <pnx-geojson
+                [geojson]="validBbox"
+                [zoomOnFirstTime]="true"
+              ></pnx-geojson>
+            </pnx-map>
+            <button
+              mat-raised-button
+              class="align-self-center"
+              color="primary"
+              [disabled]="importData?.date_end_import === null"
+              (click)="goToSynthese(importData?.id_dataset)"
+            >
+              Afficher dans la synthèse
+            </button>
+          </div>
+          <div
+            id="chartreport"
+            data-qa="import-report-chart"
+          ></div>
         </div>
-        <div
-          id="chartreport"
-          data-qa="import-report-chart"
-        ></div>
       </div>
-    </mat-expansion-panel>
+    </div>
   </div>
 </div>

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.scss
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.scss
@@ -1,96 +1,87 @@
-.card-columns {
-  -webkit-column-count: 2;
-  -moz-column-count: 2;
-  column-count: 2;
-  -webkit-column-gap: 1.25rem;
-  -moz-column-gap: 1.25rem;
-  column-gap: 1.25rem;
-  orphans: 1;
-  widows: 1;
-}
-
-.card.main {
+.ImportReport {
   background-color: transparent;
-  padding: 0;
   border: none;
-}
+  font:
+    400 14px/20px Roboto,
+    sans-serif;
 
-.card.content {
-  border-radius: 5px;
-}
-
-.flex-row {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-img {
-  width: 40px;
-}
-
-.mat-raised-button {
-  margin: 10px;
-  white-space: pre-line !important;
-  max-width: 200px;
-}
-.import-status {
-  font-size: larger;
-}
-
-.unfinished {
-  color: orange;
-  font-weight: bold;
-}
-
-.inerror {
-  color: red;
-  font-weight: bold;
-}
-
-.importdone {
-  color: green;
-  font-weight: bold;
-}
-
-.back-button {
-  margin-left: 1.25rem;
-  max-width: 125px;
-}
-
-.mat-expansion-panel-header.mat-expanded {
-  background: #f7f7f7 !important;
-}
-
-.import-info {
-  height: 64px;
-}
-
-.report-button {
-  max-height: 200px;
-}
-
-@media screen and (min-width: 768px) {
-  .card.main {
-    padding-left: 140px;
-    padding-right: 140px;
+  h3 {
+    margin-bottom: 0;
   }
-}
 
-table {
-  display: block;
-  overflow-x: auto;
-}
+  .card-header {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    column-gap: 0.5rem;
 
-table caption {
-  caption-side: top;
-  border-collapse: collapse;
-}
+    h5,
+    h6 {
+      margin: 0;
+    }
+  }
 
-mat-panel-title {
-  justify-content: space-between;
-  align-items: center !important;
-  column-gap: 0.5rem;
-  h6 {
-    margin: 0 !important;
+  &__title {
+    text-align: center;
+    height: 64px;
+    .BackButton {
+      display: flex;
+      flex-flow: row nowrap;
+      justify-content: flex-start;
+      margin: 0;
+      padding: 0;
+
+      button {
+        max-width: 150px;
+      }
+    }
+
+    .Status {
+      text-align: right;
+      font-weight: bold;
+
+      &.unfinished {
+        color: orange;
+      }
+
+      &.inerror {
+        color: red;
+      }
+
+      &.importdone {
+        color: green;
+      }
+    }
+  }
+
+  &__content {
+    .mat-expansion-panel-header.mat-expanded {
+      background: #f7f7f7 !important;
+    }
+
+    table {
+      display: block;
+      overflow-x: auto;
+    }
+
+    table caption {
+      caption-side: top;
+      border-collapse: collapse;
+    }
+
+    button {
+      padding: 10px;
+      min-height: 36px;
+      max-height: 100px !important;
+      height: auto !important;
+
+      .ButtonContent {
+        text-overflow: ellipsis !important;
+        overflow: hidden !important;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+      }
+    }
   }
 }


### PR DESCRIPTION
Cette PR porte sur le layout 

Ceci est une proposition.
J'ai fait un essai de refacto de la page importe report, pour qu'elle soit plus cohérente avec la liste des imports.
Modifications: 
- marge et padding un peu partout
- containers de section de material à boostrap
- le header (précédent, titre, status) sur une seule ligne
- taille des polices, des icones, des titres ajustées.
- équilibre horizontal contenu / bouton en faveur du contenu

Rapport d'import
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/bd8b355f-757c-4944-856c-903c46fe3723)

Liste des imports
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/dc7b4423-f6af-4dd4-bcaf-a2f8f6b52307)
