### PR TITLE
fix: tiny fix on home discussions table

### DIFF
--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -1496,8 +1496,8 @@ def list_all_reports(permissions):
     type_name = request.args.get("type")
     orderby = request.args.get("orderby", "creation_date")
     sort = request.args.get("sort")
-    page = int(request.args.get("page", 1))
-    per_page = int(request.args.get("per_page", 10))
+    page = request.args.get("page", 1, int)
+    per_page = request.args.get("per_page", 10, int)
     my_reports = request.args.get("my_reports", "false").lower() == "true"
 
     # Start query
@@ -1599,11 +1599,9 @@ def list_all_reports(permissions):
         result.append(report_dict)
 
     response = {
-        "total_filtered": paginated_results.total,
-        "total": total,
-        "pages": paginated_results.pages,
-        "current_page": page,
-        "per_page": per_page,
+        "total": paginated_results.total,
+        "page": paginated_results.page,
+        "per_page": paginated_results.per_page,
         "items": result,
     }
     return jsonify(response)

--- a/frontend/src/app/components/home-content/home-discussions/home-discussions-table/home-discussions-table.component.ts
+++ b/frontend/src/app/components/home-content/home-discussions/home-discussions-table/home-discussions-table.component.ts
@@ -51,6 +51,7 @@ export class HomeDiscussionsTableComponent implements OnInit, OnDestroy {
   _myReportsOnly: boolean;
   @Input()
   set myReportsOnly(value: boolean) {
+    this.pagination = this.DEFAULT_PAGINATION;
     this._myReportsOnly = value;
     this._fetchDiscussions();
   }
@@ -120,7 +121,7 @@ export class HomeDiscussionsTableComponent implements OnInit, OnDestroy {
     this.discussions = this._transformDiscussions(data.items);
     this.pagination = {
       totalItems: data.total,
-      currentPage: data.current_page,
+      currentPage: data.page,
       perPage: data.per_page,
     };
   }


### PR DESCRIPTION
Ajout d'un petit fix pour régler le problème de la pagination quand on utilise le switch de mes discussions. 
La pagination est maintenant réinitialisée lors de la mise à jour de la valeur de "Mes discussions".

Au passage, deux trois petits refacto de simplification des paramètres de pagination sur la route appelée 