### PR TITLE
fix(login): hide external connection portal configuration to frontend configuration

### DIFF
--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -177,6 +177,17 @@ class AuthenticationConfig(Schema):
             ProviderConfigurationSchema().load(provider, unknown=INCLUDE)
 
 
+class AuthenticationFrontendConfig(AuthenticationConfig):
+
+    @post_load
+    def post_load(self, data, **kwargs):
+        new_providers_list = []
+        for provider in data["PROVIDERS"]:
+            new_providers_list.append({"id_provider": provider["id_provider"]})
+        data["PROVIDERS"] = new_providers_list
+        return data
+
+
 class GnPySchemaConf(Schema):
     SQLALCHEMY_DATABASE_URI = fields.String(
         required=True,
@@ -208,6 +219,9 @@ class GnPySchemaConf(Schema):
     SERVER = fields.Nested(ServerConfig, load_default=ServerConfig().load({}))
     MEDIAS = fields.Nested(MediasConfig, load_default=MediasConfig().load({}))
     ALEMBIC = fields.Nested(AlembicConfig, load_default=AlembicConfig().load({}))
+    AUTHENTICATION = fields.Nested(
+        AuthenticationConfig, load_default=AuthenticationConfig().load({}), unknown=INCLUDE
+    )
 
     @post_load()
     def folders(self, data, **kwargs):
@@ -579,7 +593,9 @@ class GnGeneralSchemaConf(Schema):
     PROFILES_REFRESH_CRONTAB = fields.String(load_default="0 3 * * *")
     MEDIA_CLEAN_CRONTAB = fields.String(load_default="0 1 * * *")
     AUTHENTICATION = fields.Nested(
-        AuthenticationConfig, load_default=AuthenticationConfig().load({}), unknown=INCLUDE
+        AuthenticationFrontendConfig,
+        load_default=AuthenticationFrontendConfig().load({}),
+        unknown=INCLUDE,
     )
 
     @validates_schema

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -181,10 +181,9 @@ class AuthenticationFrontendConfig(AuthenticationConfig):
 
     @post_load
     def post_load(self, data, **kwargs):
-        new_providers_list = []
-        for provider in data["PROVIDERS"]:
-            new_providers_list.append({"id_provider": provider["id_provider"]})
-        data["PROVIDERS"] = new_providers_list
+        data["PROVIDERS"] = [
+            {"id_provider": provider["id_provider"]} for provider in data["PROVIDERS"]
+        ]
         return data
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,8 @@
 - [Sensibilité] Correction du comptage du nombre de règles supprimées dans la commande `geonature sensitivity remove-referential` (#3323, par @jacquesfize)
 - [Synthèse] Correction de la disparition du filtre par `id_import` après l'affichage d'une fiche observation (par @jacquesfize)
 - [Authentification] Correction des redirections du module Admin lors de l'authentification (#3322, par @jacquesfize)
-- Correction d'une régression de performances de la récupération des JDD, introduite dans la 2.15.1 (#3320, par @Pierre-Narcisi)
+- [Métadonnées] Correction d'une régression de performances de la récupération des JDD, introduite dans la 2.15.1 (#3320, par @Pierre-Narcisi)
+- [Authentification] La configuration des providers n'est plus accessible depuis la route `gn_commons/config` (#3330 par @jacquesfize)
 
 ## 2.15.1 (2025-01-10)
 


### PR DESCRIPTION
Since GeoNature 2.15, connect to other identity providers was made possible. However, sensible configuration variable were made accessible in the frontend config returned in the public route `gn_commons/config`.

**A notice must be made in GeoNature 2.15.0 and 2.15.1 to warn users to update the 2.15.2 version if they wish to use such functionnality !** 