### PR TITLE
[IMPORT] [BACKEND] [CHORE] chore: replace abc abstract by raise NotImplementedError in ImportMixin

### DIFF
--- a/backend/geonature/core/gn_commons/models/abstract_mixin.py
+++ b/backend/geonature/core/gn_commons/models/abstract_mixin.py
@@ -1,9 +1,8 @@
 from .base import TModules
-import abc
 import typing
 
 
-class AbstractMixin(abc.ABC):
+class AbstractMixin:
     _module: TModules = None
 
     def __init__(self, module: TModules) -> None:

--- a/backend/geonature/core/gn_synthese/module.py
+++ b/backend/geonature/core/gn_synthese/module.py
@@ -1,10 +1,9 @@
 from geonature.core.gn_commons.models import TModules
 
 from geonature.core.gn_synthese.imports import SyntheseImportMixin
-from geonature.utils.metaclass_utils import metaclass_resolver
 
 
-class SyntheseModule(metaclass_resolver(TModules, SyntheseImportMixin)):
+class SyntheseModule(TModules, SyntheseImportMixin):
     __mapper_args__ = {"polymorphic_identity": "synthese"}
 
     def generate_input_url_for_dataset(self, dataset):

--- a/backend/geonature/core/imports/import_mixin.py
+++ b/backend/geonature/core/imports/import_mixin.py
@@ -3,7 +3,6 @@ from geonature.core.imports.models import TImports
 
 from bokeh.embed.standalone import StandaloneEmbedJson
 
-from abc import abstractmethod
 import typing
 
 
@@ -19,37 +18,30 @@ class ImportInputUrl(typing.TypedDict):
 
 class ImportMixin(AbstractMixin):
     @staticmethod
-    @abstractmethod
     def statistics_labels() -> typing.List[ImportStatisticsLabels]:
-        pass
+        raise NotImplementedError
 
     # The output of this method is NEVER used
     @staticmethod
-    @abstractmethod
     def preprocess_transient_data(imprt: TImports, df) -> set:
-        return None
+        raise NotImplementedError
 
     @staticmethod
-    @abstractmethod
     def check_transient_data(task, logger, imprt: TImports) -> None:
-        pass
+        raise NotImplementedError
 
     @staticmethod
-    @abstractmethod
     def import_data_to_destination(imprt: TImports) -> None:
-        pass
+        raise NotImplementedError
 
     @staticmethod
-    @abstractmethod
     def remove_data_from_destination(imprt: TImports) -> None:
-        pass
+        raise NotImplementedError
 
     @staticmethod
-    @abstractmethod
     def report_plot(imprt: TImports) -> StandaloneEmbedJson:
-        pass
+        raise NotImplementedError
 
     @staticmethod
-    @abstractmethod
     def compute_bounding_box(imprt: TImports) -> None:
-        pass
+        raise NotImplementedError

--- a/contrib/gn_module_occhab/backend/gn_module_occhab/module.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/module.py
@@ -1,10 +1,9 @@
 from geonature.core.gn_commons.models import TModules
-from geonature.utils.metaclass_utils import metaclass_resolver
 
 from .imports import OcchabImportMixin
 
 
-class OcchabModule(metaclass_resolver(TModules, OcchabImportMixin)):
+class OcchabModule(TModules, OcchabImportMixin):
     __mapper_args__ = {"polymorphic_identity": "occhab"}
 
     def generate_input_url_for_dataset(self, dataset):


### PR DESCRIPTION
C'est une PR proposition: vous pouvez la supprimer, je ne me vexe pas :)

On observe des warnings liés au polymorphisme, et à l'abstraction sur les modules. 
Le fait de basculer de l'approche _du module_ `ABC` à l'approche _artisanale_ `raise NotImplementedError` supprime ces warnings. 

Je fais confiance aux tests pour voir si ça fonctionne correctement :)


```bash
/home/etienne/Documents/devel/geonature/ns-github/geonature_import/geonature/backend/venv/lib/python3.10/site-packages/flask_sqlalchemy/model.py:120: SAWarning: 
Mapper mapped class TModules_SyntheseImportMixin->t_modules does not indicate a polymorphic_identity, yet is part of an inheritance hierarchy that has a polymorphic_on column of 't_modules.type'.  
Objects of this type cannot be loaded polymorphically which can lead to degraded or incorrect loading behavior in some scenarios.  
Please establish a polmorphic_identity for this class, or leave it un-mapped.  
To omit mapping an intermediary class when using declarative, set the '__abstract__ = True' attribute on that class.
super().__init__(name, bases, d, **kwargs)

/home/etienne/Documents/devel/geonature/ns-github/geonature_import/geonature/backend/venv/lib/python3.10/site-packages/flask_sqlalchemy/model.py:120: SAWarning: 
Mapper mapped class TModules_OcchabImportMixin->t_modules does not indicate a polymorphic_identity, yet is part of an inheritance hierarchy that has a polymorphic_on column of 't_modules.type'.  
Objects of this type cannot be loaded polymorphically which can lead to degraded or incorrect loading behavior in some scenarios.  
Please establish a polmorphic_identity for this class, or leave it un-mapped.  To omit mapping an intermediary class when using declarative, set the '__abstract__ = True' attribute on that class.
super().__init__(name, bases, d, **kwargs)

```