### PR TITLE
feat(workflows): add reusable pytest actions

### DIFF
--- a/.github/workflows/gn-module-pytest.yml
+++ b/.github/workflows/gn-module-pytest.yml
@@ -1,0 +1,159 @@
+name: Run pytest against GeoNature module
+
+on:
+  workflow_call:
+    inputs:
+      geonature_ref:
+        description: "La branche, tag ou SHA de GeoNature à utiliser"
+        default: "master"
+        required: false
+        type: string
+      upload_coverage:
+        description: "Téléverser la couverture de code sur Codecov"
+        default: false
+        required: false
+        type: boolean
+    secrets:
+      codecov_token:
+        description: "Token pour téléverser sur codecov"
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        debian-version: ['11', '12']
+        include:
+          - debian-version: '11'
+            python-version: '3.9'
+            postgres-version: '13'
+            postgis-version: '3.2'
+          - debian-version: '12'
+            python-version: '3.11'
+            postgres-version: '15'
+            postgis-version: '3.3'
+
+    name: Debian ${{ matrix.debian-version }}
+
+    services:
+      postgres:
+        image: postgis/postgis:${{ matrix.postgres-version }}-${{ matrix.postgis-version }}
+        env:
+          POSTGRES_DB: geonature2db
+          POSTGRES_PASSWORD: geonatpasswd
+          POSTGRES_USER: geonatadmin
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      MODULE_DIR: ${{ github.workspace }}/extra/${{ github.event.repository.name }}
+
+    steps:
+      - name: Clone GeoNature
+        uses: actions/checkout@v4
+        with:
+          repository: pnx-si/geonature
+          ref: ${{ inputs.geonature_ref }}
+          submodules: true
+      - name: Clone ${{ github.event.repository.name }} module
+        uses: actions/checkout@v4
+        with:
+          path: ${{ env.MODULE_DIR }}
+      - name: Add database extensions
+        run: |
+          psql -h localhost -U geonatadmin -d geonature2db -f install/assets/db/add_pg_extensions.sql
+        env:
+          PGPASSWORD: geonatpasswd
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Install GDAL
+        run: |
+          sudo apt update
+          sudo apt install -y libgdal-dev
+      - name: Install dependencies
+        if: github.action_ref == 'master'
+        run: |
+          echo 'Installation des requirements de prod'
+          python -m pip install --upgrade pip
+          python -m pip install \
+            -e ..[tests] \
+            -r requirements.txt
+        working-directory: ./backend
+      - name: Install dependencies
+        if: github.action_ref != 'master'
+        run: |
+          echo 'Installation des requirements de dev'
+          python -m pip install --upgrade pip
+          python -m pip install \
+            -e ..[tests] \
+            -r requirements-dev.txt
+        working-directory: ./backend
+      - name: Show database branches and dependencies
+        run: |
+          geonature db status --dependencies
+        env:
+          GEONATURE_CONFIG_FILE: config/test_config.toml
+      - name: Install database
+        run: |
+          install/03b_populate_db.sh
+        env:
+          GEONATURE_CONFIG_FILE: config/test_config.toml
+          srid_local: 2154
+          install_bdc_statuts: true
+          taxref_region: fr
+          add_sample_data: true
+          install_sig_layers: true
+          install_grid_layer_5: true
+          install_grid_layer_10: true
+          install_ref_sensitivity: true
+      - name: Show database status
+        run: |
+          geonature db status
+        env:
+          GEONATURE_CONFIG_FILE: config/test_config.toml
+      - name: Install core modules backend
+        run: |
+          pip install -e contrib/occtax
+          pip install -e contrib/gn_module_occhab
+          pip install -e contrib/gn_module_validation
+      - name: Install ${{ github.event.repository.name }} module backend
+        run: |
+          pip install -e .
+        working-directory: ${{ env.MODULE_DIR }}
+      - name: Install modules database
+        run: |
+          geonature upgrade-modules-db
+        env:
+          GEONATURE_CONFIG_FILE: config/test_config.toml
+      - name: Show database status
+        run: |
+          geonature db status --dependencies
+        env:
+          GEONATURE_CONFIG_FILE: config/test_config.toml
+      - name: Test with pytest
+        run: |
+          pytest -v --cov --cov-report xml
+        working-directory: ${{ env.MODULE_DIR }}
+        env:
+          GEONATURE_CONFIG_FILE: ${{ github.workspace }}/config/test_config.toml
+      - name: Show coverage
+        run: |
+          coverage report
+        working-directory: ${{ env.MODULE_DIR }}
+      - name: Upload coverage to Codecov
+        if: ${{ inputs.upload_coverage && matrix.debian-version == '12' }}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.codecov_token }}
+          flags: pytest


### PR DESCRIPTION
Action réutilisable par les modules GeoNature pour lancer les tests pytest.

Usage:
```
name: pytest

on:
  push:
    branches:
      - main
      - develop
  pull_request:

jobs:
  build:
    uses: pnx-si/geonature/.github/workflows/gn-module-pytest.yml@master
    with:
      geonature_ref: "develop"
```

Exemple: https://github.com/PnX-SI/gn_module_permrequests/blob/main/.github/workflows/pytest.yml

Perspectives :
- configurer la commande d’installation
- configurer la commande de test
- activer l’envoi du code coverage → fait, à tester
- si la ref geonature n’est pas fournit, utiliser la ref de l’action plutôt que master (ce qui revient au même si on utilise la version master de l’action) (pas si simple, voir cf https://github.com/dariocurr/checkout-called)
