### PR TITLE
feat: adjust plot width with magic values, suited to current renderring

### DIFF
--- a/backend/geonature/core/gn_synthese/imports/synthese_import_mixin.py
+++ b/backend/geonature/core/gn_synthese/imports/synthese_import_mixin.py
@@ -468,7 +468,6 @@ class SyntheseImportMixin(ImportMixin):
                 y_range=Range1d(start=-3, end=3),
                 title=f"Distribution des taxons (selon le rang = {rank})",
                 tooltips=[("Number", "@countvalue"), (rank, "@rankvalue")],
-                width=600,
                 toolbar_location=None,
             )
             # Add the Pie chart

--- a/contrib/gn_module_occhab/backend/gn_module_occhab/imports/plot.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/imports/plot.py
@@ -100,7 +100,6 @@ def distribution_plot(imprt) -> StandaloneEmbedJson:
             y_range=Range1d(start=-3, end=3),
             title=f"Distribution des taxons (selon le rang = {category_label})",
             tooltips=[("Number", "@countvalue"), (f"{category_label}", "@rankvalue")],
-            width=1000,
             toolbar_location=None,
         )
         # Add the Pie chart


### PR DESCRIPTION
Closes #3067 

Ce fix s’appuie sur une solution efficace, enlever tout les paramètres de taille pour avori le comportement par défaut. 
Ca a le mérite d'être concret :)
https://docs.bokeh.org/en/2.4.0/docs/reference/models/layouts.html#bokeh.models.Box.spacing

Occhab: 
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/23e5a61a-fb07-40b7-833a-1a8a09421e26)

Synthese: 
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/6924ef7c-5214-4143-9130-9359822b90dc)


