### PR TITLE
Amélioration de la recherche des métadonnées 

### DIFF
--- a/backend/geonature/core/gn_meta/models/aframework.py
+++ b/backend/geonature/core/gn_meta/models/aframework.py
@@ -329,7 +329,7 @@ class TAcquisitionFramework(db.Model):
                             func.unaccent(TAcquisitionFramework.acquisition_framework_name).ilike(
                                 func.unaccent(f"%{term}%")
                             )
-                        ) 
+                        )
                 ors = [sa.and_(*ands)]
             # enable uuid search only with at least 5 characters
             if len(search) >= 5:

--- a/backend/geonature/core/gn_meta/models/aframework.py
+++ b/backend/geonature/core/gn_meta/models/aframework.py
@@ -315,16 +315,20 @@ class TAcquisitionFramework(db.Model):
             # si uniquement des chiffres (chercher dans ID ou name)
             if search.isdigit():
                 ors = [
-                    func.unaccent(TAcquisitionFramework.acquisition_framework_name).ilike(func.unaccent(f"%{search}%")),
+                    func.unaccent(TAcquisitionFramework.acquisition_framework_name).ilike(
+                        func.unaccent(f"%{search}%")
+                    ),
                     sa.cast(TAcquisitionFramework.id_acquisition_framework, sa.String) == search,
                 ]
             else:
                 # sinon découpe sur les espaces pour rechercher dans le nom
-                ands = [];
+                ands = []
                 for term in search.split(" "):
                     if len(term) > 0:
                         ands.append(
-                            func.unaccent(TAcquisitionFramework.acquisition_framework_name).ilike(func.unaccent(f"%{term}%"))
+                            func.unaccent(TAcquisitionFramework.acquisition_framework_name).ilike(
+                                func.unaccent(f"%{term}%")
+                            )
                         ) 
                 ors = [sa.and_(*ands)]
             # enable uuid search only with at least 5 characters

--- a/backend/geonature/core/gn_meta/models/aframework.py
+++ b/backend/geonature/core/gn_meta/models/aframework.py
@@ -321,7 +321,7 @@ class TAcquisitionFramework(db.Model):
             else:
             #sinon découpe sur les espaces pour rechercher dans le nom
                 ands = [];
-                for term in search.split(' '):
+                for term in search.split(" "):
                     if len(term) > 0:
                        ands.append(func.unaccent(TAcquisitionFramework.acquisition_framework_name).ilike(func.unaccent(f"%{term}%"))) 
                 ors = [sa.and_(*ands)]

--- a/backend/geonature/core/gn_meta/models/aframework.py
+++ b/backend/geonature/core/gn_meta/models/aframework.py
@@ -312,18 +312,20 @@ class TAcquisitionFramework(db.Model):
 
         search = params.get("search")
         if search:
-            #si uniquement des chiffres (chercher dans ID ou name)
+            # si uniquement des chiffres (chercher dans ID ou name)
             if search.isdigit():
                 ors = [
                     func.unaccent(TAcquisitionFramework.acquisition_framework_name).ilike(func.unaccent(f"%{search}%")),
                     sa.cast(TAcquisitionFramework.id_acquisition_framework, sa.String) == search,
                 ]
             else:
-            #sinon découpe sur les espaces pour rechercher dans le nom
+                # sinon découpe sur les espaces pour rechercher dans le nom
                 ands = [];
                 for term in search.split(" "):
                     if len(term) > 0:
-                       ands.append(func.unaccent(TAcquisitionFramework.acquisition_framework_name).ilike(func.unaccent(f"%{term}%"))) 
+                        ands.append(
+                            func.unaccent(TAcquisitionFramework.acquisition_framework_name).ilike(func.unaccent(f"%{term}%"))
+                        ) 
                 ors = [sa.and_(*ands)]
             # enable uuid search only with at least 5 characters
             if len(search) >= 5:

--- a/backend/geonature/core/gn_meta/models/datasets.py
+++ b/backend/geonature/core/gn_meta/models/datasets.py
@@ -278,12 +278,12 @@ class TDatasets(db.Model):
             if search.isdigit():
                 ors = [
                     func.unaccent(cls.dataset_name).ilike(func.unaccent(f"%{search}%")),
-                    sa.cast(cls.id_dataset, sa.String) == search
+                    sa.cast(cls.id_dataset, sa.String) == search,
                 ]
             else:
             #sinon découpe sur les espaces pour rechercher dans le nom
                 ands = [];
-                for term in search.split(' '):
+                for term in search.split(" "):
                     if len(term) > 0:
                        ands.append(func.unaccent(cls.dataset_name).ilike(func.unaccent(f"%{term}%"))) 
                 ors = [sa.and_(*ands)]

--- a/backend/geonature/core/gn_meta/models/datasets.py
+++ b/backend/geonature/core/gn_meta/models/datasets.py
@@ -274,18 +274,20 @@ class TDatasets(db.Model):
 
         search = params.get("search")
         if search:
-            #si uniquement des chiffres (chercher dans ID ou name)
+            # si uniquement des chiffres (chercher dans ID ou name)
             if search.isdigit():
                 ors = [
                     func.unaccent(cls.dataset_name).ilike(func.unaccent(f"%{search}%")),
                     sa.cast(cls.id_dataset, sa.String) == search,
                 ]
             else:
-            #sinon découpe sur les espaces pour rechercher dans le nom
+                # sinon découpe sur les espaces pour rechercher dans le nom
                 ands = [];
                 for term in search.split(" "):
                     if len(term) > 0:
-                       ands.append(func.unaccent(cls.dataset_name).ilike(func.unaccent(f"%{term}%"))) 
+                        ands.append(
+                            func.unaccent(cls.dataset_name).ilike(func.unaccent(f"%{term}%"))
+                        ) 
                 ors = [sa.and_(*ands)]
             # enable uuid search only with at least 5 characters
             if len(search) >= 5:

--- a/backend/geonature/core/gn_meta/models/datasets.py
+++ b/backend/geonature/core/gn_meta/models/datasets.py
@@ -282,12 +282,12 @@ class TDatasets(db.Model):
                 ]
             else:
                 # sinon découpe sur les espaces pour rechercher dans le nom
-                ands = [];
+                ands = []
                 for term in search.split(" "):
                     if len(term) > 0:
                         ands.append(
                             func.unaccent(cls.dataset_name).ilike(func.unaccent(f"%{term}%"))
-                        ) 
+                        )
                 ors = [sa.and_(*ands)]
             # enable uuid search only with at least 5 characters
             if len(search) >= 5:


### PR DESCRIPTION
Salut,
Je propose une PR qui reprend le filtre rapide des métadonnées en permettant de faire une recherche par mots clés (en splittant le terme recherché sur les espaces pour faire autant de ilike que de mot).

En frontend, j'ai repris le fonctionnement des observables pour corriger un problème qu'il y avait quand on tapait une recherche rapide dont le résultat arrivait avant que les données du chargement initial de la page se trouvaient être chargées. Dans ce cas le résultat de la recherche se faisait écraser par les données initiale et donc il fallait reprendre la recherche. 

Au niveau des filtres avancés, je me pose la question d'ajouter le terme du filtre rapide aux éléments de recherche du filtre avancés. 
Le filtre rapide fait une recherche dans le nom, l'uuid et les dates exactement comme peut le faire le recherche avancée de manière plus ciblée.