### PR TITLE
[IMPORT] Allow negative altitude

### DIFF
--- a/backend/geonature/core/imports/checks/sql/extra.py
+++ b/backend/geonature/core/imports/checks/sql/extra.py
@@ -243,24 +243,9 @@ def check_altitudes(imprt, entity, alti_min_field=None, alti_max_field=None):
     if alti_min_field:
         alti_min_name_field = alti_min_field.name_field
         alti_min_dest_col = transient_table.c[alti_min_field.dest_field]
-        report_erroneous_rows(
-            imprt,
-            entity,
-            error_type="INVALID_INTEGER",
-            error_column=alti_min_name_field,
-            whereclause=(alti_min_dest_col < 0),
-        )
 
     if alti_max_field:
-        alti_max_name_field = alti_max_field.name_field
         alti_max_dest_col = transient_table.c[alti_max_field.dest_field]
-        report_erroneous_rows(
-            imprt,
-            entity,
-            error_type="INVALID_INTEGER",
-            error_column=alti_max_name_field,
-            whereclause=(alti_max_dest_col < 0),
-        )
 
     if alti_min_field and alti_max_field:
         report_erroneous_rows(


### PR DESCRIPTION
## CONTEXTE

Le problème qui a été remonté (https://github.com/PnX-SI/gn_module_import/issues/504), est que il est possible pour GeoNature de générer une altitude négative, ce qui cause une erreur.

## DISCUSSION

Dans cette PR j'ai retiré le check pour voir si l'altitude est négative, est-ce la meilleure solution à retenir ou faudrait-il mieux empêcher la génération d'altitude négative ?