### PR TITLE
[Fiche taxon] Ajout d'option sur la synthèse géographique

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
@@ -14,6 +14,16 @@ import { ConfigService } from '@geonature/services/config.service';
 import { DEFAULT_PAGINATION, SyntheseDataPaginationItem } from './synthese-data-pagination-item';
 import { DEFAULT_SORT, SyntheseDataSortItem } from './synthese-data-sort-item';
 
+export interface TaxonStats {
+  cd_ref?: 246817;
+  altitude_max?: number;
+  altitude_min?: number;
+  area_count?: number;
+  date_max?: string;
+  date_min?: string;
+  observation_count?: number;
+  observer_count?: number;
+}
 export const FormatMapMime = new Map([
   ['csv', 'text/csv'],
   ['json', 'application/json'],
@@ -57,8 +67,8 @@ export class SyntheseDataService {
     return this._api.get<any>(`${this.config.API_ENDPOINT}/synthese/general_stats`);
   }
 
-  getSyntheseTaxonSheetStat(cd_ref: number, areaType: string = 'COM') {
-    return this._api.get<any>(`${this.config.API_ENDPOINT}/synthese/taxon_stats/${cd_ref}`, {
+  getSyntheseTaxonSheetStat(cd_ref: number, areaType: string = 'COM'): Observable<TaxonStats> {
+    return this._api.get<TaxonStats>(`${this.config.API_ENDPOINT}/synthese/taxon_stats/${cd_ref}`, {
       params: new HttpParams().append('area_type', areaType),
     });
   }

--- a/frontend/src/app/syntheseModule/taxon-sheet/indicator/indicator.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/indicator/indicator.ts
@@ -1,3 +1,5 @@
+import { TaxonStats } from '@geonature_common/form/synthese-form/synthese-data.service';
+
 export interface Indicator {
   name: string;
   matIcon: string;
@@ -14,12 +16,10 @@ export interface IndicatorDescription {
   type: IndicatorRawType;
 }
 
-type Stats = Record<string, string>;
-
 const DEFAULT_VALUE = '-';
 const DEFAULT_SEPARATOR = '-';
 
-function getValue(field: string, indicatorConfig: IndicatorDescription, stats?: Stats) {
+function getValue(field: string, indicatorConfig: IndicatorDescription, stats?: TaxonStats) {
   if (stats && stats[field]) {
     let valueAsString = '';
     switch (indicatorConfig.type) {
@@ -40,7 +40,7 @@ function getValue(field: string, indicatorConfig: IndicatorDescription, stats?: 
 
 export function computeIndicatorFromDescription(
   indicatorDescription: IndicatorDescription,
-  stats?: Stats
+  stats: TaxonStats
 ): Indicator {
   let value = DEFAULT_VALUE;
   if (stats) {

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.html
@@ -11,7 +11,14 @@
   </pnx-map>
   <div class="TabGeographic__side">
     <div class="TabGeographic__sideItem">
-      <mat-label>Plage d'observations: {{ yearInterval.min }} -> {{ yearInterval.max }}</mat-label>
+      <div class="text-muted">
+        Plage d'observations:
+        <b class="text">
+          {{ yearInterval.min }}
+        </b>
+        -
+        <b class="text">{{ yearInterval.max }}</b>
+      </div>
       <mat-slider
         class="DateSlider"
         [displayWith]="formatLabel"

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.html
@@ -2,5 +2,6 @@
   <pnx-geojson
     [geojson]="observations"
     [zoomOnFirstTime]="true"
+    [style]="styleTabGeoJson"
   ></pnx-geojson>
 </pnx-map>

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.html
@@ -10,7 +10,15 @@
     ></pnx-geojson>
   </pnx-map>
   <div class="TabGeographic__side">
-    <div class="TabGeographic__sideItem">
+    <div
+      class="TabGeographic__sideItem"
+      *ngIf="
+        yearIntervalBoundaries &&
+          yearInterval &&
+          yearIntervalBoundaries.max != yearIntervalBoundaries.min;
+        else yearSliderPlaceholder
+      "
+    >
       <div class="text-muted">
         Plage d'observations:
         <b class="text">
@@ -22,8 +30,8 @@
       <mat-slider
         class="DateSlider"
         [displayWith]="formatLabel"
-        [min]="YEAR_INTERVAL.min"
-        [max]="YEAR_INTERVAL.max"
+        [min]="yearIntervalBoundaries.min"
+        [max]="yearIntervalBoundaries.max"
         step="1"
         discrete
       >
@@ -39,5 +47,15 @@
         />
       </mat-slider>
     </div>
+    <ng-template #yearSliderPlaceholder>
+      <div class="TabGeographic__sideItem">
+        <div class="text-muted">
+          Année d'observation(s):
+          <b class="text">
+            {{ yearInterval?.min ?? '' }}
+          </b>
+        </div>
+      </div>
+    </ng-template>
   </div>
 </div>

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.html
@@ -1,7 +1,36 @@
-<pnx-map height="100%">
-  <pnx-geojson
-    [geojson]="observations"
-    [zoomOnFirstTime]="true"
-    [style]="styleTabGeoJson"
-  ></pnx-geojson>
-</pnx-map>
+<div class="TabGeographic">
+  <pnx-map
+    class="TabGeographic__map"
+    height="100%"
+  >
+    <pnx-geojson
+      [geojson]="observations"
+      [zoomOnFirstTime]="true"
+      [style]="styleTabGeoJson"
+    ></pnx-geojson>
+  </pnx-map>
+  <div class="TabGeographic__side">
+    <div class="TabGeographic__sideItem">
+      <mat-label>Plage d'observations: {{ yearInterval.min }} -> {{ yearInterval.max }}</mat-label>
+      <mat-slider
+        class="DateSlider"
+        [displayWith]="formatLabel"
+        [min]="YEAR_INTERVAL.min"
+        [max]="YEAR_INTERVAL.max"
+        step="1"
+        discrete
+      >
+        <input
+          (change)="updateTabGeographic()"
+          [(ngModel)]="yearInterval.min"
+          matSliderStartThumb
+        />
+        <input
+          (change)="updateTabGeographic()"
+          [(ngModel)]="yearInterval.max"
+          matSliderEndThumb
+        />
+      </mat-slider>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.scss
@@ -37,3 +37,25 @@
 ::ng-deep .legend:hover {
   opacity: 1;
 }
+
+.TabGeographic {
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 1rem;
+  height: 100%;
+  &__map {
+    width: 70%;
+  }
+  &__side {
+    width: 30%;
+    &Item {
+      display: flex;
+      flex-flow: column;
+      justify-content: flex-start;
+      max-width: 100%;
+      .DateSlider {
+        width: inherit;
+      }
+    }
+  }
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.scss
@@ -54,6 +54,11 @@
       justify-content: flex-start;
       max-width: 100%;
       .DateSlider {
+        --mdc-slider-handle-width: 15px;
+        --mdc-slider-handle-height: 15px;
+        --mdc-slider-inactive-track-height: 3px;
+        --mdc-slider-active-track-height: var(--mdc-slider-inactive-track-height);
+
         width: inherit;
       }
     }

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.scss
@@ -1,0 +1,39 @@
+::ng-deep .leaflet-tooltip-pane .number-obs {
+  color: rgb(0, 0, 0);
+  /* font-weight: bold; */
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  /* font-size:2; */
+}
+::ng-deep .tab-geographic-overview {
+  background-color: rgba(255, 255, 255, 0.8);
+}
+::ng-deep .tab-geographic-overview .custom-control-label {
+  margin: 0.2rem;
+}
+::ng-deep .tab-geographic-overview .custom-control-label::before {
+  top: 0.05rem;
+}
+::ng-deep .tab-geographic-overview .custom-control-label::after {
+  top: calc(0.05rem + 2px);
+}
+::ng-deep .legend {
+  line-height: 10px;
+  font-size: 14px;
+  color: #555;
+  background-color: white;
+  opacity: 0.7;
+  padding: 5px;
+  border-radius: 4px;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
+}
+::ng-deep .legend i {
+  width: 18px;
+  height: 18px;
+  float: left;
+  margin-right: 8px;
+}
+::ng-deep .legend:hover {
+  opacity: 1;
+}

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.ts
@@ -6,6 +6,18 @@ import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
 import { SyntheseDataService } from '@geonature_common/form/synthese-form/synthese-data.service';
 import { FeatureCollection } from 'geojson';
 import { TaxonSheetService } from '../taxon-sheet.service';
+import { ConfigService } from '@geonature/services/config.service';
+import * as L from 'leaflet';
+import { SyntheseFormService } from '@geonature_common/form/synthese-form/synthese-form.service';
+import { TranslateService } from '@ngx-translate/core';
+import { MapService } from '@geonature_common/map/map.service';
+
+interface MapAreasStyle {
+  color: string;
+  weight: number;
+  fillOpacity: number;
+  fillColor?: string;
+}
 
 @Component({
   standalone: true,
@@ -16,11 +28,38 @@ import { TaxonSheetService } from '../taxon-sheet.service';
 })
 export class TabGeographicOverviewComponent implements OnInit {
   observations: FeatureCollection | null = null;
+  areasEnable: boolean;
+  areasLegend: any;
+  private areasLabelSwitchBtn;
+  public featureGroup: any;
+  styleTabGeoJson: {};
+
+  mapAreasStyle: MapAreasStyle = {
+    color: '#FFFFFF',
+    weight: 0.4,
+    fillOpacity: 0.8,
+  };
+
+  mapAreasStyleActive: MapAreasStyle = {
+    color: '#FFFFFF',
+    weight: 0.4,
+    fillOpacity: 0,
+  };
+
   constructor(
     private _syntheseDataService: SyntheseDataService,
     private _tss: TaxonSheetService,
-    public mapListService: MapListService
-  ) {}
+    public mapListService: MapListService,
+    public config: ConfigService,
+    public formService: SyntheseFormService,
+    public translateService: TranslateService,
+    private _ms: MapService
+  ) {
+    this.areasEnable =
+      this.config.SYNTHESE.AREA_AGGREGATION_ENABLED &&
+      this.config.SYNTHESE.AREA_AGGREGATION_BY_DEFAULT;
+    this.featureGroup = new L.FeatureGroup();
+  }
 
   ngOnInit() {
     this._tss.taxon.subscribe((taxon: Taxon | null) => {
@@ -28,17 +67,169 @@ export class TabGeographicOverviewComponent implements OnInit {
         this.observations = null;
         return;
       }
-      this._syntheseDataService
-        .getSyntheseData(
-          {
-            cd_ref: [taxon.cd_ref],
-          },
-          {}
-        )
-        .subscribe((data) => {
-          // Store geojson
-          this.observations = data;
-        });
+      const format = this.areasEnable ? 'grouped_geom_by_areas' : 'grouped_geom';
+      this.updateTabGeographic(taxon, format);
     });
+    this.initializeFormWithMapParams();
+  }
+
+  updateTabGeographic(taxon: Taxon, format: string) {
+    this._syntheseDataService
+      .getSyntheseData(
+        {
+          cd_ref: [taxon.cd_ref],
+        },
+        { format }
+      )
+      .subscribe((data) => {
+        this.observations = data;
+
+        this.styleTabGeoJson = undefined;
+
+        const map = this._ms.getMap();
+
+        map.eachLayer((layer) => {
+          if (!(layer instanceof L.TileLayer)) {
+            map.removeLayer(layer);
+          }
+        });
+
+        if (this.observations && this.areasEnable) {
+          L.geoJSON(this.observations, {
+            onEachFeature: (feature, layer) => {
+              const observations = feature.properties.observations;
+              if (observations && observations.length > 0) {
+                const obsCount = observations.length;
+                this.setAreasStyle(layer as L.Path, obsCount);
+              }
+            },
+          }).addTo(map);
+        }
+      });
+  }
+
+  private initializeFormWithMapParams() {
+    this.formService.searchForm.patchValue({
+      format: this.areasEnable ? 'grouped_geom_by_areas' : 'grouped_geom',
+    });
+  }
+
+  ngAfterViewInit() {
+    this.addAreasButton();
+    if (this.areasEnable) {
+      this.addAreasLegend();
+    }
+  }
+
+  addAreasButton() {
+    const LayerControl = L.Control.extend({
+      options: {
+        position: 'topright',
+      },
+      onAdd: (map) => {
+        let switchBtnContainer = L.DomUtil.create(
+          'div',
+          'leaflet-bar custom-control custom-switch leaflet-control-custom tab-geographic-overview'
+        );
+
+        let switchBtn = L.DomUtil.create('input', 'custom-control-input', switchBtnContainer);
+        switchBtn.id = 'toggle-areas-btn';
+        switchBtn.type = 'checkbox';
+        switchBtn.checked = this.config.SYNTHESE.AREA_AGGREGATION_BY_DEFAULT;
+
+        switchBtn.onclick = () => {
+          this.areasEnable = switchBtn.checked;
+          const format = switchBtn.checked ? 'grouped_geom_by_areas' : 'grouped_geom';
+
+          this._tss.taxon.subscribe((taxon: Taxon | null) => {
+            if (taxon) {
+              this.updateTabGeographic(taxon, format);
+            }
+          });
+
+          if (this.areasEnable) {
+            this.addAreasLegend();
+          } else {
+            this.removeAreasLegend();
+          }
+        };
+
+        this.areasLabelSwitchBtn = L.DomUtil.create(
+          'label',
+          'custom-control-label',
+          switchBtnContainer
+        );
+        this.areasLabelSwitchBtn.setAttribute('for', 'toggle-areas-btn');
+        this.areasLabelSwitchBtn.innerText = this.translateService.instant(
+          'Synthese.Map.AreasToggleBtn'
+        );
+
+        return switchBtnContainer;
+      },
+    });
+
+    const map = this._ms.getMap();
+    map.addControl(new LayerControl());
+  }
+
+  private addAreasLegend() {
+    if (this.areasLegend) return;
+    this.areasLegend = new (L.Control.extend({
+      options: { position: 'bottomright' },
+    }))();
+
+    this.areasLegend.onAdd = (map: L.Map): HTMLElement => {
+      let div: HTMLElement = L.DomUtil.create('div', 'info legend');
+      let grades: number[] = this.config['SYNTHESE']['AREA_AGGREGATION_LEGEND_CLASSES']
+        .map((legendClass: { min: number; color: string }) => legendClass.min)
+        .reverse();
+      let labels: string[] = ["<strong> Nombre <br> d'observations </strong> <br>"];
+
+      for (let i = 0; i < grades.length; i++) {
+        labels.push(
+          '<i style="background:' +
+            this.getColor(grades[i] + 1) +
+            '"></i> ' +
+            grades[i] +
+            (grades[i + 1] ? '&ndash;' + grades[i + 1] + '<br>' : '+')
+        );
+      }
+      div.innerHTML = labels.join('<br>');
+
+      return div;
+    };
+
+    const map = this._ms.getMap();
+    this.areasLegend.addTo(map);
+  }
+
+  private removeAreasLegend() {
+    if (this.areasLegend) {
+      const map = this._ms.getMap();
+      map.removeControl(this.areasLegend);
+      this.areasLegend = null;
+    }
+  }
+
+  private setAreasStyle(layer: L.Path, obsNbr: number) {
+    this.mapAreasStyle['fillColor'] = this.getColor(obsNbr);
+    layer.setStyle(this.mapAreasStyle);
+    delete this.mapAreasStyle['fillColor'];
+    this.styleTabGeoJson = this.mapAreasStyleActive;
+  }
+
+  private getColor(obsNbr: number) {
+    let classesNbr = this.config['SYNTHESE']['AREA_AGGREGATION_LEGEND_CLASSES'].length;
+    let lastIndex = classesNbr - 1;
+    for (let i = 0; i < classesNbr; i++) {
+      let legendClass = this.config['SYNTHESE']['AREA_AGGREGATION_LEGEND_CLASSES'][i];
+      if (i != lastIndex) {
+        if (obsNbr > legendClass.min) {
+          return legendClass.color;
+        }
+      } else {
+        return legendClass.color;
+      }
+    }
   }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.ts
@@ -42,7 +42,7 @@ export class TabGeographicOverviewComponent implements OnInit {
 
   readonly YEAR_INTERVAL: YearInterval = {
     min: 1970,
-    max: 2025,
+    max: new Date().getFullYear(),
   };
   yearInterval: YearInterval = { ...this.YEAR_INTERVAL };
 

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.ts
@@ -30,8 +30,7 @@ export class TabGeographicOverviewComponent implements OnInit {
   observations: FeatureCollection | null = null;
   areasEnable: boolean;
   areasLegend: any;
-  private areasLabelSwitchBtn;
-  public featureGroup: any;
+  private _areasLabelSwitchBtn;
   styleTabGeoJson: {};
 
   mapAreasStyle: MapAreasStyle = {
@@ -58,7 +57,6 @@ export class TabGeographicOverviewComponent implements OnInit {
     this.areasEnable =
       this.config.SYNTHESE.AREA_AGGREGATION_ENABLED &&
       this.config.SYNTHESE.AREA_AGGREGATION_BY_DEFAULT;
-    this.featureGroup = new L.FeatureGroup();
   }
 
   ngOnInit() {
@@ -154,13 +152,13 @@ export class TabGeographicOverviewComponent implements OnInit {
           }
         };
 
-        this.areasLabelSwitchBtn = L.DomUtil.create(
+        this._areasLabelSwitchBtn = L.DomUtil.create(
           'label',
           'custom-control-label',
           switchBtnContainer
         );
-        this.areasLabelSwitchBtn.setAttribute('for', 'toggle-areas-btn');
-        this.areasLabelSwitchBtn.innerText = this.translateService.instant(
+        this._areasLabelSwitchBtn.setAttribute('for', 'toggle-areas-btn');
+        this._areasLabelSwitchBtn.innerText = this.translateService.instant(
           'Synthese.Map.AreasToggleBtn'
         );
 

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-geographic-overview/tab-geographic-overview.component.ts
@@ -109,11 +109,11 @@ export class TabGeographicOverviewComponent implements OnInit {
     const format = this.areasEnable ? 'grouped_geom_by_areas' : 'grouped_geom';
 
     const filter: {
-      cd_ref: number[];
+      cd_ref_parent: number[];
       date_min?: string;
       date_max?: string;
     } = {
-      cd_ref: [this.taxon.cd_ref],
+      cd_ref_parent: [this.taxon.cd_ref],
     };
     if (this.yearInterval) {
       filter.date_min = `${this.yearInterval.min}-01-01`;

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.ts
@@ -17,7 +17,7 @@ import {
 import { TaxonImageComponent } from './infos/taxon-image/taxon-image.component';
 import { IndicatorComponent } from './indicator/indicator.component';
 import { CommonModule } from '@angular/common';
-import { SyntheseDataService } from '@geonature_common/form/synthese-form/synthese-data.service';
+import { TaxonStats } from '@geonature_common/form/synthese-form/synthese-data.service';
 import { TaxonSheetService } from './taxon-sheet.service';
 import { RouteService } from './taxon-sheet.route.service';
 
@@ -83,7 +83,6 @@ export class TaxonSheetComponent implements OnInit {
     private _router: Router,
     private _route: ActivatedRoute,
     private _tss: TaxonSheetService,
-    private _syntheseDataService: SyntheseDataService,
     private _routes: RouteService
   ) {
     this.TAB_LINKS = this._routes.TAB_LINKS;
@@ -93,14 +92,14 @@ export class TaxonSheetComponent implements OnInit {
       const cd_ref = params['cd_ref'];
       if (cd_ref) {
         this._tss.updateTaxonByCdRef(cd_ref);
-        this._syntheseDataService.getSyntheseTaxonSheetStat(cd_ref).subscribe((stats) => {
-          this.setIndicators(stats);
-        });
       }
+    });
+    this._tss.taxonStats.subscribe((stats: TaxonStats | null) => {
+      this.setIndicators(stats);
     });
   }
 
-  setIndicators(stats: any) {
+  setIndicators(stats: TaxonStats) {
     this.indicators = INDICATORS.map((indicatorConfig: IndicatorDescription) =>
       computeIndicatorFromDescription(indicatorConfig, stats)
     );

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
@@ -1,16 +1,22 @@
 import { Injectable } from '@angular/core';
 import { ConfigService } from '@geonature/services/config.service';
 import { DataFormService } from '@geonature_common/form/data-form.service';
+import {
+  SyntheseDataService,
+  TaxonStats,
+} from '@geonature_common/form/synthese-form/synthese-data.service';
 import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
 import { BehaviorSubject } from 'rxjs';
 
 @Injectable()
 export class TaxonSheetService {
   taxon: BehaviorSubject<Taxon | null> = new BehaviorSubject<Taxon | null>(null);
+  taxonStats: BehaviorSubject<TaxonStats | null> = new BehaviorSubject<TaxonStats | null>(null);
 
   constructor(
     private _ds: DataFormService,
-    public config: ConfigService
+    public config: ConfigService,
+    private _sds: SyntheseDataService
   ) {}
 
   updateTaxonByCdRef(cd_ref: number) {
@@ -24,6 +30,13 @@ export class TaxonSheetService {
         return this.config.SYNTHESE.ID_ATTRIBUT_TAXHUB.includes(v.id_attribut);
       });
       this.taxon.next(taxon);
+      this.fetchTaxonStats(cd_ref);
+    });
+  }
+
+  fetchTaxonStats(cd_ref: number) {
+    this._sds.getSyntheseTaxonSheetStat(cd_ref).subscribe((stats: TaxonStats) => {
+      this.taxonStats.next(stats);
     });
   }
 }


### PR DESCRIPTION
closes https://github.com/orgs/PnX-SI/projects/20/views/7?pane=issue&itemId=69854886

## Description
Ajout d'une option de maillage sur la synthèse géographique.
Ajout d'un tooltip sur la fiche espèce de la synthèse géographique.

## Aperçu
![Capture d’écran du 2024-10-11 15-13-50](https://github.com/user-attachments/assets/6ecb5cbb-8346-4055-bf17-fd106a1c1c95)

Le développement réalisé s'appuie sur le composant `synthese-carte`.
