### PR TITLE
bump taxhub to 2.1.1

### DIFF
--- a/backend/requirements-dependencies.in
+++ b/backend/requirements-dependencies.in
@@ -3,5 +3,5 @@ pypnnomenclature>=1.6.4,<2
 pypn_habref_api>=0.4.1,<1
 utils-flask-sqlalchemy-geo>=0.3.2,<1
 utils-flask-sqlalchemy>=0.4.1,<1
-taxhub==2.1.0
+taxhub==2.1.1
 pypn-ref-geo>=1.5.3,<2

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -104,7 +104,7 @@ cligj==0.7.2
     # via fiona
 contourpy==1.3.0
     # via bokeh
-cryptography==44.0.0
+cryptography==43.0.3
     # via authlib
 cssselect2==0.7.0
     # via weasyprint
@@ -180,7 +180,9 @@ flask-wtf==1.2.2
     #   -r requirements-common.in
     #   usershub
 fonttools[woff]==4.55.3
-    # via weasyprint
+    # via
+    #   fonttools
+    #   weasyprint
 geoalchemy2==0.16.0
     # via utils-flask-sqlalchemy-geo
 geojson==3.2.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -72,7 +72,7 @@ cligj==0.7.2
     # via fiona
 contourpy==1.3.0
     # via bokeh
-cryptography==44.0.0
+cryptography==43.0.3
     # via authlib
 cssselect2==0.7.0
     # via weasyprint
@@ -143,7 +143,9 @@ flask-weasyprint==1.1.0
 flask-wtf==1.2.2
     # via -r requirements-common.in
 fonttools[woff]==4.55.3
-    # via weasyprint
+    # via
+    #   fonttools
+    #   weasyprint
 geoalchemy2==0.16.0
     # via utils-flask-sqlalchemy-geo
 geojson==3.2.0
@@ -312,7 +314,7 @@ sqlalchemy==1.4.54
     #   utils-flask-sqlalchemy
     #   utils-flask-sqlalchemy-geo
     #   wtforms-sqlalchemy
-taxhub==2.1.0
+taxhub==2.1.1
     # via
     #   -r requirements-dependencies.in
     #   pypnnomenclature


### PR DESCRIPTION
The downgrade of cryptography from 44.0 to 43.x is due to an incompatibility of the latest version with python 3.9 and python 3.9.1 . Check https://pypi.org/project/cryptography/ 