### PR TITLE
feat: add route to tabs synthese info

### DIFF
--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs-container.component.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs-container.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { SyntheseInfoObsComponent } from './synthese-info-obs/synthese-info-obs.component';
+import { Location } from '@angular/common';
+
+@Component({
+  selector: 'pnx-synthese-info-obs-modal-container',
+  template: '',
+})
+export class SyntheseObsModalWrapperComponent implements OnDestroy {
+  destroy = new Subject<any>();
+  currentDialog = null;
+  dialogResult: any;
+  constructor(
+    private modalService: NgbModal,
+    private location: Location,
+    route: ActivatedRoute
+  ) {
+    route.params.pipe(takeUntil(this.destroy)).subscribe((params) => {
+      // When router navigates on this component is takes the params
+      // and opens up the photo detail modal
+      this.currentDialog = this.modalService.open(SyntheseInfoObsComponent, {
+        size: 'lg',
+        windowClass: 'large-modal',
+      });
+      this.currentDialog.componentInstance.idSynthese = params.id_synthese;
+      this.currentDialog.componentInstance.selectedTab = params.tab;
+      this.currentDialog.componentInstance.useFrom = 'synthese';
+      this.currentDialog.componentInstance.header = true;
+
+      // Go back to home page after the modal is closed
+      this.dialogResult = this.currentDialog.result.then(
+        (result) => {
+          this.location.back();
+        },
+        (reason) => {
+          this.location.back();
+        }
+      );
+    });
+  }
+  ngOnDestroy(): void {
+    this.destroy.next();
+    this.currentDialog?.close(-1);
+    this.dialogResult = null;
+  }
+}

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.html
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.html
@@ -216,468 +216,481 @@
 </mat-card>
 
 <mat-tab-group
-  (selectedTabChange)="setValidationTab()"
+  [(selectedIndex)]="selectedIndex"
+  (selectedTabChange)="setValidationTab($event)"
   #tabGroup
   class="my-tab-grp"
 >
-  <mat-tab label="Détail de l'occurrence">
-    <table class="font-xs table table-striped table-sm">
-      <tr>
-        <td>{{ 'Synthese.ObsState' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_observation_status?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsTech' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_obs_technique?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsStateBio' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_bio_condition?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsStatusBio' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_bio_status?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsStatBiogeo' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_occ_biogeo_status?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsBehav' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_behaviour?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsSex' | translate }}</td>
-        <td data-qa="synthese-info-obs-sexe-value">
-          {{ selectedObs?.nomenclature_sex?.label_default }}
-        </td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.ObsLifeStep' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_life_stage?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Denombrement min</td>
-        <td>{{ selectedObs?.count_min }}</td>
-      </tr>
-      <tr>
-        <td>Denombrement max</td>
-        <td>{{ selectedObs?.count_max }}</td>
-      </tr>
-      <tr>
-        <td>Type de dénombrement</td>
-        <td>{{ selectedObs?.nomenclature_type_count?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Objet du dénombrement</td>
-        <td>{{ selectedObs?.nomenclature_obj_count?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Naturalité</td>
-        <td>{{ selectedObs?.nomenclature_naturalness?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Commentaire relevé</td>
-        <td>{{ selectedObs?.comment_context }}</td>
-      </tr>
-      <tr>
-        <td>Commentaire occurrence</td>
-        <td>{{ selectedObs?.comment_description }}</td>
-      </tr>
-      <tr>
-        <td>Determinateur</td>
-        <td>{{ selectedObs?.determiner }}</td>
-      </tr>
-      <tr>
-        <td>{{ 'Synthese.DeterMeth' | translate }}</td>
-        <td>{{ selectedObs?.nomenclature_determination_method?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Preuve d'existence</td>
-        <td>{{ selectedObs?.nomenclature_exist_proof?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Preuve numérique</td>
-        <td>{{ selectedObs?.digital_proof }}</td>
-      </tr>
-      <tr>
-        <td>Preuve non numérique</td>
-        <td>{{ selectedObs?.non_digital_proof }}</td>
-      </tr>
-      <tr>
-        <td>Echantillon de preuve</td>
-        <td>{{ selectedObs?.sample_number_proof }}</td>
-      </tr>
-      <tr></tr>
-      <tr>
-        <td>Type de regroupement</td>
-        <td>{{ selectedObs?.nomenclature_grp_typ?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Méthode de regroupement</td>
-        <td>{{ selectedObs?.grp_method }}</td>
-      </tr>
-      <tr>
-        <td>Source de la donnée</td>
-        <td>{{ selectedObs?.nomenclature_source_status?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Statut de validation</td>
-        <td>{{ selectedObs?.nomenclature_valid_status?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Sensibilité</td>
-        <td>{{ selectedObs?.nomenclature_sensitivity?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Niveau de diffusion</td>
-        <td>{{ selectedObs?.nomenclature_diffusion_level?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Nature de l'objet géographique</td>
-        <td>{{ selectedObs?.nomenclature_geo_object_nature?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Floutage</td>
-        <td>{{ selectedObs?.nomenclature_blurring?.label_default }}</td>
-      </tr>
-      <tr>
-        <td>Identifiant unique SINP</td>
-        <td>{{ selectedObs?.unique_id_sinp }}</td>
-      </tr>
-      <tr>
-        <td>Champs additionnels</td>
-        <td>{{ selectedObs?.additional_data | json }}</td>
-      </tr>
-    </table>
-  </mat-tab>
-
-  <mat-tab label="Métadonnées">
-    <table class="font-xs table table-striped table-sm">
-      <tr>
-        <td>Jeu de données</td>
-        <td data-qa="synthese-obs-detail-jdd">{{ selectedObs?.dataset.dataset_name }}</td>
-      </tr>
-      <tr>
-        <td>Cadre d'acquisition</td>
-        <td data-qa="synthese-obs-detail-ca">
-          {{ selectedObs?.dataset.acquisition_framework.acquisition_framework_name }}
-        </td>
-      </tr>
-      <tr>
-        <td>Acteurs</td>
-        <td>
-          <ul>
-            <li *ngFor="let actor of selectedObs?.dataset.cor_dataset_actor">
-              {{ actor.display_name }}
-            </li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td>Module de provenance</td>
-        <td>{{ selectedObs?.source.name_source }}</td>
-      </tr>
-    </table>
-  </mat-tab>
-
-  <mat-tab label="Taxonomie">
-    <table class="font-xs table table-striped table-sm">
-      <tr>
-        <td>
-          <b>Groupe taxonomique</b>
-        </td>
-        <td>{{ selectedObsTaxonDetail?.classe }}</td>
-      </tr>
-      <tr>
-        <td>
-          <b>Ordre</b>
-        </td>
-        <td>{{ selectedObsTaxonDetail?.ordre }}</td>
-      </tr>
-      <tr>
-        <td>
-          <b>Famille</b>
-        </td>
-        <td data-qa="synthese-obs-detail-taxo-familly">{{ selectedObsTaxonDetail?.famille }}</td>
-      </tr>
-    </table>
-
-    <h5 class="underlined underlined-sm main-color">Attribut(s) Taxonomique(s) locaux</h5>
-    <table class="font-xs table table-striped table-sm">
-      <tr
-        class="font-xs"
-        *ngFor="let attr of selectObsTaxonInfo?.attributs"
-      >
-        <td>
-          <b>{{ attr.label_attribut }}</b>
-        </td>
-        <td>{{ attr.valeur_attribut }}</td>
-      </tr>
-    </table>
-
-    <h5 class="underlined underlined-sm main-color">Statuts</h5>
-    <table
-      class="font-xs table table-sm"
-      *ngIf="selectedObsTaxonDetail?.status; else noStatus"
-    >
-      <ng-container *ngFor="let status of selectedObsTaxonDetail?.status | keyvalue">
-        <tr class="table-primary">
-          <th>{{ status.value.display }}</th>
-        </tr>
-        <tr *ngFor="let text of status.value.text | keyvalue">
-          <td>
-            <ul class="list-unstyled mt-2">
-              <li
-                *ngIf="text.value.full_citation"
-                class="d-flex w-100 justify-content-between"
-              >
-                <span class="flex-shrink-1 w-75">
-                  <strong [innerHtml]="text.value.full_citation | safeHTML"></strong>
-                  <br />
-                  ({{ text.value.lb_adm_tr }} - {{ text.value.cd_sig }})
-                </span>
-                <a
-                  *ngIf="text.value.doc_url"
-                  class="btn align-self-start"
-                  href="{{ text.value.doc_url }}"
-                  mat-stroked-button
-                  color="primary"
-                  target="_blank"
-                >
-                  Voir / Télécharger
-                  <mat-icon aria-hidden="true">launch</mat-icon>
-                </a>
-              </li>
-              <li>
-                <span *ngFor="let value of text.value.values | keyvalue">
-                  <strong *ngIf="value.value.code != 'true'">
-                    {{ value.value.code_statut }}
-                  </strong>
-                  {{ value.value.label_statut }}
-                  {{ value.value.rq_statut }}
-                </span>
-              </li>
-            </ul>
-          </td>
-        </tr>
-      </ng-container>
-    </table>
-    <ng-template #noStatus><p>Aucun</p></ng-template>
-  </mat-tab>
-  <ng-container *ngIf="selectedObs?.medias?.length">
-    <mat-tab label="Médias">
-      <h5 class="underlined underlined-sm main-color">Médias</h5>
-      <table class="font-xs table table-striped table-sm">
-        <ng-container *ngFor="let media of selectedObs?.medias; index as i">
-          <tr>
-            <td>Titre</td>
-            <td>
-              <a
-                target="_blank"
-                [href]="mediaService.href(media)"
-              >
-                {{ media.title_fr }}
-              </a>
-            </td>
-          </tr>
-          <tr *ngIf="media.description_fr">
-            <td>Description</td>
-            <td>{{ media.description_fr }}</td>
-          </tr>
-          <tr *ngIf="media.author">
-            <td>Auteur</td>
-            <td>{{ media.author }}</td>
-          </tr>
-          <tr>
-            <td colspan="2">
-              <pnx-display-medias
-                diaporama="true"
-                [medias]="selectedObs?.medias"
-                [index]="i"
-                display="medium"
-              ></pnx-display-medias>
-            </td>
-          </tr>
-        </ng-container>
-      </table>
-    </mat-tab>
-  </ng-container>
-
-  <mat-tab label="Zonage">
-    <table class="font-xs table table-striped table-sm">
-      <thead>
-        <tr>
-          <th class="table_date">Type de zonage</th>
-          <th class="table_comment">Zones</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr *ngFor="let area_type of formatedAreas">
-          <td>
-            {{ area_type.area_type }}
-          </td>
-          <td>
-            <span
-              data-qa="synthese-obs-detail-area"
-              *ngFor="let area of area_type.areas; let index = index"
-            >
-              {{ area.area_name }}
-              <span *ngIf="index < area_type.areas.length - 1">,</span>
-            </span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </mat-tab>
-
-  <mat-tab>
+  <mat-tab *ngFor="let tab of filteredTabs">
     <ng-template mat-tab-label>
-      <span>Validation</span>
+      <span>{{ tab.label }}</span>
     </ng-template>
-    <div *ngIf="showValidation">
-      <h3 data-qa="synthese-obs-detail-validation-title">Historique de validation de la donnée</h3>
-
-      <table class="font-xs table table-striped table-sm">
-        <thead>
+    <ng-container [ngSwitch]="tab.path">
+      <ng-container *ngSwitchCase="'details'">
+        <table class="font-xs table table-striped table-sm">
           <tr>
-            <th class="table_date">Date de validation</th>
-            <th class="table_status">Statut</th>
-            <th class="table_comment">Validateur</th>
-            <th class="table_comment">Commentaire</th>
+            <td>{{ 'Synthese.ObsState' | translate }}</td>
+            <td>{{ selectedObs?.nomenclature_observation_status?.label_default }}</td>
           </tr>
-        </thead>
+          <tr>
+            <td>{{ 'Synthese.ObsTech' | translate }}</td>
+            <td>{{ selectedObs?.nomenclature_obs_technique?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>{{ 'Synthese.ObsStateBio' | translate }}</td>
+            <td>{{ selectedObs?.nomenclature_bio_condition?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>{{ 'Synthese.ObsStatusBio' | translate }}</td>
+            <td>{{ selectedObs?.nomenclature_bio_status?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>{{ 'Synthese.ObsStatBiogeo' | translate }}</td>
+            <td>{{ selectedObs?.nomenclature_occ_biogeo_status?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>{{ 'Synthese.ObsBehav' | translate }}</td>
+            <td>{{ selectedObs?.nomenclature_behaviour?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>{{ 'Synthese.ObsSex' | translate }}</td>
+            <td data-qa="synthese-info-obs-sexe-value">
+              {{ selectedObs?.nomenclature_sex?.label_default }}
+            </td>
+          </tr>
+          <tr>
+            <td>{{ 'Synthese.ObsLifeStep' | translate }}</td>
+            <td>{{ selectedObs?.nomenclature_life_stage?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Denombrement min</td>
+            <td>{{ selectedObs?.count_min }}</td>
+          </tr>
+          <tr>
+            <td>Denombrement max</td>
+            <td>{{ selectedObs?.count_max }}</td>
+          </tr>
+          <tr>
+            <td>Type de dénombrement</td>
+            <td>{{ selectedObs?.nomenclature_type_count?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Objet du dénombrement</td>
+            <td>{{ selectedObs?.nomenclature_obj_count?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Naturalité</td>
+            <td>{{ selectedObs?.nomenclature_naturalness?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Commentaire relevé</td>
+            <td>{{ selectedObs?.comment_context }}</td>
+          </tr>
+          <tr>
+            <td>Commentaire occurrence</td>
+            <td>{{ selectedObs?.comment_description }}</td>
+          </tr>
+          <tr>
+            <td>Determinateur</td>
+            <td>{{ selectedObs?.determiner }}</td>
+          </tr>
+          <tr>
+            <td>{{ 'Synthese.DeterMeth' | translate }}</td>
+            <td>{{ selectedObs?.nomenclature_determination_method?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Preuve d'existence</td>
+            <td>{{ selectedObs?.nomenclature_exist_proof?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Preuve numérique</td>
+            <td>{{ selectedObs?.digital_proof }}</td>
+          </tr>
+          <tr>
+            <td>Preuve non numérique</td>
+            <td>{{ selectedObs?.non_digital_proof }}</td>
+          </tr>
+          <tr>
+            <td>Echantillon de preuve</td>
+            <td>{{ selectedObs?.sample_number_proof }}</td>
+          </tr>
+          <tr></tr>
+          <tr>
+            <td>Type de regroupement</td>
+            <td>{{ selectedObs?.nomenclature_grp_typ?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Méthode de regroupement</td>
+            <td>{{ selectedObs?.grp_method }}</td>
+          </tr>
+          <tr>
+            <td>Source de la donnée</td>
+            <td>{{ selectedObs?.nomenclature_source_status?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Statut de validation</td>
+            <td>{{ selectedObs?.nomenclature_valid_status?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Sensibilité</td>
+            <td>{{ selectedObs?.nomenclature_sensitivity?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Niveau de diffusion</td>
+            <td>{{ selectedObs?.nomenclature_diffusion_level?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Nature de l'objet géographique</td>
+            <td>{{ selectedObs?.nomenclature_geo_object_nature?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Floutage</td>
+            <td>{{ selectedObs?.nomenclature_blurring?.label_default }}</td>
+          </tr>
+          <tr>
+            <td>Identifiant unique SINP</td>
+            <td>{{ selectedObs?.unique_id_sinp }}</td>
+          </tr>
+          <tr>
+            <td>Champs additionnels</td>
+            <td>{{ selectedObs?.additional_data | json }}</td>
+          </tr>
+        </table>
+      </ng-container>
+      <!-- </mat-tab> -->
 
-        <tbody>
-          <tr *ngFor="let row of validationHistory">
-            <td width="15%">{{ row.date }}</td>
-            <td width="20%">
-              <span
-                class="validationCircle"
-                [ngStyle]="{ background: validationColor[row.cd_nomenclature] }"
-              >
-                <mat-icon
-                  *ngIf="row.typeValidation == 'True'"
-                  class="computer"
+      <ng-container *ngSwitchCase="'metadata'">
+        <table class="font-xs table table-striped table-sm">
+          <tr>
+            <td>Jeu de données</td>
+            <td data-qa="synthese-obs-detail-jdd">{{ selectedObs?.dataset.dataset_name }}</td>
+          </tr>
+          <tr>
+            <td>Cadre d'acquisition</td>
+            <td data-qa="synthese-obs-detail-ca">
+              {{ selectedObs?.dataset.acquisition_framework.acquisition_framework_name }}
+            </td>
+          </tr>
+          <tr>
+            <td>Acteurs</td>
+            <td>
+              <ul>
+                <li *ngFor="let actor of selectedObs?.dataset.cor_dataset_actor">
+                  {{ actor.display_name }}
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>Module de provenance</td>
+            <td>{{ selectedObs?.source.name_source }}</td>
+          </tr>
+        </table>
+      </ng-container>
+
+      <ng-container *ngSwitchCase="'taxonomy'">
+        <table class="font-xs table table-striped table-sm">
+          <tr>
+            <td>
+              <b>Groupe taxonomique</b>
+            </td>
+            <td>{{ selectedObsTaxonDetail?.classe }}</td>
+          </tr>
+          <tr>
+            <td>
+              <b>Ordre</b>
+            </td>
+            <td>{{ selectedObsTaxonDetail?.ordre }}</td>
+          </tr>
+          <tr>
+            <td>
+              <b>Famille</b>
+            </td>
+            <td data-qa="synthese-obs-detail-taxo-familly">
+              {{ selectedObsTaxonDetail?.famille }}
+            </td>
+          </tr>
+        </table>
+
+        <h5 class="underlined underlined-sm main-color">Attribut(s) Taxonomique(s) locaux</h5>
+        <table class="font-xs table table-striped table-sm">
+          <tr
+            class="font-xs"
+            *ngFor="let attr of selectObsTaxonInfo?.attributs"
+          >
+            <td>
+              <b>{{ attr.label_attribut }}</b>
+            </td>
+            <td>{{ attr.valeur_attribut }}</td>
+          </tr>
+        </table>
+
+        <h5 class="underlined underlined-sm main-color">Statuts</h5>
+        <table
+          class="font-xs table table-sm"
+          *ngIf="selectedObsTaxonDetail?.status; else noStatus"
+        >
+          <ng-container *ngFor="let status of selectedObsTaxonDetail?.status | keyvalue">
+            <tr class="table-primary">
+              <th>{{ status.value.display }}</th>
+            </tr>
+            <tr *ngFor="let text of status.value.text | keyvalue">
+              <td>
+                <ul class="list-unstyled mt-2">
+                  <li
+                    *ngIf="text.value.full_citation"
+                    class="d-flex w-100 justify-content-between"
+                  >
+                    <span class="flex-shrink-1 w-75">
+                      <strong [innerHtml]="text.value.full_citation | safeHTML"></strong>
+                      <br />
+                      ({{ text.value.lb_adm_tr }} - {{ text.value.cd_sig }})
+                    </span>
+                    <a
+                      *ngIf="text.value.doc_url"
+                      class="btn align-self-start"
+                      href="{{ text.value.doc_url }}"
+                      mat-stroked-button
+                      color="primary"
+                      target="_blank"
+                    >
+                      Voir / Télécharger
+                      <mat-icon aria-hidden="true">launch</mat-icon>
+                    </a>
+                  </li>
+                  <li>
+                    <span *ngFor="let value of text.value.values | keyvalue">
+                      <strong *ngIf="value.value.code != 'true'">
+                        {{ value.value.code_statut }}
+                      </strong>
+                      {{ value.value.label_statut }}
+                      {{ value.value.rq_statut }}
+                    </span>
+                  </li>
+                </ul>
+              </td>
+            </tr>
+          </ng-container>
+        </table>
+        <ng-template #noStatus><p>Aucun</p></ng-template>
+      </ng-container>
+
+      <ng-container *ngSwitchCase="'media'">
+        <h5 class="underlined underlined-sm main-color">Médias</h5>
+        <table class="font-xs table table-striped table-sm">
+          <ng-container *ngFor="let media of selectedObs?.medias; index as i">
+            <tr>
+              <td>Titre</td>
+              <td>
+                <a
+                  target="_blank"
+                  [href]="mediaService.href(media)"
                 >
-                  computer
-                </mat-icon>
-              </span>
-              <span
-                class="statusName"
-                class="ml-4"
-              >
-                {{ row.label_default }}
-              </span>
-            </td>
-            <td width="20%">
-              <span>{{ row.validator }}</span>
-            </td>
-            <td>{{ row.comment }}</td>
-          </tr>
-        </tbody>
-      </table>
+                  {{ media.title_fr }}
+                </a>
+              </td>
+            </tr>
+            <tr *ngIf="media.description_fr">
+              <td>Description</td>
+              <td>{{ media.description_fr }}</td>
+            </tr>
+            <tr *ngIf="media.author">
+              <td>Auteur</td>
+              <td>{{ media.author }}</td>
+            </tr>
+            <tr>
+              <td colspan="2">
+                <pnx-display-medias
+                  diaporama="true"
+                  [medias]="selectedObs?.medias"
+                  [index]="i"
+                  display="medium"
+                ></pnx-display-medias>
+              </td>
+            </tr>
+          </ng-container>
+        </table>
+      </ng-container>
 
-      <div *ngIf="config.FRONTEND.ENABLE_PROFILES">
-        <div *ngIf="profile; else noProfile">
-          <h3>Profil du taxon</h3>
-          <div class="row row-sm">
-            <div class="col-4 padding-sm">
-              <h5>Informations générales sur le taxon</h5>
-              <table class="font-xs table table-striped table-sm">
-                <tr>
-                  <td>Nombre de données valides</td>
-                  <td>{{ profile?.properties?.count_valid_data }}</td>
-                </tr>
-                <tr>
-                  <td>Altitude minimale valide</td>
-                  <td>{{ profile?.properties?.altitude_min }}</td>
-                </tr>
-                <tr>
-                  <td>Altitude maximale valide</td>
-                  <td>{{ profile?.properties?.altitude_max }}</td>
-                </tr>
+      <ng-container *ngSwitchCase="'zonage'">
+        <table class="font-xs table table-striped table-sm">
+          <thead>
+            <tr>
+              <th class="table_date">Type de zonage</th>
+              <th class="table_comment">Zones</th>
+            </tr>
+          </thead>
 
-                <tr>
-                  <td>Première observation valide</td>
-                  <td>{{ profile?.properties?.first_valid_data | date: 'dd/MM/yyyy' }}</td>
-                </tr>
-                <tr>
-                  <td>Dernière observation valide</td>
-                  <td>{{ profile?.properties?.last_valid_data | date: 'dd/MM/yyyy' }}</td>
-                </tr>
-              </table>
+          <tbody>
+            <tr *ngFor="let area_type of formatedAreas">
+              <td>
+                {{ area_type.area_type }}
+              </td>
+              <td>
+                <span
+                  data-qa="synthese-obs-detail-area"
+                  *ngFor="let area of area_type.areas; let index = index"
+                >
+                  {{ area.area_name }}
+                  <span *ngIf="index < area_type.areas.length - 1">,</span>
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </ng-container>
 
-              <h5>Cohérence de la donnée</h5>
-              <table class="font-xs table table-sm table-striped">
-                <tr>
-                  <td>Dans l'aire d'observation valide</td>
-                  <td *ngIf="profileDataChecks?.valid_distribution">
-                    <mat-icon class="success">check</mat-icon>
-                  </td>
-                  <td *ngIf="!profileDataChecks?.valid_distribution">
-                    <mat-icon class="error">close</mat-icon>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Cohérence phénologique</td>
-                  <td *ngIf="profileDataChecks?.valid_phenology">
-                    <mat-icon class="success">check</mat-icon>
-                  </td>
-                  <td *ngIf="!profileDataChecks?.valid_phenology">
-                    <mat-icon class="error">close</mat-icon>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Dans la fourchette altitudinale valide</td>
-                  <td *ngIf="profileDataChecks?.valid_altitude">
-                    <mat-icon class="success">check</mat-icon>
-                  </td>
-                  <td *ngIf="!profileDataChecks?.valid_altitude">
-                    <mat-icon class="error">close</mat-icon>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Score</td>
-                  <td>{{ profileDataChecks?.score }}</td>
-                </tr>
-              </table>
+      <ng-container *ngSwitchCase="'validation'">
+        <div *ngIf="showValidation">
+          <h3 data-qa="synthese-obs-detail-validation-title">
+            Historique de validation de la donnée
+          </h3>
+
+          <table class="font-xs table table-striped table-sm">
+            <thead>
+              <tr>
+                <th class="table_date">Date de validation</th>
+                <th class="table_status">Statut</th>
+                <th class="table_comment">Validateur</th>
+                <th class="table_comment">Commentaire</th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <tr *ngFor="let row of validationHistory">
+                <td width="15%">{{ row.date }}</td>
+                <td width="20%">
+                  <span
+                    class="validationCircle"
+                    [ngStyle]="{ background: validationColor[row.cd_nomenclature] }"
+                  >
+                    <mat-icon
+                      *ngIf="row.typeValidation == 'True'"
+                      class="computer"
+                    >
+                      computer
+                    </mat-icon>
+                  </span>
+                  <span
+                    class="statusName"
+                    class="ml-4"
+                  >
+                    {{ row.label_default }}
+                  </span>
+                </td>
+                <td width="20%">
+                  <span>{{ row.validator }}</span>
+                </td>
+                <td>{{ row.comment }}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div *ngIf="config.FRONTEND.ENABLE_PROFILES">
+            <div *ngIf="profile; else noProfile">
+              <h3>Profil du taxon</h3>
+              <div class="row row-sm">
+                <div class="col-4 padding-sm">
+                  <h5>Informations générales sur le taxon</h5>
+                  <table class="font-xs table table-striped table-sm">
+                    <tr>
+                      <td>Nombre de données valides</td>
+                      <td>{{ profile?.properties?.count_valid_data }}</td>
+                    </tr>
+                    <tr>
+                      <td>Altitude minimale valide</td>
+                      <td>{{ profile?.properties?.altitude_min }}</td>
+                    </tr>
+                    <tr>
+                      <td>Altitude maximale valide</td>
+                      <td>{{ profile?.properties?.altitude_max }}</td>
+                    </tr>
+
+                    <tr>
+                      <td>Première observation valide</td>
+                      <td>{{ profile?.properties?.first_valid_data | date: 'dd/MM/yyyy' }}</td>
+                    </tr>
+                    <tr>
+                      <td>Dernière observation valide</td>
+                      <td>{{ profile?.properties?.last_valid_data | date: 'dd/MM/yyyy' }}</td>
+                    </tr>
+                  </table>
+
+                  <h5>Cohérence de la donnée</h5>
+                  <table class="font-xs table table-sm table-striped">
+                    <tr>
+                      <td>Dans l'aire d'observation valide</td>
+                      <td *ngIf="profileDataChecks?.valid_distribution">
+                        <mat-icon class="success">check</mat-icon>
+                      </td>
+                      <td *ngIf="!profileDataChecks?.valid_distribution">
+                        <mat-icon class="error">close</mat-icon>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Cohérence phénologique</td>
+                      <td *ngIf="profileDataChecks?.valid_phenology">
+                        <mat-icon class="success">check</mat-icon>
+                      </td>
+                      <td *ngIf="!profileDataChecks?.valid_phenology">
+                        <mat-icon class="error">close</mat-icon>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Dans la fourchette altitudinale valide</td>
+                      <td *ngIf="profileDataChecks?.valid_altitude">
+                        <mat-icon class="success">check</mat-icon>
+                      </td>
+                      <td *ngIf="!profileDataChecks?.valid_altitude">
+                        <mat-icon class="error">close</mat-icon>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Score</td>
+                      <td>{{ profileDataChecks?.score }}</td>
+                    </tr>
+                  </table>
+                </div>
+              </div>
+            </div>
+
+            <h5>Aire de répartition des observations valides</h5>
+            <div class="mb-3 border border-secondary">
+              <pnx-map height="40vh">
+                <pnx-geojson
+                  [geojson]="selectedGeom"
+                  [style]="{ color: 'red' }"
+                ></pnx-geojson>
+                <pnx-geojson
+                  [geojson]="profile"
+                  [zoomOnFirstTime]="true"
+                ></pnx-geojson>
+              </pnx-map>
             </div>
           </div>
+          <ng-template #noProfile>
+            <span class="alert alert-info">Pas de profil pour ce taxon</span>
+            <br />
+            <br />
+          </ng-template>
         </div>
+      </ng-container>
 
-        <h5>Aire de répartition des observations valides</h5>
-        <div class="mb-3 border border-secondary">
-          <pnx-map height="40vh">
-            <pnx-geojson
-              [geojson]="selectedGeom"
-              [style]="{ color: 'red' }"
-            ></pnx-geojson>
-            <pnx-geojson
-              [geojson]="profile"
-              [zoomOnFirstTime]="true"
-            ></pnx-geojson>
-          </pnx-map>
-        </div>
-      </div>
-      <ng-template #noProfile>
-        <span class="alert alert-info">Pas de profil pour ce taxon</span>
-        <br />
-        <br />
-      </ng-template>
-    </div>
-  </mat-tab>
-
-  <mat-tab
-    label="{{ 'Synthese.Discussion' | translate }}"
-    *ngIf="config.SYNTHESE.DISCUSSION_MODULES.includes(moduleInfos.code)"
-  >
-    <pnx-discussion-card
-      [validationColor]="validationColor"
-      [idSynthese]="idSynthese"
-      [codeModule]="moduleInfos.code"
-      [additionalData]="{ data: validationHistory, dateField: 'dateTime' }"
-    ></pnx-discussion-card>
+      <ng-container
+        *ngIf="
+          config.SYNTHESE.DISCUSSION_MODULES.includes(moduleInfos.code) && tab.path === 'discussion'
+        "
+      >
+        <!-- <ng-template mat-tab-label>
+    <span>{{ tabLabels['discussion']  | translate }}</span>
+  </ng-template> -->
+        <pnx-discussion-card
+          [validationColor]="validationColor"
+          [idSynthese]="idSynthese"
+          [codeModule]="moduleInfos.code"
+          [additionalData]="{ data: validationHistory, dateField: 'dateTime' }"
+        ></pnx-discussion-card>
+      </ng-container>
+    </ng-container>
   </mat-tab>
 </mat-tab-group>

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.html
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.html
@@ -37,7 +37,7 @@
     >
       <button
         class="btn btn-outline-shadow btn-no-padding btn-ghost"
-        (click)="openInfoModal(row)"
+        [routerLink]="['occurrence', row['id_synthese'], 'details']"
       >
         <i
           #iElement

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.ts
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.ts
@@ -24,6 +24,7 @@ import { CruvedStoreService } from '@geonature_common/service/cruved-store.servi
 import { SyntheseInfoObsComponent } from '@geonature/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component';
 import { ConfigService } from '@geonature/services/config.service';
 import { FormArray, FormControl } from '@angular/forms';
+import { Router } from '@angular/router';
 @Component({
   selector: 'pnx-synthese-list',
   templateUrl: 'synthese-list.component.html',
@@ -53,7 +54,8 @@ export class SyntheseListComponent implements OnInit, OnChanges, AfterContentChe
     public sanitizer: DomSanitizer,
     public ref: ChangeDetectorRef,
     public _cruvedStore: CruvedStoreService,
-    public config: ConfigService
+    public config: ConfigService,
+    private _router: Router
   ) {
     this.SYNTHESE_CONFIG = this.config.SYNTHESE;
   }
@@ -151,6 +153,8 @@ export class SyntheseListComponent implements OnInit, OnChanges, AfterContentChe
     link.remove();
   }
 
+  // TODO: cette method peut être supprimé car redondante avec celle appelée dans syntheseComponent  https://github.com/PnX-SI/GeoNature/blob/a6a9c05acfa8a0a2f7aecbb70e6deacdb250b2c4/frontend/src/app/syntheseModule/synthese.component.ts#L222
+  //  car le composant est monté via la route /occurence/:id_synthese/:tab
   openInfoModal(row) {
     row.id_synthese = row.id_synthese;
     const modalRef = this.ngbModal.open(SyntheseInfoObsComponent, {

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.ts
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.ts
@@ -153,19 +153,6 @@ export class SyntheseListComponent implements OnInit, OnChanges, AfterContentChe
     link.remove();
   }
 
-  // TODO: cette method peut être supprimé car redondante avec celle appelée dans syntheseComponent  https://github.com/PnX-SI/GeoNature/blob/a6a9c05acfa8a0a2f7aecbb70e6deacdb250b2c4/frontend/src/app/syntheseModule/synthese.component.ts#L222
-  //  car le composant est monté via la route /occurence/:id_synthese/:tab
-  openInfoModal(row) {
-    row.id_synthese = row.id_synthese;
-    const modalRef = this.ngbModal.open(SyntheseInfoObsComponent, {
-      size: 'lg',
-      windowClass: 'large-modal',
-    });
-    modalRef.componentInstance.idSynthese = row.id_synthese;
-    modalRef.componentInstance.header = true;
-    modalRef.componentInstance.useFrom = 'synthese';
-  }
-
   openModalCol($event, modal) {
     this.ngbModal.open(modal);
   }

--- a/frontend/src/app/syntheseModule/synthese.component.html
+++ b/frontend/src/app/syntheseModule/synthese.component.html
@@ -57,3 +57,4 @@
     </div>
   </div>
 </div>
+<router-outlet></router-outlet>

--- a/frontend/src/app/syntheseModule/synthese.component.ts
+++ b/frontend/src/app/syntheseModule/synthese.component.ts
@@ -7,7 +7,7 @@ import { SyntheseFormService } from '@geonature_common/form/synthese-form/synthe
 import { SyntheseStoreService } from './services/store.service';
 import { SyntheseModalDownloadComponent } from './synthese-results/synthese-list/modal-download/modal-download.component';
 import { ToastrService } from 'ngx-toastr';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { SyntheseInfoObsComponent } from '../shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component';
 import * as cloneDeep from 'lodash/cloneDeep';
 import { EventToggle } from './synthese-results/synthese-carte/synthese-carte.component';
@@ -36,7 +36,8 @@ export class SyntheseComponent implements OnInit {
     private _route: ActivatedRoute,
     private _ngModal: NgbModal,
     private _changeDetector: ChangeDetectorRef,
-    public config: ConfigService
+    public config: ConfigService,
+    private _router: Router
   ) {}
 
   ngOnInit() {
@@ -227,6 +228,17 @@ export class SyntheseComponent implements OnInit {
     modalRef.componentInstance.idSynthese = idSynthese;
     modalRef.componentInstance.header = true;
     modalRef.componentInstance.useFrom = 'synthese';
+
+    let tabRoute = this._route.snapshot.paramMap.get('tab');
+    if (tabRoute != null) {
+      modalRef.componentInstance.selectedTab = tabRoute;
+    }
+
+    modalRef.result
+      .then((result) => {})
+      .catch((_) => {
+        this._router.navigate([modalRef.componentInstance.useFrom]);
+      });
   }
 
   mooveButton() {

--- a/frontend/src/app/syntheseModule/synthese.module.ts
+++ b/frontend/src/app/syntheseModule/synthese.module.ts
@@ -16,16 +16,21 @@ import { SyntheseModalDownloadComponent } from './synthese-results/synthese-list
 import { DiscussionCardComponent } from '@geonature/shared/discussionCardModule/discussion-card.component';
 import { AlertInfoComponent } from '../shared/alertInfoModule/alert-Info.component';
 import { TaxonSheetComponent } from './taxon-sheet/taxon-sheet.component';
+import { NgbActiveModal, NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { SyntheseObsModalWrapperComponent } from '@geonature/shared/syntheseSharedModule/synthese-info-obs-container.component';
+import { BrowserModule } from '@angular/platform-browser';
 const routes: Routes = [
-  { path: '', component: SyntheseComponent },
   {
-    path: 'occurrence/:id_synthese/:tab',
+    path: '',
     component: SyntheseComponent,
-  },
-  {
-    path: 'occurrence/:id_synthese',
-    redirectTo: 'occurrence/:id_synthese/details',
-    pathMatch: 'full',
+    children: [
+      {
+        path: 'occurrence/:id_synthese',
+        redirectTo: 'occurrence/:id_synthese/details',
+        pathMatch: 'full',
+      },
+      { path: 'occurrence/:id_synthese/:tab', component: SyntheseObsModalWrapperComponent },
+    ],
   },
   { path: 'taxon/:cd_nom', component: TaxonSheetComponent },
 ];
@@ -37,6 +42,7 @@ const routes: Routes = [
     SharedSyntheseModule,
     CommonModule,
     TreeModule,
+    NgbModule,
   ],
   declarations: [
     SyntheseComponent,
@@ -46,11 +52,19 @@ const routes: Routes = [
     TaxonSheetComponent,
   ],
   entryComponents: [
+    SyntheseComponent,
     SyntheseInfoObsComponent,
     SyntheseModalDownloadComponent,
     DiscussionCardComponent,
     AlertInfoComponent,
+    SyntheseObsModalWrapperComponent,
   ],
-  providers: [MapService, DynamicFormService, TaxonAdvancedStoreService, SyntheseFormService],
+  providers: [
+    MapService,
+    DynamicFormService,
+    TaxonAdvancedStoreService,
+    SyntheseFormService,
+    NgbActiveModal,
+  ],
 })
 export class SyntheseModule {}

--- a/frontend/src/app/syntheseModule/synthese.module.ts
+++ b/frontend/src/app/syntheseModule/synthese.module.ts
@@ -1,54 +1,53 @@
-import { NgModule } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { Routes, RouterModule } from "@angular/router";
-import { GN2CommonModule } from "@geonature_common/GN2Common.module";
-import { SyntheseComponent } from "./synthese.component";
-import { SyntheseListComponent } from "./synthese-results/synthese-list/synthese-list.component";
-import { SyntheseCarteComponent } from "./synthese-results/synthese-carte/synthese-carte.component";
-import { SyntheseFormService } from "@geonature_common/form/synthese-form/synthese-form.service";
-import { MapService } from "@geonature_common/map/map.service";
-import { TreeModule } from "@circlon/angular-tree-component";
-import { DynamicFormService } from "@geonature_common/form/dynamic-form-generator/dynamic-form.service";
-import { TaxonAdvancedStoreService } from "@geonature_common/form/synthese-form/advanced-form/synthese-advanced-form-store.service";
-import { SharedSyntheseModule } from "@geonature/shared/syntheseSharedModule/synthese-shared.module";
-import { SyntheseInfoObsComponent } from "@geonature/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component";
-import { SyntheseModalDownloadComponent } from "./synthese-results/synthese-list/modal-download/modal-download.component";
-import { DiscussionCardComponent } from "@geonature/shared/discussionCardModule/discussion-card.component";
-import { AlertInfoComponent } from "../shared/alertInfoModule/alert-Info.component";
-import { TaxonSheetComponent } from "./taxon-sheet/taxon-sheet.component";
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { GN2CommonModule } from '@geonature_common/GN2Common.module';
+import { SyntheseComponent } from './synthese.component';
+import { SyntheseListComponent } from './synthese-results/synthese-list/synthese-list.component';
+import { SyntheseCarteComponent } from './synthese-results/synthese-carte/synthese-carte.component';
+import { SyntheseFormService } from '@geonature_common/form/synthese-form/synthese-form.service';
+import { MapService } from '@geonature_common/map/map.service';
+import { TreeModule } from '@circlon/angular-tree-component';
+import { DynamicFormService } from '@geonature_common/form/dynamic-form-generator/dynamic-form.service';
+import { TaxonAdvancedStoreService } from '@geonature_common/form/synthese-form/advanced-form/synthese-advanced-form-store.service';
+import { SharedSyntheseModule } from '@geonature/shared/syntheseSharedModule/synthese-shared.module';
+import { SyntheseInfoObsComponent } from '@geonature/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component';
+import { SyntheseModalDownloadComponent } from './synthese-results/synthese-list/modal-download/modal-download.component';
+import { DiscussionCardComponent } from '@geonature/shared/discussionCardModule/discussion-card.component';
+import { AlertInfoComponent } from '../shared/alertInfoModule/alert-Info.component';
+import { TaxonSheetComponent } from './taxon-sheet/taxon-sheet.component';
 import {
   RouteService,
   ALL_TAXON_SHEET_ADVANCED_INFOS_ROUTES,
   ROUTE_MANDATORY,
-} from "./taxon-sheet/taxon-sheet.route.service";
-import { NgbActiveModal, NgbModule } from "@ng-bootstrap/ng-bootstrap";
-import { SyntheseObsModalWrapperComponent } from "@geonature/shared/syntheseSharedModule/synthese-info-obs-container.component";
-import { BrowserModule } from "@angular/platform-browser";
+} from './taxon-sheet/taxon-sheet.route.service';
+import { NgbActiveModal, NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { SyntheseObsModalWrapperComponent } from '@geonature/shared/syntheseSharedModule/synthese-info-obs-container.component';
 const routes: Routes = [
   {
-    path: "",
+    path: '',
     component: SyntheseComponent,
     children: [
       {
-        path: "occurrence/:id_synthese",
-        redirectTo: "occurrence/:id_synthese/details",
-        pathMatch: "full",
+        path: 'occurrence/:id_synthese',
+        redirectTo: 'occurrence/:id_synthese/details',
+        pathMatch: 'full',
       },
       {
-        path: "occurrence/:id_synthese/:tab",
+        path: 'occurrence/:id_synthese/:tab',
         component: SyntheseObsModalWrapperComponent,
       },
     ],
   },
   {
-    path: "taxon/:cd_ref",
+    path: 'taxon/:cd_ref',
     component: TaxonSheetComponent,
     canActivateChild: [RouteService],
     children: [
       {
-        path: "",
+        path: '',
         redirectTo: ROUTE_MANDATORY.path,
-        pathMatch: "prefix",
+        pathMatch: 'prefix',
       },
       ...ALL_TAXON_SHEET_ADVANCED_INFOS_ROUTES.map((tab) => {
         return {

--- a/frontend/src/app/syntheseModule/synthese.module.ts
+++ b/frontend/src/app/syntheseModule/synthese.module.ts
@@ -18,7 +18,15 @@ import { AlertInfoComponent } from '../shared/alertInfoModule/alert-Info.compone
 import { TaxonSheetComponent } from './taxon-sheet/taxon-sheet.component';
 const routes: Routes = [
   { path: '', component: SyntheseComponent },
-  { path: 'occurrence/:id_synthese', component: SyntheseComponent, pathMatch: 'full' },
+  {
+    path: 'occurrence/:id_synthese/:tab',
+    component: SyntheseComponent,
+  },
+  {
+    path: 'occurrence/:id_synthese',
+    redirectTo: 'occurrence/:id_synthese/details',
+    pathMatch: 'full',
+  },
   { path: 'taxon/:cd_nom', component: TaxonSheetComponent },
 ];
 


### PR DESCRIPTION
- Manage dynamic tabs displayed (using tabs object with path and label)
- Add route 'occurrence/:id_synthese/:tab'
- Add manage event when modal is closed (go back to module 'synthese')
- Apply lint frontend
- Add "TODO" --> delete openInfoModal in syntheseListComponent because using routerLink to openModal

Concernant le TODO, pour moi on peut tout simplement supprimer la method "openInfoModal" vu qu'on utilise dans les devs proposés une manière plus classique à savoir l'utilisation du routerLink.

[Refs_Issue] : #3155 

Reviewed-by: andriacap