### PR TITLE
Documentation - Remove external TaxHub references

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -7,7 +7,7 @@ Problèmes liés au frontend
 Changement d'URL de GeoNature
 """""""""""""""""""""""""""""
 
-Si vous souhaitez changer l'URL de l'API de GeoNature, il est nécessaire d'indiquer les nouvelles adresses dans le fichier de configuration principale (``geonature/config/geonature_config.toml`` pour GeoNature, ainsi que ceux de TaxHub et UsersHub)  ainsi que le fichier ``frontend/src/assets/config.json`` précisant l'URL de l'API au frontend. Pour mettre à jour ce fichier automatiquement, relancer le script ``install/05_install_frontend.sh``.
+Si vous souhaitez changer l'URL de l'API de GeoNature, il est nécessaire d'indiquer les nouvelles adresses dans le fichier de configuration principale (``geonature/config/geonature_config.toml`` pour GeoNature, ainsi que celle de UsersHub)  ainsi que le fichier ``frontend/src/assets/config.json`` précisant l'URL de l'API au frontend. Pour mettre à jour ce fichier automatiquement, relancer le script ``install/05_install_frontend.sh``.
  
 Message d'erreur lors de la compilation du frontend
 """""""""""""""""""""""""""""""""""""""""""""""""""
@@ -50,14 +50,12 @@ Vous pouvez essayer de stopper les backends durant le build du frontend :
 
     $ sudo systemctl stop geonature
     $ sudo systemctl stop geonature-worker
-    $ sudo systemctl stop taxhub
     $ sudo systemctl stop usershub
     $ cd frontend
     $ nvm use
     $ npm run build
     $ sudo systemctl start geonature
     $ sudo systemctl start geonature-worker
-    $ sudo systemctl start taxhub
     $ sudo systemctl start usershub
 
 

--- a/docs/admin-manual.rst
+++ b/docs/admin-manual.rst
@@ -7,7 +7,7 @@ Architecture
 GeoNature possède une architecture modulaire et s'appuie sur plusieurs "services" indépendants pour fonctionner :
 
 - UsersHub et son sous-module d'authentification Flask (https://github.com/PnX-SI/UsersHub-authentification-module) sont utilisés pour gérer le schéma de BDD ``ref_users`` (actuellement nommé ``utilisateurs``) et l'authentification. UsersHub permet une gestion centralisée de ses utilisateurs (listes, organismes, applications), utilisable par les différentes applications de son système d'informations.
-- TaxHub (https://github.com/PnX-SI/TaxHub) est utilisé pour la gestion du schéma de BDD ``ref_taxonomy`` (actuellement nommé ``taxonomie``). L'API de TaxHub est utilisée pour récupérer des informations sur les espèces et la taxonomie en général.
+- TaxHub (https://github.com/PnX-SI/TaxHub) est utilisé pour la gestion du schéma de BDD ``ref_taxonomy`` (actuellement nommé ``taxonomie``). L'API de TaxHub est utilisée pour récupérer des informations sur les espèces et la taxonomie en général. TaxHub est intégré à GeoNature depuis sa version 2.15.
 - Un sous-module Flask (https://github.com/PnX-SI/Nomenclature-api-module/) a été créé pour une gestion centralisée des nomenclatures (https://github.com/PnX-SI/Nomenclature-api-module/), il pilote le schéma ``ref_nomenclature``.
 - ``ref_geo`` est le schéma de base de données qui gère le référentiel géographique. Il est utilisé pour gérer les zonages, les communes, le MNT, le calcul automatique d'altitude et les intersections spatiales.
 
@@ -356,11 +356,6 @@ Cette section liste les branches Alembic disponibles et leur impact sur la base 
 * ``habitats`` : Créé le schéma ``ref_habitats``. Fourni par Habref-api-module.
 * ``habitats_inpn_data`` : Insère le référentiel HABREF de l’INPN en base. Fourni par Habref-api-module.
 * ``ref_geo`` : Créé le schéma ``ref_geo``. Fourni par RefGeo.
-
-Si vous utilisez TaxHub, vous pouvez être intéressé par les branches suivantes :
-
-* ``taxhub`` : Déclare l’application TaxHub dans la liste des applications. Fourni par TaxHub.
-* ``taxhub-admin`` : Associe le groupe « Grp_admin » issue des données d’exemple à l’application UsersHub et au profil « Administrateur » permettant aux utilisateurs du groupe de se connecter à TaxHub. Fourni par TaxHub.
 
 Si vous utilisez UsersHub, vous pouvez être intéressé par les branches suivantes :
 
@@ -975,7 +970,6 @@ Logs
 * Logs d’installation de GeoNature : ``geonature/install/install.log``
 * Logs de GeoNature : ``/var/log/geonature/geonature.log``
 * Logs du worker Celery : ``/var/log/geonature/geonature-worker.log``
-* Logs de TaxHub : ``/var/log/taxhub.log``
 * Logs de UsersHub : ``/var/log/usershub.log``
 
 Commandes GeoNature
@@ -1012,18 +1006,15 @@ Démarrer / arrêter les API
 * Redémarrer GeoNature : ``systemctl restart geonature``
 * Vérifier l’état de GeoNature : ``systemctl status geonature``
 
-Les mêmes commandes sont disponibles pour TaxHub en remplacant ``geonature`` par ``taxhub``.
-
 Supervision des services
 """"""""""""""""""""""""
 
-- Vérifier que les applications GeoNature et TaxHub sont accessibles en http
+- Vérifier que l'application GeoNature est accessible en http
 - Vérifier que leurs services (API) sont lancés et fonctionnent correctement (tester les deux routes ci-dessous).
 
   - Exemple de route locale pour tester l'API GeoNature : http://127.0.0.1:8000/occtax/defaultNomenclatures qui ne doit pas renvoyer de 404. URL absolue : https://urlgeonature/api/occtax/defaultNomenclatures
-  - Exemple de route locale pour tester l'API TaxHub : http://127.0.0.1:5000/api/taxref/regnewithgroupe2 qui ne doit pas renvoyer de 404. URL absolue : https://urltaxhub/api/taxref/regnewithgroupe2
 
-- Vérifier que les fichiers de logs de TaxHub et GeoNature ne sont pas trop volumineux pour la capacité du serveur
+- Vérifier que le fichier de logs de GeoNature n'est pas trop volumineux pour la capacité du serveur
 - Vérifier que les services nécessaires au fonctionnement de l'application tournent bien (Apache, PostgreSQL)
 
 Maintenance
@@ -1051,7 +1042,7 @@ Attention : ne pas stopper le backend (des opérations en BDD en cours pourraien
 
 - Redémarrage de PostgreSQL
 
-  Si vous effectuez des manipulations de PostgreSQL qui nécessitent un redémarrage du SGBD (``sudo service postgresql restart``), il faut impérativement lancer un redémarrage des API GeoNature et TaxHub pour que celles-ci continuent de fonctionner. Pour cela, lancez les commandes ``sudo systemctl restart geonature`` et ``sudo systemctl restart taxhub`` (GeoNature 2.8+).
+  Si vous effectuez des manipulations de PostgreSQL qui nécessitent un redémarrage du SGBD (``sudo service postgresql restart``), il faut impérativement lancer un redémarrage de l'API GeoNature pour que celle-ci continue de fonctionner. Pour cela, lancez la commande ``sudo systemctl restart geonature`` (GeoNature 2.8+).
 
   **NB**: Ne pas faire ces manipulations sans avertir les utilisateurs d'une perturbation temporaire des applications.
 
@@ -2006,7 +1997,7 @@ TaxHub
 """"""
 
 Module de gestion des taxons (basé sur TaxHub) permettant de faire des listes de taxons ainsi que d'ajouter des attributs et des médias aux taxons.
-Voir la documentation de TaxHub : https://taxhub.readthedocs.io/fr/latest/
+Voir la documentation de TaxHub : https://taxhub.readthedocs.io/fr/
 
 Module OCCHAB
 -------------
@@ -2311,9 +2302,8 @@ Une commande dans TaxHub permet de désactiver automatiquement les textes en deh
 
 ::
 
-  cd ~/taxhub
-  source venv/bin/activate
-  flask taxref enable-bdc-statut-text -d <MON_DEP_1> -d <MON_DEP_2> --clean
+  source ~/geonature/backend/venv/bin/activate
+  geonature taxref enable-bdc-statut-text -d <MON_DEP_1> -d <MON_DEP_2> --clean
 
 **6.** Définir des filtres par défaut
 
@@ -2438,7 +2428,7 @@ Dans GeoNature, la validation automatique est effectuée par une fonction en ``P
 Module TaxHub
 -------------
 
-Depuis la version 2.14 de GeoNature, TaxHub est integré comme un module de GeoNature. Il est disponible depuis le module "Admin" de GeoNature.
+Depuis la version 2.15 de GeoNature, TaxHub est integré comme un module de GeoNature. Il est disponible depuis le module "Admin" de GeoNature.
 
 L'emplacement de stockage des médias est contrôlé par le paramètre `MEDIA_FOLDER`. Les médias de TaxHub seront à l'emplacement `<MEDIA_FOLDER>/taxhub`. Par défaut tous les médias de GeoNature sont stockés dans le répertoire de GeoNature : `<GEONATURE_DIR>/backend/media`. Via ce paramètre, il est possible de mettre un chemin absolu pour stocker les médias n'importe où ailleurs sur votre serveur.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -27,7 +27,7 @@ API
 
 GeoNature utilise :
 
-- l'API de TaxHub (recherche taxon, règne et groupe d'un taxon...)
+- l'API de TaxHub (recherche taxon, règne et groupe d'un taxon...), intégrée à GeoNature depuis sa version 2.15
 - l'API du sous-module Nomenclatures (typologies et listes déroulantes)
 - l'API du sous-module d'authentification de UsersHub (login/logout, récupération du CRUVED d'un utilisateur)
 - l'API de GeoNature (get, post, update des données des différents modules, métadonnées, intersections géographiques, exports...)
@@ -242,15 +242,8 @@ Autres extensions en développement
 Il n'est pas forcémment utile de passer toutes les extensions en mode dévelomment.
 Pour plus d'informations, référez-vous aux documentations dédiées :
 
-- https://taxhub.readthedocs.io/fr/latest/installation.html#developpement
+- https://taxhub.readthedocs.io/fr/latest/developpement.html
 - https://usershub.readthedocs.io/fr/latest/
-
-Si toutefois TaxHub retourne une erreur 500 et ne répond pas sur l'URL http://127.0.0.1:5000, alors vous pouvez avoir besoin de passer TaxHub en mode développement :
-
-.. code-block:: bash
-
-  source ~/taxhub/venv/bin/activate
-  flask run
 
 Debugger avec un navigateur
 ***************************

--- a/docs/https.rst
+++ b/docs/https.rst
@@ -40,7 +40,7 @@ Activer les modules ``ssl``, ``headers`` et ``rewrite`` puis redémarrer Apache�
     sudo a2enmod headers
     sudo apachectl restart
 
-Les fichiers de configuration des sites TaxHub et UsersHub ne sont pas à modifier, ils seront automatiquement associés à la configuration HTTPS. En revanche, la configuration de GeoNature doit être mise à jour.
+Les fichiers de configuration du site UsersHub n'est pas à modifier, il sera automatiquement associé à la configuration HTTPS. En revanche, la configuration de GeoNature doit être mise à jour.
 
 
 Configuration de l'application GeoNature

--- a/docs/installation-all.rst
+++ b/docs/installation-all.rst
@@ -7,11 +7,10 @@ En lançant le script d'installation ci-dessous, l'application GeoNature ainsi q
 
 Les applications suivantes seront installées :
 
-- `GeoNature <https://github.com/PnX-SI/GeoNature>`_
-- `TaxHub <https://github.com/PnX-SI/TaxHub>`_ qui pilote le schéma ``taxonomie``
+- `GeoNature <https://github.com/PnX-SI/GeoNature>`_ (incluant `TaxHub <https://github.com/PnX-SI/TaxHub>`_ qui pilote le schéma ``taxonomie``)
 - `UsersHub <https://github.com/PnX-SI/UsersHub>`_ qui pilote le schéma ``utilisateurs`` (le paramètre ``install_usershub_app`` du fichier de configuration ``install_all.ini`` permet de désactiver l'installation de l'application. Il est cependant recommandé d'installer l'application pour disposer d'une interface pour gérer les utilisateurs dans GeoNature)
 
-Si vous disposez déjà de Taxhub ou de UsersHub sur un autre serveur ou une autre base de données et que vous souhaitez installer simplement GeoNature, veuillez suivre la documentation :ref:`installation-standalone`.
+Si vous disposez déjà de UsersHub sur un autre serveur ou une autre base de données et que vous souhaitez installer simplement GeoNature, veuillez suivre la documentation :ref:`installation-standalone`.
 
 
 Installation des applications
@@ -19,7 +18,7 @@ Installation des applications
 
 Commencer la procédure en se connectant au serveur en SSH avec l'utilisateur dédié précédemment créé lors de l’étape de :ref:`preparation-server` (usuellement ``geonatureadmin``).
 
-* Se placer à la racine du ``home`` de l'utilisateur puis récupérer les scripts d'installation (X.Y.Z à remplacer par le numéro de la `dernière version stable de GeoNature <https://github.com/PnEcrins/GeoNature/releases>`_). Ces scripts installent les applications GeoNature, TaxHub et UsersHub (en option) ainsi que leurs bases de données (uniquement les schémas du coeur) :
+* Se placer à la racine du ``home`` de l'utilisateur puis récupérer les scripts d'installation (X.Y.Z à remplacer par le numéro de la `dernière version stable de GeoNature <https://github.com/PnEcrins/GeoNature/releases>`_). Ces scripts installent les applications GeoNature (incluant TaxHub) et UsersHub (en option) ainsi que leurs bases de données (uniquement les schémas du coeur) :
  
   .. code:: console
 
@@ -56,7 +55,6 @@ Une fois l'installation terminée, lancez la commande suivante:
 Les applications sont disponibles aux adresses suivantes :
 
 - http://monip.com/geonature/
-- http://monip.com/taxhub/
 - http://monip.com/usershub/ (en option)
 
 Vous pouvez vous connecter avec l'utilisateur intégré par défaut (admin/admin).
@@ -83,14 +81,13 @@ Si vous rencontrez une erreur, se reporter aux fichiers de logs ``/home/`whoami`
 
     Par défaut et par mesure de sécurité, la base de données est accessible uniquement localement par la machine où elle est installée. Pour accéder à la BDD depuis une autre machine (pour s'y connecter avec QGIS, pgAdmin ou autre), vous pouvez consulter cette documentation https://github.com/PnX-SI/Ressources-techniques/blob/master/PostgreSQL/acces-bdd.rst.
     Attention, exposer la base de données sur internet n'est pas recommandé. Il est préférable de se connecter via un tunnel SSH. QGIS et la plupart des outils d'administration de base de données permettent d'établir une connexion à la base de cette manière.
-    Attention si vous redémarrez PostgreSQL (``sudo service postgresql restart``), il faut ensuite redémarrer les API de GeoNature, UsersHub et TaxHub :
+    Attention si vous redémarrez PostgreSQL (``sudo service postgresql restart``), il faut ensuite redémarrer les API de GeoNature et UsersHub :
 
     .. code:: console
 
         $ sudo systemctl restart geonature
         $ sudo systemctl restart geonature-worker
         $ sudo systemctl restart usershub
-        $ sudo systemctl restart taxhub
 
 :Note:
 

--- a/docs/installation-docker.rst
+++ b/docs/installation-docker.rst
@@ -1,7 +1,7 @@
 Docker
 ******
 
-L'installation de GeoNature avec Docker est la manière la plus simple de déployer GeoNature, ses 4 modules externes principaux (Import, Export, Dashboard, Monitoring), TaxHub et UsersHub, mais aussi de les mettre à jour, avec seulement quelques lignes de commandes.
+L'installation de GeoNature avec Docker est la manière la plus simple de déployer GeoNature, ses 4 modules externes principaux (Import, Export, Dashboard, Monitoring) et UsersHub, mais aussi de les mettre à jour, avec seulement quelques lignes de commandes.
 
 Elle permet aussi d'installer GeoNature sur différents systèmes, et pas uniquement sur Debian, comme c'est le cas avec l'installation classique.
 
@@ -12,7 +12,7 @@ Docker Compose
 
 Pour déployer facilement GeoNature avec Docker, utilisez le Docker Compose proposé et documenté dans le dépôt `GeoNature-Docker-services <https://github.com/PnX-SI/Geonature-Docker-services/>`_.
 
-Pour des déploiements Docker plus avancés et spécifiques, des images Docker des différents outils (GeoNature, TaxHub, UsersHub, GeoNature et ses 4 modules externes principaux) sont automatiquement construites et publiées à chaque nouvelle version publiée.
+Pour des déploiements Docker plus avancés et spécifiques, des images Docker des différents outils (GeoNature, UsersHub, GeoNature et ses 4 modules externes principaux) sont automatiquement construites et publiées à chaque nouvelle version publiée.
 
 Image backend
 -------------

--- a/docs/installation-standalone.rst
+++ b/docs/installation-standalone.rst
@@ -1,8 +1,8 @@
 Installation de GeoNature uniquement
 ************************************
 
-Cette procédure détail l’installation de GeoNature seul, sans TaxHub et UsersHub.
-Si vous souhaitez installer GeoNature avec TaxHub et UsersHub, reportez-vous à la section :ref:`installation-all`.
+Cette procédure détaille l’installation de GeoNature (incluant TaxHub) sans UsersHub.
+Si vous souhaitez installer GeoNature avec UsersHub, reportez-vous à la section :ref:`installation-all`.
 
 Installation des dépendances
 ----------------------------
@@ -111,37 +111,9 @@ Lors de l'installation de la BDD (``02_create_db.sh``), le schéma ``utilisateur
 
 UsersHub n'est pas nécessaire au fonctionnement de GeoNature mais il sera utile pour avoir une interface de gestion des utilisateurs, des groupes et de leurs droits. 
 
-Par contre il est nécessaire d'installer TaxHub (https://github.com/PnX-SI/TaxHub) pour que GeoNature fonctionne. En effet, GeoNature utilise l'API de TaxHub. Une fois GeoNature installé, il vous faut donc installer TaxHub en le connectant à la BDD de GeoNature, vu que son schéma ``taxonomie`` a déjà été installé par le script ``02_create_db.sh`` de GeoNature. Lors de l'installation de TaxHub, n'installez donc que l'application et pas la BDD.
+TaxHub v2 est intégré à GeoNature depuis sa version 2.15.0
 
-Télécharger TaxHub depuis son dépôt Github depuis la racine de votre utilisateur :
-
-::
-
-    cd ~
-    wget https://github.com/PnX-SI/TaxHub/archive/X.Y.Z.zip
-    unzip X.Y.Z.zip
-    rm X.Y.Z.zip
-    
-en mode développeur: 
-
-``https://github.com/PnX-SI/TaxHub.git``
-
-Rendez vous dans le répertoire téléchargé et dézippé, puis "désamplez" le fichier ``settings.ini`` et remplissez la configuration avec les paramètres de connexion à la BDD GeoNature précedemment installée :
-
-::
-
-    cp settings.ini.sample settings.ini
-    nano settings.ini
-
-Lancer le script d'installation de l'application :
-
-::
-
-    ./install_app.sh 2>&1 | tee install_app.log
-
-Suite à l'execution de ce script, l'application Taxhub a été lancée automatiquement par le superviseur et est disponible à l'adresse ``http://127.0.0.1:5000`` (et l'API, à ``http://127.0.0.1:5000/api``)
-
-Voir la doc d'installation de TaxHub : https://taxhub.readthedocs.io/
+Voir la documentation de TaxHub : https://taxhub.readthedocs.io/
 
 Voir la doc d'installation de UsersHub : https://usershub.readthedocs.io/
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,8 +14,8 @@ GeoNature repose sur les composants suivants :
 
 Deux méthodes d’installation existent :
 
-- :ref:`installation-all` : Installation automatisée de GeoNature, TaxHub et UsersHub.
-- :ref:`installation-standalone` : TaxHub et UsersHub ne sont pas installés (mais leurs schémas sont tous de même créés dans la base de données).
+- :ref:`installation-all` : Installation automatisée de GeoNature (incluant TaxHub) et UsersHub.
+- :ref:`installation-standalone` : UsersHub n'est pas installé (mais son schéma de BDD est tout de même créé dans la base de données de GeoNature).
 
 
 Prérequis
@@ -265,7 +265,7 @@ Mise à jour de l'application
 .. warning::
     Vérifiez préalablement la compatibilité des modules que vous utilisez avant de mettre GeoNature à jour.
     S’il est nécessaire de les mettre à jour, arrêtez vous après le remplacement du dossier par le nouveau code source
-    (et la récupération éventuelle de la configuration) ; le script de migration de GeoNature s’occupera automatiquement
+    (et la récupération éventuelle de la configuration); le script de migration de GeoNature s’occupera automatiquement
     d’installer la nouvelle version du module.
 
 La mise à jour de GeoNature consiste à télécharger sa nouvelle version dans un nouveau répertoire, récupérer les fichiers de configuration et de surcouche, ainsi que les médias depuis la version actuelle et de relancer l'installation dans le répertoire de la nouvelle version.
@@ -292,7 +292,7 @@ La mise à jour doit être réalisée avec votre utilisateur linux courant (``ge
 
 Sauf mentions contraires dans les notes de version, vous pouvez sauter des versions mais en suivant bien les différentes notes de versions intermédiaires.
 
-* Si vous devez aussi mettre à jour TaxHub et/ou UsersHub, suivez leurs notes de versions mais aussi leur documentation (https://usershub.readthedocs.io et https://taxhub.readthedocs.io).
+* Si vous devez aussi mettre à jour UsersHub, suivez ses notes de version et sa documentation (https://usershub.readthedocs.io).
 
 * Lancez le script de ``migration.sh`` à la racine du dossier ``geonature``:
 
@@ -310,5 +310,5 @@ Dans ce cas, les commandes à exécuter sont :
   git status # optionnel, pour connaitre l'état et la version ou branche actuellement utilisée
   git fetch
   git checkout X.Y.Z # où X.Y.Z est le numéro du tag de la version vers laquelle faire la mise à jour, ou le nom de la branche à utiliser
-  git submodule update # ou "git config submodule.recurse true" lancé une seule fois, pour que la mise à jour des sous-modules soit relancée automatiquement à chaque git pull
+  git submodule update # ou "git config submodule.recurse true" lancé une seule fois, pour que la mise à jour des sous-modules soit relancée automatiquement à chaque "git pull"
   ./install/migration/migration.sh .


### PR DESCRIPTION
As TaxHub has been integrated in GeoNature in its 2.15 version