### PR TITLE
feat(pytest) : Disable defaut launch of benchmark

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -123,7 +123,7 @@ jobs:
           GEONATURE_CONFIG_FILE: config/test_config.toml
       - name: Test with pytest
         run: |
-          pytest -v --cov --cov-report xml --benchmark-skip
+          pytest -v --cov --cov-report xml
         env:
           GEONATURE_CONFIG_FILE: config/test_config.toml
       - name: Upload coverage to Codecov

--- a/docs/tests_backend.rst
+++ b/docs/tests_backend.rst
@@ -249,13 +249,7 @@ Cette fonctionnalité s'appuie sur ``pytest`` et son extension ``pytest-benchmar
 Lancement des tests de performances
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Il existe différentes manières de lancer les tests de performances:
-
-- La commande ``pytest`` sans arguments. Cette dernière lancera les tests de performances en plus des tests unitaires.
-- La commande ``pytest --benchmark-only`` qui lancera uniquement les tests de performances.
-
-
-
+Pour lancer les tests de performances, utiliser la commande suivante : ``pytest --benchmark-only``
 
 
 Ajouter des tests de performances

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ minversion = "6.0"
 testpaths = [
     "backend/geonature/tests/",
 ]
+addopts = "--benchmark-skip"
 
 [tool.coverage.run]
 source = [


### PR DESCRIPTION
This PR propose to disable benchmark automatic launch when running pytest.

To run the benchmarks, you have to run the following command:

```shell
pytest --benchmark-only
```