### PR TITLE
Fix/gn synthese query taxons filters

### DIFF
--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -318,7 +318,7 @@ class SyntheseQuery:
                 protection_status_value += value
 
         if protection_status_value or red_list_filters:
-            self.build_bdc_status_pr_nb_lateral_join(protection_status_value, red_list_filters)
+            self.build_bdc_status_filters(protection_status_value, red_list_filters)
         # remove attributes taxhub from filters
         self.filters = {
             colname: value
@@ -536,7 +536,7 @@ class SyntheseQuery:
         self.apply_all_filters(user, permissions)
         return self.build_query()
 
-    def build_bdc_status_pr_nb_lateral_join(self, protection_status_value, red_list_filters):
+    def build_bdc_status_filters(self, protection_status_value, red_list_filters):
         """
         Create subquery for bdc_status filters
 

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -274,6 +274,11 @@ class SyntheseQuery:
                 self.query = self.query.where(getattr(Taxref, colname).in_(value))
 
             if colname.startswith("taxhub_attribut"):
+                # Test si la valeur n'est pas une liste transformation
+                # de value en liste pour utiliser le filtre IN
+                if not type(value) is list:
+                    value = [value]
+
                 self.add_join(Taxref, Taxref.cd_nom, self.model.cd_nom)
                 taxhub_id_attr = colname[16:]
                 aliased_cor_taxon_attr[taxhub_id_attr] = aliased(CorTaxonAttribut)

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -539,9 +539,9 @@ class SyntheseQuery:
           - les statuts du type demandé par l'utilisateur
           - les status s'appliquent bien sur la zone géographique de la donnée (c-a-d le département)
 
-        Idée de façon à limiter le nombre de sous reqêtes,
+        Idée de façon à limiter le nombre de sous requêtes (le nombre de status demandé ne dégrade pas les performances),
             la liste des status selectionnés par l'utilisateur s'appliquant à l'observation est
-            aggrégée de façon à tester le nombre puis jointé sur le département de la donnée
+            aggrégée de façon à tester le nombre puis jointer sur le département de la donnée
         """
         # Ajout de la table taxref si non ajouté
         self.add_join(Taxref, Taxref.cd_nom, self.model.cd_nom)
@@ -559,11 +559,13 @@ class SyntheseQuery:
 
         # Creation requête CTE : taxon, zone d'application départementale des textes
         #   pour les taxons répondant aux critères de selection
-        bdc_status_cte = (
+        bdc_status_by_type_cte = (
             select(
                 TaxrefBdcStatutTaxon.cd_ref,
-                func.array_agg(bdc_statut_cor_text_area.c.id_area).label("ids_area"),
+                bdc_statut_cor_text_area.c.id_area,
+                TaxrefBdcStatutText.cd_type_statut,
             )
+            .distinct()
             .select_from(
                 TaxrefBdcStatutTaxon.__table__.join(
                     TaxrefBdcStatutCorTextValues,
@@ -601,15 +603,20 @@ class SyntheseQuery:
                 TaxrefBdcStatutText.cd_type_statut.in_(protection_status_value)
             )
 
-        bdc_status_cte = bdc_status_cte.where(or_(*bdc_status_filters))
+        bdc_status_by_type_cte = bdc_status_by_type_cte.where(or_(*bdc_status_filters))
+        bdc_status_by_type_cte = bdc_status_by_type_cte.cte(name="status_by_type")
 
         # group by de façon à ne selectionner que les taxons
-        #   qui ont les textes selectionnés par l'utilisateurs
-        bdc_status_cte = bdc_status_cte.group_by(TaxrefBdcStatutTaxon.cd_ref).having(
-            func.count(distinct(TaxrefBdcStatutText.cd_type_statut))
+        #   qui ont l'ensemble des textes selectionnés par l'utilisateur
+        #   c-a-d dont le nombre de cd_type_statut correspond au nombre demandé
+        bdc_status_cte = select(
+            bdc_status_by_type_cte.c.cd_ref,
+            func.array_agg(bdc_status_by_type_cte.c.id_area).label("ids_area"),
+        )
+        bdc_status_cte = bdc_status_cte.group_by(bdc_status_by_type_cte.c.cd_ref).having(
+            func.count(distinct(bdc_status_by_type_cte.c.cd_type_statut))
             == (len(protection_status_value) + len(red_list_filters))
         )
-
         bdc_status_cte = bdc_status_cte.cte(name="status")
 
         # Jointure sur le taxon

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -537,7 +537,8 @@ def synthese_data(app, users, datasets, source, sources_modules):
     data = {}
     with db.session.begin_nested():
         for name, cd_nom, point, ds, comment_description, source_m in [
-            ("obs1", 713776, point1, datasets["own_dataset"], "obs1", sources_modules[0]),
+            # Donnnées de gypaète : possède des statuts de protection nationale
+            ("obs1", 2852, point1, datasets["own_dataset"], "obs1", sources_modules[0]),
             ("obs2", 212, point2, datasets["own_dataset"], "obs2", sources_modules[0]),
             ("obs3", 2497, point3, datasets["own_dataset"], "obs3", sources_modules[1]),
             ("p1_af1", 713776, point1, datasets["belong_af_1"], "p1_af1", sources_modules[1]),

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -333,6 +333,8 @@ class TestSynthese:
         # test status protection
         filters = {"protections_protection_status": ["PN"]}
         r = self.client.get(url, json=filters)
+        # doit au moins contenir une donnée de gypaète (protection nationale)
+        assert len(r.json["features"]) >= 1
         assert r.status_code == 200
         # test status protection and znieff
         filters = {"protections_protection_status": ["PN"], "znief_protection_status": True}
@@ -1253,7 +1255,9 @@ class TestSynthese:
         response = self.client.get(url_for(url), query_string={"id_dataset": id_dataset})
         response_empty = self.client.get(url_for(url), query_string={"id_dataset": unexisted_id})
 
-        assert response.json == len(set(synt.cd_nom for synt in synthese_data.values()))
+        assert response.json == len(
+            set(synt.cd_nom for synt in synthese_data.values() if synt.id_dataset == id_dataset)
+        )
         assert response_empty.json == 0
 
     def test_get_observation_count(self, synthese_data, users):

--- a/config/test_config.toml
+++ b/config/test_config.toml
@@ -56,3 +56,9 @@ REF_LAYERS=[
 
 [SYNTHESE]
 AREA_AGGREGATION_TYPE = "M5"
+STATUS_FILTERS = [
+    { "id" = "protections", "show" = true, "display_name" = "Taxons protégés", "status_types" = ["PN", "PR", "PD"] },
+    { "id" = "regulations", "show" = true, "display_name" = "Taxons réglementés", "status_types" = ["REGLII", "REGL", "REGLSO"] },
+    { "id" = "invasive", "show" = true, "display_name" = "Espèces envahissantes", "status_types" = ["REGLLUTTE"] },
+    { "id" = "znief", "show" = true, "display_name" = "Espèces déterminantes ZNIEFF", "status_types" = ["ZDET"] },
+]


### PR DESCRIPTION
Correction filtres taxonomique de la synthèse :
 - Quand un taxon à plusieurs statuts de protection du même type. Par exemple le gypaête qui a deux statuts de protection national
 - FIltre sur un attribut taxhub qui n'est pas une valeur multiple