### PR TITLE
feat(doc): publish documentation on push action on master branch

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,8 +1,9 @@
 name: "Build Sphinx Documentation"
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
 
 jobs:
   docs:

--- a/docs/admin-manual.rst
+++ b/docs/admin-manual.rst
@@ -1597,7 +1597,7 @@ Exemple : `<https://demo.geonature.fr/geonature/#/synthese?access=public>`_
 
 
 
-.. include:: admin/authentication_custom.rst
+.. include:: admin/authentication-custom.rst
 
 
 


### PR DESCRIPTION
This PR proposes to change the publication process of the documentation. To allow hot-fix on the doc without releasing a new version of GeoNature. An example is given by a wrong path leading to a .rst file.