### PR TITLE
feat(notifications): hide unallowed categories

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -96,8 +96,9 @@ jobs:
           geonature install-gn-module contrib/gn_module_validation VALIDATION --build=false --upgrade-db=false
           geonature db upgrade occtax-samples-test@head 
           geonature db upgrade occhab-samples@head
-          geonature permissions supergrant --group --nom "Grp_admin" --yes
           geonature db upgrade import-samples@head
+          geonature db autoupgrade
+          geonature permissions supergrant --group --nom "Grp_admin" --yes
         env:
           GEONATURE_CONFIG_FILE: config/test_config.toml
       - name: Run GeoNature backend

--- a/backend/geonature/core/notifications/routes.py
+++ b/backend/geonature/core/notifications/routes.py
@@ -1,5 +1,3 @@
-import json
-
 import logging
 
 from flask import (
@@ -193,17 +191,19 @@ def list_notification_methods():
 @routes.route("/categories", methods=["GET"])
 @permissions.login_required
 def list_notification_categories():
-    notificationCategories = db.session.scalars(
+    categories = db.session.scalars(
         select(NotificationCategory).order_by(NotificationCategory.code.asc())
     ).all()
-    result = [
-        notificationsCategory.as_dict(
-            fields=[
-                "code",
-                "label",
-                "description",
-            ]
-        )
-        for notificationsCategory in notificationCategories
-    ]
-    return jsonify(result)
+    categories = [category for category in categories if category.is_allowed()]
+    return jsonify(
+        [
+            category.as_dict(
+                fields=[
+                    "code",
+                    "label",
+                    "description",
+                ]
+            )
+            for category in categories
+        ]
+    )

--- a/backend/geonature/migrations/versions/0bea266db3ec_hide_unauthorized_notifications.py
+++ b/backend/geonature/migrations/versions/0bea266db3ec_hide_unauthorized_notifications.py
@@ -1,0 +1,75 @@
+"""hide unauthorized notifications categories
+
+Revision ID: 0bea266db3ec
+Revises: 7b6a578eccd7
+Create Date: 2024-11-20 17:23:42.017660
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import column
+
+
+# revision identifiers, used by Alembic.
+revision = "0bea266db3ec"
+down_revision = "7b6a578eccd7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        schema="gn_notifications",
+        table_name="bib_notifications_categories",
+        column=sa.Column(
+            "id_module",
+            sa.Integer,
+            sa.ForeignKey("gn_commons.t_modules.id_module"),
+        ),
+    )
+    op.add_column(
+        schema="gn_notifications",
+        table_name="bib_notifications_categories",
+        column=sa.Column(
+            "id_object",
+            sa.Integer,
+            sa.ForeignKey("gn_permissions.t_objects.id_object"),
+        ),
+    )
+    op.add_column(
+        schema="gn_notifications",
+        table_name="bib_notifications_categories",
+        column=sa.Column(
+            "id_action",
+            sa.Integer,
+            sa.ForeignKey("gn_permissions.bib_actions.id_action"),
+        ),
+    )
+    op.execute(
+        """
+        UPDATE gn_notifications.bib_notifications_categories
+        SET
+            id_module = (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'IMPORT'),
+            id_object = (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'IMPORT')
+        WHERE code = 'IMPORT-DONE'
+        """
+    )
+
+
+def downgrade():
+    op.drop_column(
+        table_name="bib_notifications_categories",
+        column_name="id_action",
+        schema="gn_notifications",
+    )
+    op.drop_column(
+        table_name="bib_notifications_categories",
+        column_name="id_object",
+        schema="gn_notifications",
+    )
+    op.drop_column(
+        table_name="bib_notifications_categories",
+        column_name="id_module",
+        schema="gn_notifications",
+    )

--- a/backend/geonature/migrations/versions/0bea266db3ec_hide_unauthorized_notifications.py
+++ b/backend/geonature/migrations/versions/0bea266db3ec_hide_unauthorized_notifications.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql import column
 
 # revision identifiers, used by Alembic.
 revision = "0bea266db3ec"
-down_revision = "d73f74e7b662"
+down_revision = "4e6ce32305f0"
 branch_labels = None
 depends_on = None
 

--- a/backend/geonature/migrations/versions/0bea266db3ec_hide_unauthorized_notifications.py
+++ b/backend/geonature/migrations/versions/0bea266db3ec_hide_unauthorized_notifications.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql import column
 
 # revision identifiers, used by Alembic.
 revision = "0bea266db3ec"
-down_revision = "7b6a578eccd7"
+down_revision = "d73f74e7b662"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Fixes #3262

- Pour import, il faut une permission sur le module import objet import, n’importe quelle action.
- La prochaine version du module d’export pourra rajouter une contraintes identiques.
- Pour la modification du statut de validation ou le commentaire sur une observation, les notifications sont envoyées aux observateurs et au digitaliser. En conséquence, pas de contrainte.
- Pour les demandes de permissions, il y aura une contraintes action C pour les notifs au demandeur, et une contrainte action V pour les notifs aux admins.