### PR TITLE
feat(home): optimize `general_stats` route

### DIFF
--- a/backend/geonature/migrations/versions/5cf0ce9e669c_create_index_on_synthese_observers.py
+++ b/backend/geonature/migrations/versions/5cf0ce9e669c_create_index_on_synthese_observers.py
@@ -1,0 +1,35 @@
+"""create_index_on_synthese_observers
+
+Revision ID: 5cf0ce9e669c
+Revises: 9df933cc3c7a
+Create Date: 2025-01-13 14:14:30.085725
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "5cf0ce9e669c"
+down_revision = "9df933cc3c7a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "synthese_observers_idx",
+        "synthese",
+        ["observers"],
+        if_not_exists=True,
+        schema="gn_synthese",
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "synthese_observers_idx",
+        table_name="synthese",
+        schema="gn_synthese",
+    )

--- a/backend/geonature/tests/benchmarks/test_benchmark_home.py
+++ b/backend/geonature/tests/benchmarks/test_benchmark_home.py
@@ -1,0 +1,24 @@
+import logging
+import pytest
+from geonature.tests.benchmarks import *
+from geonature.tests.test_pr_occhab import stations
+
+from .benchmark_generator import BenchmarkTest, CLater
+from .utils import activate_profiling_sql
+
+logging.basicConfig()
+logger = logging.getLogger("logger-name")
+logger.setLevel(logging.DEBUG)
+
+from .utils import CLIENT_GET, CLIENT_POST
+
+
+@pytest.mark.benchmark(group="home")
+@pytest.mark.usefixtures("client_class", "temporary_transaction", "activate_profiling_sql")
+class TestBenchmarkHome:
+
+    test_general_stats = BenchmarkTest(
+        CLIENT_GET,
+        [CLater("""url_for("gn_synthese.general_stats")""")],
+        dict(user_profile="admin_user", fixtures=[]),
+    )()


### PR DESCRIPTION
closes #3309 

Based on propositions made by @dba-sig-sfepm

Includes :
 - update of the `general_stats` route
 - new benchmark test
 - new index on the `observers` column of the `gn_synthese.synthese` column