### PR TITLE
[IMPORT][BACKEND][SYNTHESE] Fix import: add "no data" handling in synthese plot

### DIFF
--- a/backend/geonature/core/gn_synthese/imports/synthese_import_mixin.py
+++ b/backend/geonature/core/gn_synthese/imports/synthese_import_mixin.py
@@ -436,6 +436,10 @@ class SyntheseImportMixin(ImportMixin):
                 ]
             )
 
+            # if data is empty
+            if not data.size:
+                continue
+
             # Extract the rank values and counts
             rank_values, counts = data[:, 1], data[:, 0].astype(int)
 
@@ -503,6 +507,9 @@ class SyntheseImportMixin(ImportMixin):
 
             # Add the plot to the list of figures
             figures.append(fig)
+
+        if not figures:
+            return {}
 
         # Generate the layout with the plots and the rank selector
         plot_area = column(figures)


### PR DESCRIPTION
Cette PR dépend de la PR #3007 qui fait apparaître le mixin de l'import.

Cette toute mini PR corrige le problème suivant en ajoutant un check sur les données. 
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/6eb8f079-aac9-4fb1-b7fe-eb77ad76110e)
