### PR TITLE
fix: adjust frontend of tab-profile

### DIFF
--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.html
@@ -1,7 +1,10 @@
 <div
-  *ngIf="profile; else noProfile"
   class="Profile"
+  *ngIf="profile; else noProfile"
 >
+  <small class="Profile__disclaimer text-muted">
+    {{ 'FicheTaxon.MessageProfil' | translate }}
+  </small>
   <div class="Profile__indicators">
     <indicator
       *ngFor="let indicator of indicators"
@@ -15,9 +18,6 @@
       [zoomOnFirstTime]="true"
     ></pnx-geojson>
   </pnx-map>
-  <small class="Profile__disclaimer text-muted">
-    {{ 'FicheTaxon.MessageProfil' | translate }}
-  </small>
 </div>
 <ng-template #noProfile>
   <div class="text-muted text-center">{{ 'FicheTaxon.MessageNoProfil' | translate }}</div>

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.html
@@ -1,4 +1,7 @@
-<div class="Profile">
+<div
+  *ngIf="profile; else noProfile"
+  class="Profile"
+>
   <div class="Profile__indicators">
     <indicator
       *ngFor="let indicator of indicators"
@@ -16,3 +19,6 @@
     {{ 'FicheTaxon.MessageProfil' | translate }}
   </small>
 </div>
+<ng-template #noProfile>
+  <div class="text-muted text-center">{{ 'FicheTaxon.MessageNoProfil' | translate }}</div>
+</ng-template>

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.scss
@@ -1,8 +1,8 @@
 .Profile {
   display: flex;
   flex-flow: column;
-  gap: 1rem;
   &__disclaimer {
+    margin-top: -0.5rem;
     font-style: italic;
   }
   &__indicators {

--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-profile/tab-profile.component.ts
@@ -71,9 +71,6 @@ export class TabProfileComponent implements OnInit {
         },
         (errors) => {
           this.profile = null;
-          if (errors.status == 404) {
-            this._commonService.regularToaster('warning', 'Aucune donnée pour ce taxon');
-          }
         }
       );
     });

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -273,7 +273,8 @@
     "previous": "Voir le média précédent"
   },
   "FicheTaxon": {
-    "MessageProfil": "* Ce profil est calculé sur les observations considérées valides présentes dans la Synthèse. Il permet de faciliter la validation de nouvelles observations en les comparant à la répartition spatiale, altitudinale et phénologique des observations valides."
+    "MessageProfil": "* Ce profil est calculé sur les observations considérées valides présentes dans la Synthèse. Il permet de faciliter la validation de nouvelles observations en les comparant à la répartition spatiale, altitudinale et phénologique des observations valides.",
+    "MessageNoProfil": "Aucune donnée de profile pour ce taxon"
   },
   "Import": {
     "DestinationLabel": "Destination",


### PR DESCRIPTION
C'est une PR sans issue initiale, ce sont des petits ajustements. 

- Remplace le toaster "aucune donnée" par un message simple
  Cela permet notamment d'éviter le côté envahissant et répétitif des toasts. 
- Mettre le disclaimer en haut de la section, et l'afficher tout le temps.
  Actuellement, il faut scroller pour le voir. On ne le voit le plus souvent jamais. 


## Aucune donnée
Avant
![image](https://github.com/user-attachments/assets/096805a6-dd5f-4e52-baca-981915c519f0)

Après
![image](https://github.com/user-attachments/assets/f51c0747-1f86-464b-9086-4ceff7308e81)

## Disclaimer monté en haut de la sectin, et 
Avant
![image](https://github.com/user-attachments/assets/f04f61ac-d414-4aef-b2f0-4662bd5cf1eb)

Après
![image](https://github.com/user-attachments/assets/c32063da-6171-4627-82ff-dca5493fe2b0)

