### PR TITLE
Placement de la position des matTooltip à droite

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.html
+++ b/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.html
@@ -18,6 +18,7 @@
   >
     <div
       matTooltip="{{ item.acquisition_framework_name }}"
+      matTooltipPosition="after"
       [attr.data-qa]="item.acquisition_framework_name"
     >
       <span class="pre-wrap">{{ item.acquisition_framework_name }}</span>

--- a/frontend/src/app/GN2CommonModule/form/areas/areas.component.html
+++ b/frontend/src/app/GN2CommonModule/form/areas/areas.component.html
@@ -34,6 +34,7 @@
       <span
         class="bg-warning p-2 rounded"
         matTooltip="Aucune correspondance pour «&nbsp;{{ searchTerm }}&nbsp;»"
+        matTooltipPosition="after"
       >
         <mat-icon inline>warning_amber</mat-icon>
         Aucune correspondance pour «&nbsp;{{ searchTerm }}&nbsp;»
@@ -48,6 +49,7 @@
     <div
       class="ng-option disabled"
       matTooltip="Chargements des zones pour «&nbsp;{{ searchTerm }}&nbsp;»"
+      matTooltipPosition="after"
     >
       <span class="bg-info p-2 rounded">
         <mat-icon inline>autorenew</mat-icon>
@@ -60,7 +62,10 @@
     ng-option-tmp
     let-item="item"
   >
-    <div matTooltip="{{ item.area_name }}">
+    <div 
+      matTooltip="{{ item.area_name }}"
+      matTooltipPosition="after"
+    >
       <span class="pre-wrap">{{ item.area_name }}</span>
     </div>
   </ng-template>

--- a/frontend/src/app/GN2CommonModule/form/datalist/datalist.component.html
+++ b/frontend/src/app/GN2CommonModule/form/datalist/datalist.component.html
@@ -57,6 +57,7 @@
       <mat-icon
         *ngIf="definition"
         [matTooltip]="definition"
+        matTooltipPosition="after"
         matTooltipClass="form-tooltip"
         class="small-icon"
         matSuffix
@@ -87,7 +88,10 @@
         let-index="index"
         let-search="searchTerm"
       >
-        <div [matTooltip]="item[keyLabel]">
+        <div 
+          [matTooltip]="item[keyLabel]"
+          matTooltipPosition="after"
+        >
           <span class="pre-wrap">{{ item[keyLabel] }}</span>
         </div>
       </ng-template>

--- a/frontend/src/app/GN2CommonModule/form/datasets/datasets.component.html
+++ b/frontend/src/app/GN2CommonModule/form/datasets/datasets.component.html
@@ -18,6 +18,7 @@
   >
     <div
       matTooltip="{{ item.dataset_name }}"
+      matTooltipPosition="after"
       [attr.data-qa]="item.dataset_name"
     >
       <span class="pre-wrap">{{ item.dataset_name }}</span>

--- a/frontend/src/app/GN2CommonModule/form/multiselect/multiselect.component.html
+++ b/frontend/src/app/GN2CommonModule/form/multiselect/multiselect.component.html
@@ -18,7 +18,10 @@
     let-index="index"
     let-search="searchTerm"
   >
-    <div [matTooltip]="item[keyLabel]">
+    <div 
+      [matTooltip]="item[keyLabel]"
+      matTooltipPosition="after"
+    >
       <span class="pre-wrap">{{ item[keyLabel] }}</span>
     </div>
   </ng-template>

--- a/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.html
+++ b/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.html
@@ -19,6 +19,7 @@
   >
     <div
       matTooltip="{{ item[definitionLang] }}"
+      matTooltipPosition="after"
       [attr.data-qa]="item['cd_nomenclature']"
     >
       <span class="pre-wrap">{{ item[labelLang] }}</span>

--- a/frontend/src/app/GN2CommonModule/form/observers/observers.component.html
+++ b/frontend/src/app/GN2CommonModule/form/observers/observers.component.html
@@ -18,7 +18,10 @@
     let-index="index"
     let-search="searchTerm"
   >
-    <div matTooltip="{{ item.nom_complet }}">
+    <div 
+      matTooltip="{{ item.nom_complet }}"
+      matTooltipPosition="after"
+    >
       <span
         class="pre-wrap"
         [attr.data-qa]="'gn-common-form-observers-select-' + item.nom_complet"

--- a/frontend/src/app/metadataModule/actors/actors.component.html
+++ b/frontend/src/app/metadataModule/actors/actors.component.html
@@ -53,7 +53,10 @@
           let-index="index"
           let-search="searchTerm"
         >
-          <div [matTooltip]="item.label_default">
+          <div 
+            [matTooltip]="item.label_default"
+            matTooltipPosition="after"
+          >
             <span class="pre-wrap">{{ item.label_default }}</span>
           </div>
         </ng-template>
@@ -82,6 +85,7 @@
         >
           <div
             [matTooltip]="item.nom_organisme"
+            matTooltipPosition="after"
             [attr.data-qa]="'pnx-metadata-organism-' + item.nom_organisme"
           >
             <span class="pre-wrap">{{ item.nom_organisme }}</span>
@@ -110,7 +114,10 @@
           let-index="index"
           let-search="searchTerm"
         >
-          <div [matTooltip]="item.nom_complet">
+          <div 
+            [matTooltip]="item.nom_complet"
+            matTooltipPosition="after"
+          >
             <span class="pre-wrap">{{ item.nom_complet }}</span>
           </div>
         </ng-template>

--- a/frontend/src/app/metadataModule/metadata.component.html
+++ b/frontend/src/app/metadataModule/metadata.component.html
@@ -293,6 +293,7 @@
       >
         <div
           [matTooltip]="item.nom_organisme"
+          matTooltipPosition="after"
           [attr.data-qa]="item.id_organism"
         >
           <span class="pre-wrap">{{ item.nom_organisme }}</span>
@@ -318,6 +319,7 @@
       >
         <div
           [matTooltip]="item.nom_complet"
+          matTooltipPosition="after"
           [attr.data-qa]="item.id_role"
         >
           <span class="pre-wrap">{{ item.nom_complet }}</span>


### PR DESCRIPTION
En lien avec #3142 : force le positionnement des tooltips des valeurs des listes ng-select à droite.