### PR TITLE
[GN_META] Allow for acquisition framework deletion

### DIFF
--- a/backend/geonature/core/gn_meta/models/aframework.py
+++ b/backend/geonature/core/gn_meta/models/aframework.py
@@ -121,14 +121,21 @@ class TAcquisitionFramework(db.Model):
     def organism_actors(self):
         return [actor.organism for actor in self.cor_af_actor if actor.organism]
 
-    def is_deletable(self):
-        return not (
-            db.session.scalar(
-                exists()
-                .select_from()
-                .where(TDatasets.id_acquisition_framework == self.id_acquisition_framework)
-                .select()
+    def has_datasets(self):
+        return db.session.scalar(
+            exists(TDatasets)
+            .where(TDatasets.id_acquisition_framework == self.id_acquisition_framework)
+            .select()
+        )
+
+    def has_child_acquisition_framework(self):
+        return db.session.scalar(
+            exists(TAcquisitionFramework)
+            .where(
+                TAcquisitionFramework.acquisition_framework_parent_id
+                == self.id_acquisition_framework
             )
+            .select()
         )
 
     def has_instance_permission(self, scope, _through_ds=True):

--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -780,7 +780,7 @@ def delete_acquisition_framework(scope, af_id):
 
     if af.has_child_acquisition_framework():
         raise Conflict(
-            "La suppression du cadre d’acquisition n'est pas possible "
+            "La suppression du cadre d’acquisition est impossible "
             "car celui-ci est le parent d'autre(s) cadre(s) d'acquisition."
         )
     db.session.delete(af)

--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -774,7 +774,7 @@ def delete_acquisition_framework(scope, af_id):
         )
     if af.has_datasets():
         raise Conflict(
-            "La suppression du cadre d’acquisition n'est pas possible "
+            "La suppression du cadre d’acquisition est impossible "
             "car celui-ci contient des jeux de données."
         )
 

--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -1,5 +1,5 @@
 """
-    Routes for gn_meta 
+    Routes for gn_meta
 """
 
 import datetime as dt
@@ -772,10 +772,16 @@ def delete_acquisition_framework(scope, af_id):
         raise Forbidden(
             f"User {g.current_user} cannot delete acquisition framework {af.id_acquisition_framework}"
         )
-    if not af.is_deletable():
+    if af.has_datasets():
         raise Conflict(
             "La suppression du cadre d’acquisition n'est pas possible "
             "car celui-ci contient des jeux de données."
+        )
+
+    if af.has_child_acquisition_framework():
+        raise Conflict(
+            "La suppression du cadre d’acquisition n'est pas possible "
+            "car celui-ci est le parent d'autre(s) cadre(s) d'acquisition."
         )
     db.session.delete(af)
     db.session.commit()

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -159,11 +159,17 @@ class TestGNMeta:
             )
             ta = TAcquisitionFramework
             sc = db.session.scalars
+
             assert set(sc(ta.filter_by_scope(0, query=qs)).unique().all()) == set([])
             assert set(sc(ta.filter_by_scope(1, query=qs)).unique().all()) == set(
                 [
                     acquisition_frameworks["own_af"],
                     acquisition_frameworks["orphan_af"],  # through DS
+                    acquisition_frameworks["parent_af"],
+                    acquisition_frameworks["child_af"],
+                    acquisition_frameworks["parent_wo_children_af"],
+                    acquisition_frameworks["delete_parent_wo_children_af"],
+                    acquisition_frameworks["delete_af"],
                 ]
             )
             assert set(sc(ta.filter_by_scope(2, query=qs)).unique().all()) == set(
@@ -171,17 +177,40 @@ class TestGNMeta:
                     acquisition_frameworks["own_af"],
                     acquisition_frameworks["associate_af"],
                     acquisition_frameworks["orphan_af"],  # through DS
+                    acquisition_frameworks["parent_af"],
+                    acquisition_frameworks["child_af"],
+                    acquisition_frameworks["parent_wo_children_af"],
+                    acquisition_frameworks["delete_parent_wo_children_af"],
+                    acquisition_frameworks["delete_af"],
                 ]
             )
             assert set(sc(ta.filter_by_scope(3, query=qs)).unique().all()) == set(
                 acquisition_frameworks.values()
             )
 
-    def test_acquisition_framework_is_deletable(self, app, acquisition_frameworks, datasets):
-        assert acquisition_frameworks["own_af"].is_deletable() == True
-        assert (
-            acquisition_frameworks["orphan_af"].is_deletable() == False
-        )  # DS are attached to this AF
+    @pytest.mark.parametrize(
+        "af,has_datasets",
+        [
+            ("own_af", False),
+            ("orphan_af", True),
+        ],
+    )
+    def test_acquisition_framework_has_datasets(
+        self, app, acquisition_frameworks, datasets, af, has_datasets
+    ):
+        assert acquisition_frameworks[af].has_datasets() == has_datasets
+
+    @pytest.mark.parametrize(
+        "af,has_child_af",
+        [
+            ("parent_af", True),
+            ("parent_wo_children_af", False),
+        ],
+    )
+    def test_acquisition_framework_has_child_acquisition_framework(
+        self, app, acquisition_frameworks, datasets, af, has_child_af
+    ):
+        assert acquisition_frameworks[af].has_child_acquisition_framework() == has_child_af
 
     def test_create_acquisition_framework(self, users):
         set_logged_user(self.client, users["user"])
@@ -204,37 +233,32 @@ class TestGNMeta:
 
         assert response.status_code == Forbidden.code
 
-    def test_delete_acquisition_framework(self, app, users, acquisition_frameworks, datasets):
-        af_id = acquisition_frameworks["orphan_af"].id_acquisition_framework
+    @pytest.mark.parametrize(
+        "user,dataset,status_code",
+        [
+            (None, "orphan_af", Unauthorized.code),
+            ("noright_user", "orphan_af", Forbidden.code),
+            ("self_user", "orphan_af", Forbidden.code),
+            ("admin_user", "orphan_af", Conflict.code),
+            ("admin_user", "parent_af", Conflict.code),
+            ("user", "own_af", 204),
+            ("user", "delete_parent_wo_children_af", 204),
+            ("user", "delete_af", 204),
+        ],
+    )
+    def test_delete_acquisition_framework(
+        self, app, users, acquisition_frameworks, datasets, user, dataset, status_code
+    ):
+        if user:
+            set_logged_user(self.client, users[user])
 
-        response = self.client.delete(url_for("gn_meta.delete_acquisition_framework", af_id=af_id))
-        assert response.status_code == Unauthorized.code
-
-        set_logged_user(self.client, users["noright_user"])
-
-        # The user has no rights on METADATA module
-        response = self.client.delete(url_for("gn_meta.delete_acquisition_framework", af_id=af_id))
-        assert response.status_code == Forbidden.code
-        assert "METADATA" in response.json["description"]
-
-        set_logged_user(self.client, users["self_user"])
-
-        # The user has right on METADATA module, but not on this specific AF
-        response = self.client.delete(url_for("gn_meta.delete_acquisition_framework", af_id=af_id))
-        assert response.status_code == Forbidden.code
-        assert "METADATA" not in response.json["description"]
-
-        set_logged_user(self.client, users["admin_user"])
-
-        # The AF can not be deleted due to attached DS
-        response = self.client.delete(url_for("gn_meta.delete_acquisition_framework", af_id=af_id))
-        assert response.status_code == Conflict.code
-
-        set_logged_user(self.client, users["user"])
-        af_id = acquisition_frameworks["own_af"].id_acquisition_framework
-
-        response = self.client.delete(url_for("gn_meta.delete_acquisition_framework", af_id=af_id))
-        assert response.status_code == 204
+        response = self.client.delete(
+            url_for(
+                "gn_meta.delete_acquisition_framework",
+                af_id=acquisition_frameworks[dataset].id_acquisition_framework,
+            )
+        )
+        assert response.status_code == status_code
 
     def test_update_acquisition_framework(self, users, acquisition_frameworks):
         new_name = "thenewname"
@@ -1092,7 +1116,7 @@ class TestGNMeta:
 
         assert isinstance(afquery, Select)
         assert isinstance(afuser, list)
-        assert len(afuser) == 1
+        assert len(afuser) == 6
         assert isinstance(afdefault, list)
         assert len(afdefault) >= 1
 

--- a/frontend/src/app/metadataModule/af/af-card.component.html
+++ b/frontend/src/app/metadataModule/af/af-card.component.html
@@ -15,10 +15,14 @@
   <div class="row">
     <div class="col-8">
       <div class="card">
-        <div class="card-body">
-          <h5 class="text-muted">Cadre d'acquisition</h5>
-          <h4>
-            {{ af?.acquisition_framework_name }}
+        <div class="card-body af-card-header">
+          <div class="af-card-header__left">
+            <h5 class="text-muted">Cadre d'acquisition</h5>
+            <h4>
+              {{ af?.acquisition_framework_name }}
+            </h4>
+          </div>
+          <div class="af-card-header__right">
             <button
               [routerLink]="['/metadata/af', af?.id_acquisition_framework]"
               [disabled]="!af?.cruved?.U"
@@ -29,7 +33,11 @@
             >
               <mat-icon>create</mat-icon>
             </button>
-          </h4>
+            <gn-button-delete-af
+              [acquisitionFramework]="af"
+              buttonType="Floating"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/app/metadataModule/af/af-card.component.scss
+++ b/frontend/src/app/metadataModule/af/af-card.component.scss
@@ -1,3 +1,20 @@
+.af-card-header {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+
+  &__left {
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: flex-start;
+  }
+  &__right {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-end;
+  }
+}
+
 .btn-secondary,
 .btn-primary,
 .btn-success,

--- a/frontend/src/app/metadataModule/af/button-delete-af.component.html
+++ b/frontend/src/app/metadataModule/af/button-delete-af.component.html
@@ -1,0 +1,23 @@
+<ng-container [ngSwitch]="buttonType">
+  <button
+    *ngSwitchCase="ButtonType.Toolbar"
+    mat-icon-button
+    [disabled]="disabled"
+    matTooltip="Supprimer le cadre d'acquisition"
+    (click)="deleteAcquisitionFramework()"
+    style="color: black"
+  >
+    <mat-icon>delete</mat-icon>
+  </button>
+  <button
+    *ngSwitchCase="ButtonType.Floating"
+    mat-mini-fab
+    color="warn"
+    [disabled]="disabled"
+    matTooltip="Supprimer le cadre d'acquisition"
+    (click)="deleteAcquisitionFramework()"
+    class="mr-2 float-right"
+  >
+    <mat-icon>delete</mat-icon>
+  </button>
+</ng-container>

--- a/frontend/src/app/metadataModule/af/button-delete-af.component.ts
+++ b/frontend/src/app/metadataModule/af/button-delete-af.component.ts
@@ -1,0 +1,63 @@
+import { Component, Input } from '@angular/core';
+import { DataFormService } from '@geonature_common/form/data-form.service';
+import { MetadataService } from '../services/metadata.service';
+import { ConfirmationDialog } from '@geonature_common/others/modal-confirmation/confirmation.dialog';
+import { MatDialog } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+
+enum ButtonType {
+  Toolbar = 'Toolbar',
+  Floating = 'Floating',
+}
+
+const METADATA_URL = '/metadata';
+@Component({
+  selector: 'gn-button-delete-af',
+  templateUrl: './button-delete-af.component.html',
+  styleUrls: ['./button-delete-af.component.scss'],
+})
+export class ButtonDeleteAfComponent {
+  readonly ButtonType = ButtonType;
+
+  @Input()
+  acquisitionFramework: any;
+
+  @Input()
+  redirectionUrl: string = METADATA_URL;
+
+  @Input()
+  buttonType: ButtonType = ButtonType.Toolbar;
+
+  constructor(
+    private _dfs: DataFormService,
+    private _mds: MetadataService,
+    private _dialog: MatDialog,
+    private _router: Router
+  ) {}
+
+  deleteAcquisitionFramework() {
+    const dialogRef = this._dialog.open(ConfirmationDialog, {
+      width: 'auto',
+      position: { top: '5%' },
+      data: {
+        message: "Voulez-vous supprimer ce cadre d'acquisition ?",
+        yesColor: 'primary',
+        noColor: 'warn',
+      },
+    });
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this._dfs.deleteAf(this.acquisitionFramework.id_acquisition_framework).subscribe((res) => {
+          this._mds.getMetadata();
+          if (this.redirectionUrl) {
+            this._router.navigate([this.redirectionUrl]);
+          }
+        });
+      }
+    });
+  }
+
+  get disabled() {
+    return !this.acquisitionFramework.cruved.D;
+  }
+}

--- a/frontend/src/app/metadataModule/metadata.component.html
+++ b/frontend/src/app/metadataModule/metadata.component.html
@@ -164,6 +164,11 @@
                     >
                       <mat-icon>create</mat-icon>
                     </a>
+                    <gn-button-delete-af
+                      [acquisitionFramework]="af"
+                      buttonType="Toolbar"
+                      (click)="$event.stopPropagation()"
+                    />
                     <button
                       *ngIf="config.METADATA?.ENABLE_CLOSE_AF"
                       type="button"

--- a/frontend/src/app/metadataModule/metadata.module.ts
+++ b/frontend/src/app/metadataModule/metadata.module.ts
@@ -18,6 +18,7 @@ import { NgChartsModule } from 'ng2-charts';
 import { MetadataService } from './services/metadata.service';
 import { MetadataDataService } from './services/metadata-data.service';
 import { ActorFormService } from './services/actor-form.service';
+import { ButtonDeleteAfComponent } from './af/button-delete-af.component';
 
 const routes: Routes = [
   { path: '', component: MetadataComponent },
@@ -70,6 +71,7 @@ export class MetadataPaginator extends MatPaginatorIntl {
     AfFormComponent,
     ActorComponent,
     AfCardComponent,
+    ButtonDeleteAfComponent,
   ],
   providers: [
     MetadataService,


### PR DESCRIPTION
Closes #1673 

On souhaite ici permettre la suppression d'un Cadre d'Acquisition (CA).

Un CA peut être supprimé si et seulement si: 
- il ne contient pas de dataset
- il n'est pas le parent d'un autre CA

### backend > model

Le modèle a été modifié pour transformer "is_deletable" en deux fonctions, qui explicitent le critère.
- has_datasets
- has_child_acquisition_framework

### backend > route

La route existante, mais non utilisée, a été conservé. Le critère de possibilité de suppression a été ajusté à la suppresion du modèle

### frontend > composant button-delete-af

Le composant `button-delete-af` a été ajouté. 
Il permet, à partir d'un cadre d'acquisition donné, de réaliser la suppression avec dialog de confirmation. 
Ce bouton a été intégré au composant metadata (metadata.component) et à la page de description d'un cadre d'acquisition (af-card.component).

### frontend > composant af-card.component

Le layout du header du composant `af-card.component` a été ajusté. 
Les boutons étaient compris dans le h4 du titre. Ils sont maintenant dans un layout qui structure le header de la page. 

