### PR TITLE
Feat/refine species page

### DIFF
--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -957,6 +957,82 @@ def general_stats(permissions):
     return data
 
 
+@routes.route("/species_stats/<int:cd_ref>", methods=["GET"])
+@permissions.check_cruved_scope("R", get_scope=True, module_code="SYNTHESE")
+@json_resp
+def species_stats(scope, cd_ref):
+    """Return stats about distinct species."""
+
+    area_type = request.args.get("area_type")
+
+    if not area_type:
+        raise BadRequest("Missing area_type parameter")
+
+    # Ensure area_type is valid
+    valid_area_types = (
+        db.session.query(BibAreasTypes.type_code)
+        .distinct()
+        .filter(BibAreasTypes.type_code == area_type)
+        .scalar()
+    )
+    if not valid_area_types:
+        raise BadRequest("Invalid area_type")
+
+    # Subquery to fetch areas based on area_type
+    areas_subquery = (
+        select([LAreas.id_area])
+        .where(LAreas.id_type == BibAreasTypes.id_type)
+        .where(BibAreasTypes.type_code == area_type)
+        .alias("areas")
+    )
+
+    taxref_cd_nom_list = db.session.scalars(select(Taxref.cd_nom).where(Taxref.cd_ref == cd_ref))
+
+    # Main query to fetch stats
+    query = (
+        select(
+            [
+                func.count(distinct(Synthese.id_synthese)).label("observation_count"),
+                func.count(distinct(Synthese.observers)).label("observer_count"),
+                func.count(distinct(areas_subquery.c.id_area)).label("area_count"),
+                func.min(Synthese.altitude_min).label("altitude_min"),
+                func.max(Synthese.altitude_max).label("altitude_max"),
+                func.min(Synthese.date_min).label("date_min"),
+                func.max(Synthese.date_max).label("date_max"),
+            ]
+        )
+        .select_from(
+            sa.join(
+                Synthese,
+                CorAreaSynthese,
+                Synthese.id_synthese == CorAreaSynthese.id_synthese,
+            )
+            .join(areas_subquery, CorAreaSynthese.id_area == areas_subquery.c.id_area)
+            .join(LAreas, CorAreaSynthese.id_area == LAreas.id_area)
+            .join(BibAreasTypes, LAreas.id_type == BibAreasTypes.id_type)
+        )
+        .where(Synthese.cd_nom.in_(taxref_cd_nom_list))
+    )
+
+    synthese_query_obj = SyntheseQuery(Synthese, query, {})
+    synthese_query_obj.filter_query_with_cruved(g.current_user, scope)
+    result = DB.session.execute(synthese_query_obj.query)
+    synthese_stats = result.fetchone()
+
+    data = {
+        "cd_ref": cd_ref,
+        "observation_count": synthese_stats["observation_count"],
+        "observer_count": synthese_stats["observer_count"],
+        "area_count": synthese_stats["area_count"],
+        "altitude_min": synthese_stats["altitude_min"],
+        "altitude_max": synthese_stats["altitude_max"],
+        "date_min": synthese_stats["date_min"],
+        "date_max": synthese_stats["date_max"],
+    }
+
+    return data
+
+
 @routes.route("/taxons_tree", methods=["GET"])
 @login_required
 @json_resp

--- a/backend/geonature/core/gn_synthese/synthese_config.py
+++ b/backend/geonature/core/gn_synthese/synthese_config.py
@@ -100,3 +100,77 @@ DEFAULT_LIST_COLUMN = [
     {"prop": "dataset_name", "name": "JDD", "max_width": 200},
     {"prop": "observers", "name": "observateur", "max_width": 200},
 ]
+
+
+class DefaultProfile:
+    ENABLED = True
+    ## DEFAULT PROFILE INDICATORS
+    LIST_INDICATORS = [
+        {
+            "name": "observation(s) valide(s)",
+            "matIcon": "search",
+            "field": "count_valid_data",
+            "type": "number",
+        },
+        {
+            "name": "Première observation",
+            "matIcon": "schedule",
+            "field": "first_valid_data",
+            "type": "date",
+        },
+        {
+            "name": "Dernière observation",
+            "matIcon": "search",
+            "field": "last_valid_data",
+            "type": "date",
+        },
+        {
+            "name": "Plage d'altitude(s)",
+            "matIcon": "terrain",
+            "field": ["altitude_min", "altitude_max"],
+            "unit": "m",
+            "type": "number",
+        },
+    ]
+
+
+class DefaultGeographicOverview:
+    pass
+
+
+class DefaultSpeciesSheet:
+    ## DEFAULT SPECIES SHEET INDICATORS
+    LIST_INDICATORS = [
+        {
+            "name": "observation(s)",
+            "matIcon": "search",
+            "field": "observation_count",
+            "type": "number",
+        },
+        {
+            "name": "observateur(s)",
+            "matIcon": "people",
+            "field": "observer_count",
+            "type": "number",
+        },
+        {
+            "name": "commune(s)",
+            "matIcon": "location_on",
+            "field": "area_count",
+            "type": "number",
+        },
+        {
+            "name": "Plage d'altitude(s)",
+            "matIcon": "terrain",
+            "unit": "m",
+            "type": "number",
+            "field": ["altitude_min", "altitude_max"],
+        },
+        {
+            "name": "Plage d'observation(s)",
+            "matIcon": "date_range",
+            "type": "date",
+            "field": ["date_min", "date_max"],
+            "separator": "-",
+        },
+    ]

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -21,6 +21,9 @@ from marshmallow.validate import OneOf, Regexp, Email, Length
 from geonature.core.gn_synthese.synthese_config import (
     DEFAULT_EXPORT_COLUMNS,
     DEFAULT_LIST_COLUMN,
+    DefaultGeographicOverview,
+    DefaultProfile,
+    DefaultSpeciesSheet,
 )
 from geonature.utils.env import GEONATURE_VERSION, BACKEND_DIR, ROOT_DIR
 from geonature.utils.module import iter_modules_dist, get_module_config
@@ -274,6 +277,26 @@ class ExportObservationSchema(Schema):
     geojson_local_field = fields.String(load_default="geojson_local")
 
 
+class SpeciesSheetProfile(Schema):
+    ENABLED = fields.Boolean(load_default=DefaultProfile.ENABLED)
+    LIST_INDICATORS = fields.List(fields.Dict, load_default=DefaultProfile.LIST_INDICATORS)
+
+
+class SpeciesSheetGeographicOverview(Schema):
+    pass
+
+
+class SpeciesSheet(Schema):
+    # --------------------------------------------------------------------
+    # SYNTHESE - SPECIES_SHEET
+    LIST_INDICATORS = fields.List(fields.Dict, load_default=DefaultSpeciesSheet.LIST_INDICATORS)
+
+    GEOGRAPHIC_OVERVIEW = fields.Dict(
+        load_default=SpeciesSheetGeographicOverview().load({})
+    )  # rename
+    PROFILE = fields.Nested(SpeciesSheetProfile, load_default=SpeciesSheetProfile().load({}))
+
+
 class Synthese(Schema):
     # --------------------------------------------------------------------
     # SYNTHESE - SEARCH FORM
@@ -427,6 +450,10 @@ class Synthese(Schema):
     )
     # Activate the blurring of sensitive observations. Otherwise, exclude them
     BLUR_SENSITIVE_OBSERVATIONS = fields.Boolean(load_default=True)
+
+    # --------------------------------------------------------------------
+    # SYNTHESE - SPECIES_SHEET
+    SPECIES_SHEET = fields.Nested(SpeciesSheet, load_default=SpeciesSheet().load({}))
 
     @pre_load
     def warn_deprecated(self, data, **kwargs):

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -17,6 +17,8 @@ export interface ParamsDict {
   [key: string]: any;
 }
 
+export type Profile = GeoJSON.Feature;
+
 export const FormatMapMime = new Map([
   ['csv', 'text/csv'],
   ['json', 'application/json'],
@@ -642,8 +644,10 @@ export class DataFormService {
     return this._http.get<any>(`${this.config.API_TAXHUB}/bdc_statuts/status_values/${statusType}`);
   }
 
-  getProfile(cdRef) {
-    return this._http.get<any>(`${this.config.API_ENDPOINT}/gn_profiles/valid_profile/${cdRef}`);
+  getProfile(cdRef): Observable<Profile> {
+    return this._http.get<Profile>(
+      `${this.config.API_ENDPOINT}/gn_profiles/valid_profile/${cdRef}`
+    );
   }
 
   getPhenology(cdRef, idNomenclatureLifeStage?) {

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
@@ -55,6 +55,12 @@ export class SyntheseDataService {
     return this._api.get<any>(`${this.config.API_ENDPOINT}/synthese/general_stats`);
   }
 
+  getSyntheseSpeciesSheetStat(cd_ref: number, areaType: string = 'COM') {
+    return this._api.get<any>(`${this.config.API_ENDPOINT}/synthese/species_stats/${cd_ref}`, {
+      params: new HttpParams().append('area_type', areaType),
+    });
+  }
+
   getTaxaCount(params = {}) {
     let queryString = new HttpParams();
     for (let key in params) {

--- a/frontend/src/app/syntheseModule/synthese.module.ts
+++ b/frontend/src/app/syntheseModule/synthese.module.ts
@@ -16,10 +16,33 @@ import { SyntheseModalDownloadComponent } from './synthese-results/synthese-list
 import { DiscussionCardComponent } from '@geonature/shared/discussionCardModule/discussion-card.component';
 import { AlertInfoComponent } from '../shared/alertInfoModule/alert-Info.component';
 import { TaxonSheetComponent } from './taxon-sheet/taxon-sheet.component';
+import {
+  RouteService,
+  ALL_TAXON_SHEET_ADVANCED_INFOS_ROUTES,
+  ROUTE_MANDATORY,
+} from './taxon-sheet/taxon-sheet.route.service';
+
 const routes: Routes = [
   { path: '', component: SyntheseComponent },
   { path: 'occurrence/:id_synthese', component: SyntheseComponent, pathMatch: 'full' },
-  { path: 'taxon/:cd_nom', component: TaxonSheetComponent },
+  {
+    path: 'taxon/:cd_ref',
+    component: TaxonSheetComponent,
+    canActivateChild: [RouteService],
+    children: [
+      {
+        path: '',
+        redirectTo: ROUTE_MANDATORY.path,
+        pathMatch: 'prefix',
+      },
+      ...ALL_TAXON_SHEET_ADVANCED_INFOS_ROUTES.map((tab) => {
+        return {
+          path: tab.path,
+          component: tab.component,
+        };
+      }),
+    ],
+  },
 ];
 
 @NgModule({
@@ -29,13 +52,13 @@ const routes: Routes = [
     SharedSyntheseModule,
     CommonModule,
     TreeModule,
+    TaxonSheetComponent,
   ],
   declarations: [
     SyntheseComponent,
     SyntheseListComponent,
     SyntheseCarteComponent,
     SyntheseModalDownloadComponent,
-    TaxonSheetComponent,
   ],
   entryComponents: [
     SyntheseInfoObsComponent,
@@ -43,6 +66,12 @@ const routes: Routes = [
     DiscussionCardComponent,
     AlertInfoComponent,
   ],
-  providers: [MapService, DynamicFormService, TaxonAdvancedStoreService, SyntheseFormService],
+  providers: [
+    MapService,
+    DynamicFormService,
+    TaxonAdvancedStoreService,
+    SyntheseFormService,
+    RouteService,
+  ],
 })
 export class SyntheseModule {}

--- a/frontend/src/app/syntheseModule/taxon-sheet/indicator/indicator.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/indicator/indicator.component.html
@@ -1,0 +1,5 @@
+<div [className]="small ? 'card Indicator Indicator--small' : 'card Indicator'">
+  <mat-icon class="Indicator__icon">{{ indicator.matIcon }}</mat-icon>
+  <span class="Indicator__value">{{ indicator.value }}</span>
+  <span class="Indicator__name text-secondary">{{ indicator.name }}</span>
+</div>

--- a/frontend/src/app/syntheseModule/taxon-sheet/indicator/indicator.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/indicator/indicator.component.scss
@@ -1,0 +1,47 @@
+.Indicator {
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  justify-content: center;
+  row-gap: 0rem;
+  padding: 1rem;
+  height: 9rem;
+  width: auto;
+  min-width: 12rem;
+  &__icon {
+    $icon-size: 2rem;
+    font-size: $icon-size;
+    height: $icon-size;
+    width: $icon-size;
+    min-height: $icon-size;
+  }
+  &__value {
+    font-size: 1.5rem;
+    white-space: nowrap;
+    &Unit {
+      opacity: 0.5;
+    }
+  }
+  &__name {
+    font-size: 1rem;
+    text-align: center;
+  }
+}
+
+.Indicator--small {
+  border: none;
+  height: auto;
+  .Indicator__icon {
+    $icon-size: 1.5rem;
+    font-size: $icon-size;
+    height: $icon-size;
+    width: $icon-size;
+    min-height: $icon-size;
+  }
+  .Indicator__value {
+    font-size: 1.3rem;
+  }
+  .Indicator__name {
+    font-size: 1rem;
+  }
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/indicator/indicator.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/indicator/indicator.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { Indicator } from './indicator';
+
+@Component({
+  standalone: true,
+  selector: 'indicator',
+  templateUrl: 'indicator.component.html',
+  styleUrls: ['indicator.component.scss'],
+  imports: [MatIconModule],
+})
+export class IndicatorComponent {
+  @Input()
+  indicator: Indicator;
+
+  @Input()
+  small: boolean = false;
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/indicator/indicator.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/indicator/indicator.ts
@@ -1,0 +1,60 @@
+type IndicatorRawType = 'number' | 'string' | 'date';
+export interface IndicatorRaw {
+  name: string;
+  matIcon: string;
+  field: string | Array<string>;
+  unit?: string;
+  type: IndicatorRawType;
+}
+
+export interface Indicator {
+  name: string;
+  matIcon: string;
+  value: string | null;
+}
+
+type Stats = Record<string, string>;
+
+const DEFAULT_VALUE = '-';
+const DEFAULT_SEPARATOR = '-';
+
+function getValue(field: string, indicatorConfig: IndicatorRaw, stats?: Stats) {
+  if (stats && stats[field]) {
+    let valueAsString = '';
+    switch (indicatorConfig.type) {
+      case 'number':
+        valueAsString = stats[field].toLocaleString();
+        break;
+      case 'date':
+        valueAsString = new Date(stats[field]).toLocaleDateString();
+        break;
+      case 'string':
+      default:
+        valueAsString = stats[field];
+    }
+    return valueAsString + (indicatorConfig.unit ?? '');
+  }
+  return DEFAULT_VALUE;
+}
+
+export function computeIndicatorFromConfig(
+  indicatorConfig: IndicatorRaw,
+  stats?: Stats
+): Indicator {
+  let value = DEFAULT_VALUE;
+  if (stats) {
+    if (Array.isArray(indicatorConfig.field)) {
+      const separator = indicatorConfig['separator'] ?? DEFAULT_SEPARATOR;
+      value = indicatorConfig.field
+        .map((field) => getValue(field, indicatorConfig, stats))
+        .join(' ' + separator + ' ');
+    } else {
+      value = getValue(indicatorConfig.field, indicatorConfig, stats);
+    }
+  }
+  return {
+    name: indicatorConfig.name,
+    matIcon: indicatorConfig.matIcon,
+    value: value,
+  };
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/infos.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/infos.component.html
@@ -1,0 +1,25 @@
+<div class="Infos">
+  <div class="Infos__infos">
+    <div
+      class="Infos__infosCompleteName"
+      *ngIf="taxon?.nom_complet"
+    >
+      {{ taxon?.nom_complet }}
+    </div>
+    <div
+      class="Infos__infosVernacularName"
+      *ngIf="taxon?.nom_vern"
+    >
+      {{ taxon?.nom_vern }}
+    </div>
+  </div>
+</div>
+<div
+  class="card"
+  *ngIf="mediaUrl"
+>
+  <div
+    class="card-body cover image"
+    [style.background-image]="'url(' + mediaUrl + ')'"
+  ></div>
+</div>

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/infos.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/infos.component.scss
@@ -1,0 +1,19 @@
+.Infos {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
+  column-gap: 1rem;
+
+  &__infos {
+    display: flex;
+    flex-flow: column;
+    &CompleteName {
+      font-weight: lighter;
+      font-style: italic;
+    }
+    &VernacularName {
+      font-size: 1.5rem;
+      font-weight: bold;
+    }
+  }
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/infos.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/infos.component.ts
@@ -1,0 +1,41 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
+import { DataFormService } from '@geonature_common/form/data-form.service';
+import { ConfigService } from '@geonature/services/config.service';
+import { TaxonSheetService } from '../taxon-sheet.service';
+
+@Component({
+  standalone: true,
+  selector: 'infos',
+  templateUrl: 'infos.component.html',
+  styleUrls: ['infos.component.scss'],
+  imports: [CommonModule],
+})
+export class InfosComponent implements OnInit {
+  mediaUrl: string;
+  taxon: Taxon | null = null;
+
+  constructor(
+    private _config: ConfigService,
+    private _ds: DataFormService,
+    private _tss: TaxonSheetService
+  ) {}
+
+  ngOnInit() {
+    this._tss.taxon.subscribe((taxon: Taxon | null) => {
+      this.taxon = taxon;
+      if (!this.taxon) {
+        return;
+      }
+      this._ds.getTaxonAttributsAndMedia(this.taxon.cd_ref).subscribe((taxonAttrAndMedias) => {
+        const media = taxonAttrAndMedias.medias.find(
+          (m) => m.id_type == this._config['TAXHUB']['ID_TYPE_MAIN_PHOTO']
+        );
+        if (media) {
+          this.mediaUrl = `${this._config.API_TAXHUB}/tmedias/thumbnail/${media.id_media}?h=300&w300`;
+        }
+      });
+    });
+  }
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/layout/layout.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/layout/layout.component.html
@@ -1,0 +1,5 @@
+<div class="container-fluid">
+  <div class="card">
+    <ng-content />
+  </div>
+</div>

--- a/frontend/src/app/syntheseModule/taxon-sheet/layout/layout.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/layout/layout.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+@Component({
+  standalone: true,
+  selector: 'layout',
+  templateUrl: 'layout.component.html',
+})
+export class LayoutComponent {}

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.html
@@ -1,0 +1,6 @@
+<pnx-map height="60vh">
+  <pnx-geojson
+    [geojson]="observations"
+    [zoomOnFirstTime]="true"
+  ></pnx-geojson>
+</pnx-map>

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { GN2CommonModule } from '@geonature_common/GN2Common.module';
+import { CommonModule } from '@angular/common';
+import { MapListService } from '@geonature_common/map-list/map-list.service';
+import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
+import { SyntheseDataService } from '@geonature_common/form/synthese-form/synthese-data.service';
+import { FeatureCollection } from 'geojson';
+import { TaxonSheetService } from '../taxon-sheet.service';
+
+@Component({
+  standalone: true,
+  selector: 'tab-geographic-overview',
+  templateUrl: 'tab-geographic-overview.component.html',
+  styleUrls: ['tab-geographic-overview.component.scss'],
+  imports: [GN2CommonModule, CommonModule],
+})
+export class TabGeographicOverviewComponent implements OnInit {
+  observations: FeatureCollection | null = null;
+  constructor(
+    private _syntheseDataService: SyntheseDataService,
+    private _tss: TaxonSheetService,
+    public mapListService: MapListService
+  ) {}
+
+  ngOnInit() {
+    this._tss.taxon.subscribe((taxon: Taxon | null) => {
+      if (!taxon) {
+        this.observations = null;
+        return;
+      }
+      this._syntheseDataService
+        .getSyntheseData(
+          {
+            cd_ref: [taxon.cd_ref],
+          },
+          {}
+        )
+        .subscribe((data) => {
+          // Store geojson
+          this.observations = data;
+        });
+    });
+  }
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.html
@@ -1,0 +1,18 @@
+<div class="Profile">
+  <small class="Profile__disclaimer text-muted">
+    Le profil est calculé à partir des observations considérées comme valides
+  </small>
+  <div class="Profile__indicators">
+    <indicator
+      *ngFor="let indicator of indicators"
+      [indicator]="indicator"
+      [small]="true"
+    />
+  </div>
+  <pnx-map height="50vh">
+    <pnx-geojson
+      [geojson]="profile"
+      [zoomOnFirstTime]="true"
+    ></pnx-geojson>
+  </pnx-map>
+</div>

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.scss
@@ -1,0 +1,14 @@
+.Profile {
+  display: flex;
+  flex-flow: column;
+  gap: 1rem;
+  &__disclaimer {
+    font-style: italic;
+  }
+  &__indicators {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-evenly;
+    gap: 1rem;
+  }
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.ts
@@ -1,0 +1,72 @@
+import { Component, OnInit } from '@angular/core';
+import { GN2CommonModule } from '@geonature_common/GN2Common.module';
+import { CommonModule } from '@angular/common';
+import { ConfigService } from '@geonature/services/config.service';
+import { DataFormService, Profile } from '@geonature_common/form/data-form.service';
+import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
+import { CommonService } from '@geonature_common/service/common.service';
+import { computeIndicatorFromConfig, Indicator, IndicatorRaw } from '../indicator/indicator';
+import { IndicatorComponent } from '../indicator/indicator.component';
+import { TaxonSheetService } from '../taxon-sheet.service';
+
+@Component({
+  standalone: true,
+  selector: 'tab-profile',
+  templateUrl: 'tab-profile.component.html',
+  styleUrls: ['tab-profile.component.scss'],
+  imports: [GN2CommonModule, CommonModule, IndicatorComponent],
+})
+export class TabProfileComponent implements OnInit {
+  indicators: Array<Indicator>;
+  _profile: Profile | null;
+
+  constructor(
+    private _config: ConfigService,
+    private _ds: DataFormService,
+    private _commonService: CommonService,
+    private _tss: TaxonSheetService
+  ) {
+    this.profile = null;
+  }
+
+  ngOnInit(): void {
+    this._tss.taxon.subscribe((taxon: Taxon | null) => {
+      if (!taxon) {
+        this.profile = null;
+        return;
+      }
+      this._ds.getProfile(taxon.cd_ref).subscribe(
+        (profile) => {
+          this.profile = profile;
+        },
+        (errors) => {
+          this.profile = null;
+          if (errors.status == 404) {
+            this._commonService.regularToaster('warning', 'Aucune donnée pour ce taxon');
+          }
+        }
+      );
+    });
+  }
+  get profile(): Profile | null {
+    return this._profile;
+  }
+
+  set profile(profile: Profile | null) {
+    this._profile = profile;
+
+    if (
+      this._config &&
+      this._config['SYNTHESE'] &&
+      this._config['SYNTHESE']['SPECIES_SHEET'] &&
+      this._config['SYNTHESE']['SPECIES_SHEET']['PROFILE']
+    ) {
+      this.indicators = this._config['SYNTHESE']['SPECIES_SHEET']['PROFILE']['LIST_INDICATORS'].map(
+        (indicatorConfig: IndicatorRaw) =>
+          computeIndicatorFromConfig(indicatorConfig, profile?.properties)
+      );
+    } else {
+      this.indicators = [];
+    }
+  }
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.html
@@ -1,66 +1,35 @@
-<div class="container-fluid">
-  <div class="card">
-    <div class="card-body">
-      <div class="">
-        <h3 class="card-title mb-0">
-          <i>{{ taxon?.nom_complet }}</i>
-          <span *ngIf="taxon?.nom_vern">- {{ taxon?.nom_vern }}</span>
-        </h3>
-        <small class="text-muted">
-          *Le profil est calculé à partir des observations considérées comme valides
-        </small>
-      </div>
-      <div class="card-columns">
-        <div
-          class="card"
-          *ngIf="mediaUrl"
+<layout>
+  <div class="TaxonSheet">
+    <infos class="TaxonSheet__infos" />
+    <div class="TaxonSheet__indicators">
+      <indicator
+        *ngFor="let indicator of indicators"
+        [indicator]="indicator"
+      />
+    </div>
+    <div class="card AvancedInfos">
+      <nav
+        mat-tab-nav-bar
+        class="AvancedInfos__navBar"
+        [tabPanel]="tabPanel"
+      >
+        <a
+          *ngFor="let tab of TAB_LINKS"
+          mat-tab-link
+          [routerLink]="tab.path"
+          routerLinkActive
+          #rla="routerLinkActive"
+          [active]="rla.isActive"
         >
-          <div
-            class="card-body cover image"
-            [style.background-image]="'url(' + mediaUrl + ')'"
-          ></div>
-        </div>
-        <div class="card">
-          <div class="card-body">
-            <mat-icon>search</mat-icon>
-            <h3>{{ profile?.count_valid_data }}</h3>
-            <!-- <mat-icon style="color:green">check</mat-icon> -->
-            <p class="text-muted">Observations valides</p>
-          </div>
-        </div>
-        <div class="card">
-          <div class="card-body">
-            <mat-icon>schedule</mat-icon>
-            <h3>{{ profile?.first_valid_data | date: 'dd/MM/yyyy' }}</h3>
-            <!-- <mat-icon style="color:green">check</mat-icon> -->
-            <p class="text-muted">Première observation</p>
-          </div>
-        </div>
-        <div class="card">
-          <div class="card-body">
-            <mat-icon>schedule</mat-icon>
-            <h3>{{ profile?.last_valid_data | date: 'dd/MM/yyyy' }}</h3>
-            <!-- <mat-icon style="color:green">check</mat-icon> -->
-            <p class="text-muted">Dernière observation</p>
-          </div>
-        </div>
-
-        <div class="card">
-          <div class="card-body">
-            <mat-icon>terrain</mat-icon>
-            <h3>{{ profile?.altitude_min }}m - {{ profile?.altitude_max }}m</h3>
-            <!-- <mat-icon style="color:green">check</mat-icon> -->
-            <p class="text-muted">Plage d'altitude</p>
-          </div>
-        </div>
-      </div>
-
-      <pnx-map height="50vh">
-        <pnx-geojson
-          [geojson]="profilArea"
-          [zoomOnFirstTime]="true"
-        ></pnx-geojson>
-      </pnx-map>
+          {{ tab.label }}
+        </a>
+      </nav>
+      <mat-tab-nav-panel
+        #tabPanel
+        class="AvancedInfos__content"
+      >
+        <router-outlet></router-outlet>
+      </mat-tab-nav-panel>
     </div>
   </div>
-</div>
+</layout>

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.scss
@@ -1,52 +1,31 @@
-// .info>div {
-//     display: flex;
-// }
-
-// .title {
-//     font-size: 20px;
-//     color:#767474;
-// }
-
-// .content{
-//     font-size: 20px;
-//     color: black;
-//     font-weight: bold;
-// }
-
-// mat-icon {
-//     vertical-align: middle;
-//     font-size: 70px;
-// }
-
-.card-deck {
-  text-align: center;
-}
-.card-deck mat-icon {
-  font-size: 40px;
-}
-
-.stat .card {
-  text-align: center;
-  margin-bottom: 10px;
-}
-
-.title {
+.TaxonSheet {
   display: flex;
-}
-.card-columns .card-body {
-  height: 200px;
-  text-align: center;
-  // margin-right: 10px;
-  padding-top: 15%;
-}
-.cover {
-  background-size: cover;
-}
+  flex-flow: column;
+  justify-content: flex-start;
+  padding: 1.25rem;
+  row-gap: 1.25rem;
 
-.card-columns {
-  column-count: 5;
-}
+  &__indicators {
+    align-self: center;
+    width: 80%;
 
-.card-body.image {
-  background-position: center;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-evenly;
+    gap: 1rem;
+  }
+  .AvancedInfos {
+    &__navBar {
+      a {
+        border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+      }
+      a:hover {
+        text-decoration: none;
+      }
+    }
+
+    &__content {
+      padding: 1rem;
+    }
+  }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.ts
@@ -1,53 +1,82 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import {
+  ActivatedRoute,
+  Router,
+  RouterLink,
+  RouterLinkActive,
+  RouterOutlet,
+} from '@angular/router';
 import { ConfigService } from '@geonature/services/config.service';
-import { DataFormService } from '@geonature_common/form/data-form.service';
-import { CommonService } from '@geonature_common/service/common.service';
+import { GN2CommonModule } from '@geonature_common/GN2Common.module';
+import { InfosComponent } from './infos/infos.component';
+import { LayoutComponent } from './layout/layout.component';
+import { computeIndicatorFromConfig, Indicator, IndicatorRaw } from './indicator/indicator';
+import { IndicatorComponent } from './indicator/indicator.component';
+import { CommonModule } from '@angular/common';
+import { SyntheseDataService } from '@geonature_common/form/synthese-form/synthese-data.service';
+import { TaxonSheetService } from './taxon-sheet.service';
+import { RouteService } from './taxon-sheet.route.service';
 
 @Component({
+  standalone: true,
   selector: 'pnx-taxon-sheet',
   templateUrl: 'taxon-sheet.component.html',
   styleUrls: ['taxon-sheet.component.scss'],
+  imports: [
+    CommonModule,
+    GN2CommonModule,
+    IndicatorComponent,
+    InfosComponent,
+    LayoutComponent,
+    RouterOutlet,
+    RouterLink,
+    RouterLinkActive,
+  ],
+  providers: [TaxonSheetService],
 })
 export class TaxonSheetComponent implements OnInit {
-  public taxon: any;
-  public profile: any;
-  public profilArea: any;
-  public mediaUrl: any;
-  constructor(
-    private _route: ActivatedRoute,
-    private _ds: DataFormService,
-    private _commonService: CommonService,
-    public config: ConfigService
-  ) {}
+  readonly TAB_LINKS = [];
 
+  indicators: Array<Indicator>;
+
+  constructor(
+    private _router: Router,
+    private _route: ActivatedRoute,
+    private _tss: TaxonSheetService,
+    private _syntheseDataService: SyntheseDataService,
+    private _config: ConfigService,
+    private _routes: RouteService
+  ) {
+    this.TAB_LINKS = this._routes.TAB_LINKS;
+  }
   ngOnInit() {
     this._route.params.subscribe((params) => {
-      const cdNom = params['cd_nom'];
-      if (cdNom) {
-        this._ds.getTaxonInfo(cdNom).subscribe((taxon) => {
-          this.taxon = taxon;
-          this._ds.getProfile(taxon.cd_ref).subscribe(
-            (profil) => {
-              this.profile = profil.properties;
-              this.profilArea = profil;
-              this._ds.getTaxonAttributsAndMedia(taxon.cd_ref).subscribe((taxonAttrAndMedias) => {
-                const media = taxonAttrAndMedias.medias.find(
-                  (m) => m.id_type == this.config['TAXHUB']['ID_TYPE_MAIN_PHOTO']
-                );
-                if (media) {
-                  this.mediaUrl = `${this.config.API_TAXHUB}/tmedias/thumbnail/${media.id_media}?h=300&w300`;
-                }
-              });
-            },
-            (errors) => {
-              if (errors.status == 404) {
-                this._commonService.regularToaster('warning', 'Aucune donnée pour ce taxon');
-              }
-            }
-          );
+      const cd_ref = params['cd_ref'];
+      if (cd_ref) {
+        this._tss.updateTaxonByCdRef(cd_ref);
+        this._syntheseDataService.getSyntheseSpeciesSheetStat(cd_ref).subscribe((stats) => {
+          this.setIndicators(stats);
         });
       }
     });
+  }
+
+  setIndicators(stats: any) {
+    if (
+      this._config &&
+      this._config['SYNTHESE'] &&
+      this._config['SYNTHESE']['SPECIES_SHEET'] &&
+      this._config['SYNTHESE']['SPECIES_SHEET']['LIST_INDICATORS']
+    ) {
+      this.indicators = this._config['SYNTHESE']['SPECIES_SHEET']['LIST_INDICATORS'].map(
+        (indicatorConfig: IndicatorRaw) => computeIndicatorFromConfig(indicatorConfig, stats)
+      );
+    } else {
+      this.indicators = [];
+    }
+  }
+
+  goToPath(path: string) {
+    this._router.navigate([path], { relativeTo: this._route });
   }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.route.service.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.route.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@angular/core';
+import {
+  CanActivate,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  Router,
+  ActivatedRoute,
+  CanActivateChild,
+} from '@angular/router';
+import { ConfigService } from '@geonature/services/config.service';
+import { Observable } from 'rxjs';
+import { TabGeographicOverviewComponent } from './tab-geographic-overview/tab-geographic-overview.component';
+import { TabProfileComponent } from './tab-profile/tab-profile.component';
+
+interface Tab {
+  label: string;
+  path: string;
+  configEntry: string;
+  component: any;
+}
+
+const ROUTE_GEOGRAPHIC_OVERVIEW: Tab = {
+  label: 'Synthèse Géographique',
+  path: 'geographic_overview',
+  configEntry: 'GEOGRAPHIC_OVERVIEW',
+  component: TabGeographicOverviewComponent,
+};
+
+export const ROUTE_MANDATORY = ROUTE_GEOGRAPHIC_OVERVIEW;
+
+const ROUTE_PROFILE: Tab = {
+  label: 'Profil',
+  path: 'profile',
+  configEntry: 'PROFILE',
+  component: TabProfileComponent,
+};
+
+export const ALL_TAXON_SHEET_ADVANCED_INFOS_ROUTES: Array<Tab> = [
+  ROUTE_GEOGRAPHIC_OVERVIEW,
+  ROUTE_PROFILE,
+];
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RouteService implements CanActivateChild {
+  readonly TAB_LINKS = [];
+
+  constructor(
+    private _config: ConfigService,
+    private _router: Router
+  ) {
+    this.TAB_LINKS.push(ROUTE_MANDATORY);
+    if (this._config && this._config['SYNTHESE'] && this._config['SYNTHESE']['SPECIES_SHEET']) {
+      const config = this._config['SYNTHESE']['SPECIES_SHEET'];
+      if (config['PROFILE'] && config['PROFILE']['ENABLED']) {
+        this.TAB_LINKS.push(ROUTE_PROFILE);
+      }
+    }
+  }
+
+  canActivateChild(
+    childRoute: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean> | Promise<boolean> | boolean {
+    const targetedPath = childRoute.routeConfig.path;
+    if (ROUTE_MANDATORY.path == targetedPath) {
+      return true;
+    }
+    const targetedTab = ALL_TAXON_SHEET_ADVANCED_INFOS_ROUTES.find(
+      (tab) => tab.path === targetedPath
+    );
+    if (this._config && this._config['SYNTHESE'] && this._config['SYNTHESE']['SPECIES_SHEET']) {
+      const config = this._config['SYNTHESE']['SPECIES_SHEET'];
+      if (config[targetedTab.configEntry] && config[targetedTab.configEntry]['ENABLED']) {
+        return true;
+      }
+    }
+
+    this._router.navigate(['/404'], { skipLocationChange: true });
+    return false;
+  }
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { DataFormService } from '@geonature_common/form/data-form.service';
+import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable()
+export class TaxonSheetService {
+  taxon: BehaviorSubject<Taxon | null> = new BehaviorSubject<Taxon | null>(null);
+
+  constructor(private _ds: DataFormService) {}
+
+  updateTaxonByCdRef(cd_ref: number) {
+    const taxon = this.taxon.getValue();
+    if (taxon && taxon.cd_ref == cd_ref) {
+      return;
+    }
+    this._ds.getTaxonInfo(cd_ref).subscribe((taxon) => {
+      this.taxon.next(taxon);
+    });
+  }
+}


### PR DESCRIPTION
Closes #3131

L'issue est assez détaillée sur les fonctionnalités, je propose de se référer à cette dernière concernant les propos du développement. 

Description sommaire du développement réalisé.

## Données

Les données manipulées dans ce composant "Fiche Espèce" étaient en réalité des données de Profile. 
Des modifications ont été réalisées pour permettre de gérer les données d'observations à leur place

## Frontend

Le composant "TaxonSheetComponent" a été complètement réécrit. On note principalement: 
- Mise en page
- Modification des indicateurs
- router et navigation par onglet (conditionnée par un CanActivateChild)
- transformation en standalone
- contenu changé: contenu précédent basculé dans l'onglet "Profile"


## Backend

- Ajout de la route `/species_stats/<int:cd_ref>`
- Enrichissement du schéma de la config avec des options associées à cette fiche espèce (indicateurs, etc.)