### PR TITLE
fix(synthese): set order_by descending id_synthese to prior last

### DIFF
--- a/backend/geonature/core/gn_synthese/utils/blurring.py
+++ b/backend/geonature/core/gn_synthese/utils/blurring.py
@@ -62,7 +62,7 @@ def build_blurred_precise_geom_queries(
         columns.append(sa.literal(0).label("size_hierarchy"))
     precise_geom_query = SyntheseQuery(
         Synthese,
-        sa.select(*columns).where(sa.and_(*where_clauses)).order_by(Synthese.id_synthese.desc()),
+        sa.select(*columns).where(sa.and_(*where_clauses)).order_by(Synthese.date_min.desc()),
         filters=dict(filters),  # not to edit the actual filter object
     )
 
@@ -99,7 +99,7 @@ def build_blurred_precise_geom_queries(
             == Synthese.id_nomenclature_sensitivity
         )
         .where(sa.and_(*where_clauses))
-        .order_by(Synthese.id_synthese.desc()),
+        .order_by(Synthese.date_min.desc()),
         filters=dict(filters),
         query_joins=sa.join(
             Synthese,
@@ -181,8 +181,12 @@ def build_synthese_obs_query(observations, allowed_geom_cte, limit):
                 allowed_geom_cte, allowed_geom_cte.c.id_synthese == VSyntheseForWebApp.id_synthese
             )
         )
-        .order_by(VSyntheseForWebApp.id_synthese, allowed_geom_cte.c.priority)
-        .distinct(VSyntheseForWebApp.id_synthese)
+        .order_by(
+            VSyntheseForWebApp.date_min.desc(),
+            VSyntheseForWebApp.id_synthese.desc(),
+            allowed_geom_cte.c.priority,
+        )
+        .distinct(VSyntheseForWebApp.date_min, VSyntheseForWebApp.id_synthese)
         .limit(limit)
     )
     return obs_query


### PR DESCRIPTION
Set final order_by on id_synthese from ascending to descending - so as to retrieve up-to-50000 more recent rather than least up-to-50000 recent observations from the up-to-100000 observations of 2 unioned subqueries - for Synthese queries involving blurring.