### PR TITLE
[IMPORT][OCCHAB] Fix: add "no figure" handling in occhab plot

### DIFF
--- a/contrib/gn_module_occhab/backend/gn_module_occhab/imports/plot.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/imports/plot.py
@@ -139,6 +139,10 @@ def distribution_plot(imprt) -> StandaloneEmbedJson:
         figures.append(fig)
         final_cat.append(categorie)
 
+    # No figure added: not plot needed
+    if not figures:
+        return None
+
     plot_area = column(figures)
     select_plot = Select(
         title="Catégorie",


### PR DESCRIPTION
Problem: 
The plot method was still generating a figure even if no valid data were found.

![image](https://github.com/PnX-SI/GeoNature/assets/150020787/6a11df97-4256-4b0f-a0fb-3656e19b988e)

A short test on the content of the figures array has been added, and the method return None if the array is empty. 
It leads to the disparition of the plot on the frontend, wich is the expected behavior. 


