### PR TITLE
Feat/medias tmarkings events and little fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,4 +154,7 @@ install_all/install_all.log
 
 /docs/CHANGELOG.html
 
+
 /contrib/*/frontend/node_modules
+
+*.DS_Store

--- a/backend/geonature/core/gn_monitoring/models.py
+++ b/backend/geonature/core/gn_monitoring/models.py
@@ -259,6 +259,7 @@ class TMarkingEvent(DB.Model):
     __table_args__ = {"schema": "gn_monitoring"}
 
     id_marking = DB.Column(DB.Integer, primary_key=True, autoincrement=True)
+    uuid_marking = DB.Column(UUID(as_uuid=True), default=select(func.uuid_generate_v4()))
     id_individual = DB.Column(
         DB.ForeignKey(f"gn_monitoring.t_individuals.id_individual", ondelete="CASCADE"),
         nullable=False,
@@ -287,6 +288,14 @@ class TMarkingEvent(DB.Model):
     operator = DB.relationship(User, lazy="joined", foreign_keys=[id_operator])
 
     digitiser = DB.relationship(User, lazy="joined", foreign_keys=[id_digitiser])
+
+    medias = DB.relationship(
+        TMedias,
+        lazy="joined",
+        primaryjoin=(TMedias.uuid_attached_row == uuid_marking),
+        foreign_keys=[TMedias.uuid_attached_row],
+        overlaps="medias,medias",
+    )
 
     @hybrid_property
     def organism_actors(self):

--- a/backend/geonature/migrations/versions/84f40d008640_add_individuals.py
+++ b/backend/geonature/migrations/versions/84f40d008640_add_individuals.py
@@ -83,7 +83,7 @@ def upgrade():
             sa.ForeignKey(f"{SCHEMA}.t_individuals.id_individual", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("marking_date", sa.DateTime(timezone=False), nullable=False),
+        sa.Column("marking_date", sa.Date, nullable=False),
         sa.Column(
             "id_operator",
             sa.Integer,

--- a/contrib/occtax/backend/occtax/models.py
+++ b/contrib/occtax/backend/occtax/models.py
@@ -79,6 +79,7 @@ class CorCountingOccurrence(DB.Model):
         foreign_keys=[TMedias.uuid_attached_row],
         cascade="all",
         lazy="select",
+        overlaps="medias",
     )
 
 

--- a/frontend/src/app/GN2CommonModule/form/individuals/individuals.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/individuals/individuals.component.ts
@@ -26,7 +26,7 @@ export class IndividualsComponent implements OnInit {
   ) {}
   ngOnInit(): void {
     this.getIndividuals().subscribe((data) => {
-      this.values = data;
+      this.values = data.filter(item => item.active);
     });
   }
 


### PR DESCRIPTION
fix: filter active individuals only in individuals select widget
    
    - fix filter active individuals only in individuals select widget
    - fix datatype marking_date
  
 feat: add medias to tmarkings_events and individu
    
    - Manage revision alembic to get medias for tmarkings_events
    - Add overlap in models to avoid error sqlalchemy
    
    Author: @DonovanMaillard
    Reviewed-by: andriacap