### PR TITLE
[IMPORT][LISTE] fix informations displayed on liste import

### DIFF
--- a/backend/geonature/core/gn_synthese/imports/synthese_import_mixin.py
+++ b/backend/geonature/core/gn_synthese/imports/synthese_import_mixin.py
@@ -65,7 +65,8 @@ class SyntheseImportMixin(ImportMixin):
     @staticmethod
     def statistics_labels() -> typing.List[ImportStatisticsLabels]:
         return [
-            {"key": "taxa_count", "value": "Nombre de taxons importés"},
+            {"key": "observation_count", "value": "Nombre d'observations importées"},
+            {"key": "taxa_count", "value": "Nombre de taxons"},
         ]
 
     @staticmethod
@@ -356,12 +357,17 @@ class SyntheseImportMixin(ImportMixin):
             select=select_stmt,
         )
         db.session.execute(insert_stmt)
+
+        # TODO: Improve this
         imprt.statistics = {
+            "observation_count": (
+                db.session.query(func.count(Synthese.cd_nom)).filter_by(source=source).scalar()
+            ),
             "taxa_count": (
                 db.session.query(func.count(distinct(Synthese.cd_nom)))
                 .filter_by(source=source)
                 .scalar()
-            )
+            ),
         }
 
     @staticmethod

--- a/backend/geonature/core/imports/config_schema.py
+++ b/backend/geonature/core/imports/config_schema.py
@@ -28,8 +28,8 @@ DEFAULT_LIST_COLUMN = [
         "filter": False,
     },
     {
-        "prop": "import_count",
-        "name": "Nb de donnees",
+        "prop": "statistics_rows",
+        "name": "Lignes importées",
         "max_width": 100,
         "show": True,
         "filter": False,

--- a/backend/geonature/core/imports/models.py
+++ b/backend/geonature/core/imports/models.py
@@ -290,6 +290,8 @@ class TImports(InstancePermissionMixin, db.Model):
     date_end_import = db.Column(db.DateTime, nullable=True)
     source_count = db.Column(db.Integer, nullable=True)
     erroneous_rows = deferred(db.Column(ARRAY(db.Integer), nullable=True))
+    # TODO: integrate this in statistics
+    # statistics: common and destination (line count, etc. etc. dedans)
     import_count = db.Column(db.Integer, nullable=True)
     statistics = db.Column(
         MutableDict.as_mutable(JSON), nullable=False, server_default="'{}'::jsonb"

--- a/frontend/src/app/modules/imports/components/import_list/import-list.component.html
+++ b/frontend/src/app/modules/imports/components/import_list/import-list.component.html
@@ -90,6 +90,9 @@
                     {{ row[col.prop] }}
                   </a>
                 </ng-container>
+                <ng-container *ngSwitchCase="'statistics_rows'">
+                  {{ formattedRowCount(row) }}
+                </ng-container>
                 <ng-container *ngSwitchDefault>
                   {{ row[col.prop] }}
                 </ng-container>

--- a/frontend/src/app/modules/imports/components/import_list/import-list.component.ts
+++ b/frontend/src/app/modules/imports/components/import_list/import-list.component.ts
@@ -207,7 +207,7 @@ export class ImportListComponent implements OnInit {
   getStatisticsTooltip(row) {
     const statistics = this._getStatistics(row);
     return Object.keys(statistics)
-      .map((statkey) => this.getStatisticsLabel(row, statkey) + ' : ' + statistics[statkey])
+      .map((statkey) => this.getStatisticsLabel(row, statkey) + ': ' + statistics[statkey])
       .join('\n');
   }
 

--- a/frontend/src/app/modules/imports/components/import_list/import-list.component.ts
+++ b/frontend/src/app/modules/imports/components/import_list/import-list.component.ts
@@ -12,6 +12,7 @@ import { ImportProcessService } from '../import_process/import-process.service';
 import { Import } from '../../models/import.model';
 import { ConfigService } from '@geonature/services/config.service';
 import { CsvExportService } from '../../services/csv-export.service';
+import { formatRowCount } from '../../utils/format-row-count';
 
 @Component({
   styleUrls: ['import-list.component.scss'],
@@ -163,6 +164,10 @@ export class ImportListComponent implements OnInit {
     this._ds.downloadSourceFile(row.id_import).subscribe((result) => {
       saveAs(result, row.full_file_name);
     });
+  }
+
+  formattedRowCount(row: Import): string {
+    return formatRowCount(row);
   }
 
   openDeleteModal(row: Import, modalDelete) {

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.html
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.html
@@ -80,8 +80,8 @@
               {{ importData?.format_source_file }}
             </p>
             <p>
-              <b>Nombre de lignes :</b>
-              {{ importData?.source_count || 0 }}
+              <b>Nombre de lignes importées :</b>
+              {{ formattedRowCount(importData) }}
             </p>
             <div *ngIf="importStatus === 'TERMINE'">
               <div *ngFor="let item of importData?.destination.statistics_labels">

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.html
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.html
@@ -405,7 +405,7 @@
               color="accent"
               (click)="_csvExport.onCSV(importData?.id_import)"
             >
-              Exporter vos {{ nbTotalErrors }} observations invalides
+              Exporter vos {{ nbTotalErrors }} lignes invalides
             </button>
           </div>
         </div>

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.html
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.html
@@ -84,10 +84,6 @@
               {{ importData?.source_count || 0 }}
             </p>
             <div *ngIf="importStatus === 'TERMINE'">
-              <p>
-                <b>Nombre d’entités importées :</b>
-                {{ importData?.import_count || 0 }}
-              </p>
               <div *ngFor="let item of importData?.destination.statistics_labels">
                 <ng-container *ngIf="importData?.statistics[item.key] !== null">
                   <p>

--- a/frontend/src/app/modules/imports/components/import_report/import_report.component.ts
+++ b/frontend/src/app/modules/imports/components/import_report/import_report.component.ts
@@ -23,6 +23,7 @@ import { FieldMappingValues } from '../../models/mapping.model';
 
 import { HttpClient } from '@angular/common/http';
 import { finalize } from 'rxjs/operators';
+import { formatRowCount } from '../../utils/format-row-count';
 
 interface CorrespondancesField {
   source: string;
@@ -276,5 +277,9 @@ export class ImportReportComponent implements OnInit {
       };
     });
     return mappedFields;
+  }
+
+  formattedRowCount(row: Import): string {
+    return formatRowCount(row);
   }
 }

--- a/frontend/src/app/modules/imports/utils/format-row-count.ts
+++ b/frontend/src/app/modules/imports/utils/format-row-count.ts
@@ -1,0 +1,5 @@
+import { Import } from '../models/import.model';
+
+export function formatRowCount(imprt: Import): string {
+  return imprt && imprt.source_count ? `${imprt.import_count ?? 0} / ${imprt.source_count}` : '';
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -53,10 +53,6 @@ mat-sidenav-content {
   height: 40px !important;
 }
 
-.mat-tooltip {
-  white-space: pre-line;
-}
-
 .app-content {
   //background-color: $solitude;
   //height: calc(100% - 5vh);
@@ -577,4 +573,15 @@ ngb-modal-backdrop {
 
 .mat-mdc-button-touch-target {
   display: none;
+}
+
+.cdk-overlay-pane {
+  &.mat-mdc-tooltip-panel {
+    .mat-mdc-tooltip {
+      div {
+        max-width: unset;
+      }
+      white-space: preserve nowrap;
+    }
+  }
 }


### PR DESCRIPTION
Closes #3070

Cette PR concerne l'affichage du résumé des données importées dans la page liste import. 

## Statistique Générale

La statistique commune "nombre d'entité importée" a été remplacé par une portant sur le nombre de ligne importées. 

## Syntheses Statistique

Une statistique portant sur le nombre d'observations importées a été rajoutée.
A l'affichage, on souhaite la combinaison de plusieurs données. 
La donnée affichée n'est donc plus une propriété directement, mais un formatage propre à cette section du frontend. 

## Labels

Divers labels ont été mis à jour sur la liste d'import ou le rapport d'import. 
- Liste des imports: Nb de données --> Lignes importées
- Rapport d'import: Nombre de lignes importées
- Statistiques de la synthèse: ajout des observations, et reformulation "Nombre de taxon"

## Statistics Tooltip
Une mise à jour du layout de la popup de statistique, avec un retour à la ligne et ajustement de la largeur automatique. 
Avant: 
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/925ff464-173b-421c-a3ad-1e827524b9e9)
Après:
![image](https://github.com/PnX-SI/GeoNature/assets/150020787/43a1a29c-0673-41a5-894b-e29bc0fd5c7b)
