### PR TITLE
fix(mtd): make `sync_af` return actual af model and not int

### DIFF
--- a/backend/geonature/core/gn_meta/mtd/mtd_utils.py
+++ b/backend/geonature/core/gn_meta/mtd/mtd_utils.py
@@ -140,8 +140,12 @@ def sync_af(af):
             .on_conflict_do_nothing(index_elements=["unique_acquisition_framework_id"])
             .returning(TAcquisitionFramework)
         )
+    DB.session.execute(statement)
 
-    return DB.session.scalar(statement)
+    acquisition_framework = DB.session.scalars(
+        select(TAcquisitionFramework).filter_by(unique_acquisition_framework_id=af_uuid)
+    )
+    return acquisition_framework
 
 
 def add_or_update_organism(uuid, nom, email):


### PR DESCRIPTION
Modify the function `sync_af` so that it returns the actual acquisition framework ; an instance of the model `TAcquisitionFramework` ; rather than an integer.

This, in turn, fixes the function `process_af_and_ds` and fixes MTD synchronization.