### PR TITLE
fix: radio button invalid form

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/dynamic-form/dynamic-form.component.html
+++ b/frontend/src/app/GN2CommonModule/form/dynamic-form/dynamic-form.component.html
@@ -208,25 +208,30 @@
 
     <div *ngSwitchCase="'radio'">
       <div
-        *ngFor="let item of formDefComp['values']"
-        class="custom-control custom-radio"
-        [ngClass]="{ 'ng-invalid': form.get(formDefComp['attribut_name']).invalid }"
+        class="radio-group-container"
+        [ngClass]="{ 'border-red': form.get(formDefComp['attribut_name']).invalid }"
       >
-        <input
-          type="radio"
-          id="{{ formDefComp['attribut_name'] }}_{{ rand }}_{{ item.value }}"
-          (click)="onRadioChange(item.value, form.get(formDefComp['attribut_name']))"
-          class="custom-control-input"
-          name="{{ formDefComp['attribut_name'] }}_{{ rand }}_{{ item.value }}"
-          [value]="item.value"
-          [formControl]="form.get(formDefComp['attribut_name'])"
-        />
-        <label
-          class="custom-control-label"
-          for="{{ formDefComp['attribut_name'] }}_{{ rand }}_{{ item.value }}"
+        <div
+          *ngFor="let item of formDefComp['values']"
+          class="custom-control custom-radio"
+          [ngClass]="{ 'ng-invalid': form.get(formDefComp['attribut_name']).invalid }"
         >
-          <span [innerHTML]="item.label"></span>
-        </label>
+          <input
+            type="radio"
+            id="{{ formDefComp['attribut_name'] }}_{{ rand }}_{{ item.value }}"
+            (click)="onRadioChange(item.value, form.get(formDefComp['attribut_name']))"
+            class="custom-control-input"
+            name="{{ formDefComp['attribut_name'] }}_{{ rand }}_{{ item.value }}"
+            [value]="item.value"
+            [formControl]="form.get(formDefComp['attribut_name'])"
+          />
+          <label
+            class="custom-control-label"
+            for="{{ formDefComp['attribut_name'] }}_{{ rand }}_{{ item.value }}"
+          >
+            <span [innerHTML]="item.label"></span>
+          </label>
+        </div>
       </div>
     </div>
 

--- a/frontend/src/app/GN2CommonModule/form/dynamic-form/dynamic-form.component.scss
+++ b/frontend/src/app/GN2CommonModule/form/dynamic-form/dynamic-form.component.scss
@@ -17,6 +17,17 @@
   border: 0px !important;
 }
 
+.radio-group-container {
+  padding-left: 0px;
+}
+
+.border-red {
+  border-left: 4px solid red;
+  border-radius: 4px 0 0 4px;
+  outline: none;
+  padding-left: 10px;
+}
+
 //
 // factorisation patchs présents dans media et monitoring
 //


### PR DESCRIPTION
Cette PR propose de résoudre le problème d'UX concernant le composant radio bouton .

Voici les images présentant la solution mise en place (le premier radio bouton est non obligatoire et le deuxième radio bouton Scope est obligatoire):

![radio-btn-invalid-form](https://github.com/user-attachments/assets/fce43d5a-406d-445b-af35-cfcf5cfa983d)

----------------------------------------

![image](https://github.com/user-attachments/assets/70308b09-cd29-458a-86d6-dc0aedaf593d)


[Refs_issue] : closes #3210 
Reviewed-by: andriacap