### PR TITLE
FESP_TAXO_1 : Mettre en place la taxonomie montante

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -146,10 +146,18 @@ export class DataFormService {
     });
   }
 
-  getTaxonInfo(cd_nom: number, fields?: Array<string>, areasStatus?: Array<string>) {
+  getTaxonInfo(
+    cd_nom: number,
+    fields?: Array<string>,
+    areasStatus?: Array<string>,
+    linnaeanParents?: boolean
+  ) {
     let query_string = new HttpParams();
     if (areasStatus) {
       query_string = query_string.append('areas_status', areasStatus.join(','));
+    }
+    if (linnaeanParents) {
+      query_string = query_string.append('linnaean_parents', true);
     }
     if (fields) {
       query_string = query_string.append('fields', fields.join(','));

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -6,7 +6,7 @@ import {
   HttpErrorResponse,
   HttpEvent,
 } from '@angular/common/http';
-import { Taxon } from './taxonomy/taxonomy.component';
+import { Taxon, TaxonParents } from './taxonomy/taxonomy.component';
 import { Observable } from 'rxjs';
 import { isArray } from 'rxjs/internal-compatibility';
 import { map } from 'rxjs/operators';
@@ -164,6 +164,12 @@ export class DataFormService {
     }
     return this._http.get<Taxon>(`${this.getTaxhubAPI()}/taxref/${cd_nom}`, {
       params: query_string,
+    });
+  }
+
+  getTaxonLinnaeanParents(taxon: Taxon): Observable<TaxonParents> {
+    return this._http.get<TaxonParents>(`${this.getTaxhubAPI()}/taxref/${taxon.cd_nom}/parents`, {
+      params: { linnaean: true },
     });
   }
 

--- a/frontend/src/app/GN2CommonModule/form/taxonomy/taxonomy.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/taxonomy/taxonomy.component.ts
@@ -14,6 +14,18 @@ import { debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 
 import { DataFormService } from '../data-form.service';
 import { ConfigService } from '@geonature/services/config.service';
 
+export interface Parents {
+  cd_nom: number;
+  cd_ref: number;
+  lb_nom: string;
+  id_rang: string;
+}
+
+export interface Tree {
+  parents: Parents[];
+  path: string;
+}
+
 export interface Taxon {
   search_name?: string;
   nom_valide?: string;
@@ -38,6 +50,7 @@ export interface Taxon {
   status?: any[];
   synonymes?: any[];
   attributs?: any[];
+  tree?: Tree;
 }
 
 /**

--- a/frontend/src/app/GN2CommonModule/form/taxonomy/taxonomy.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/taxonomy/taxonomy.component.ts
@@ -14,17 +14,11 @@ import { debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 
 import { DataFormService } from '../data-form.service';
 import { ConfigService } from '@geonature/services/config.service';
 
-export interface Parents {
-  cd_nom: number;
+export type LinnaeanParents = Array<{
   cd_ref: number;
   lb_nom: string;
   id_rang: string;
-}
-
-export interface Tree {
-  parents: Parents[];
-  path: string;
-}
+}>;
 
 export interface Taxon {
   search_name?: string;
@@ -50,7 +44,7 @@ export interface Taxon {
   status?: any[];
   synonymes?: any[];
   attributs?: any[];
-  tree?: Tree;
+  linnaean_parents: LinnaeanParents;
 }
 
 /**

--- a/frontend/src/app/GN2CommonModule/form/taxonomy/taxonomy.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/taxonomy/taxonomy.component.ts
@@ -14,11 +14,13 @@ import { debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 
 import { DataFormService } from '../data-form.service';
 import { ConfigService } from '@geonature/services/config.service';
 
-export type LinnaeanParents = Array<{
+export interface TaxonParent {
   cd_ref: number;
   lb_nom: string;
   id_rang: string;
-}>;
+}
+
+export type TaxonParents = Array<TaxonParent>;
 
 export interface Taxon {
   search_name?: string;
@@ -44,7 +46,6 @@ export interface Taxon {
   status?: any[];
   synonymes?: any[];
   attributs?: any[];
-  linnaean_parents: LinnaeanParents;
 }
 
 /**

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.html
@@ -6,7 +6,7 @@
     <span *ngFor="let item of taxon.linnaean_parents">
       <a
         class="Link"
-        [routerLink]="['/synthese/taxon', item.cd_ref, 'geographic_overview']"
+        (click)="navigateToCDRef(item.cd_ref)"
       >
         {{ item.lb_nom }}
       </a>

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.html
@@ -1,19 +1,27 @@
-<div class="Taxonomy">
+<div
+  class="Taxonomy"
+  *ngIf="taxon"
+>
   <div class="Taxonomy__breadcrumb">
-    <span *ngFor="let item of breadcrumb; let last = last">
+    <span *ngFor="let item of taxon.linnaean_parents">
       <a
+        class="Link"
         [routerLink]="['/synthese/taxon', item.cd_ref, 'geographic_overview']"
-        [class.active]="last"
       >
         {{ item.lb_nom }}
       </a>
-      <span *ngIf="!last">/</span>
+      <span>/</span>
+    </span>
+    <span>
+      <a class="active">
+        {{ taxon.lb_nom }}
+      </a>
     </span>
   </div>
   <div class="Taxonomy__completeName">
     {{ taxon?.nom_complet }}
   </div>
   <div class="Taxonomy__vernacularName">
-    {{ taxon?.nom_vern }}
+    {{ nomComplet }}
   </div>
 </div>

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.html
@@ -3,7 +3,7 @@
   *ngIf="taxon"
 >
   <div class="Taxonomy__breadcrumb">
-    <span *ngFor="let item of taxon.linnaean_parents">
+    <span *ngFor="let item of linnaeanParents">
       <a
         class="Link"
         (click)="navigateToCDRef(item.cd_ref)"

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.html
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.html
@@ -1,4 +1,15 @@
 <div class="Taxonomy">
+  <div class="Taxonomy__breadcrumb">
+    <span *ngFor="let item of breadcrumb; let last = last">
+      <a
+        [routerLink]="['/synthese/taxon', item.cd_ref, 'geographic_overview']"
+        [class.active]="last"
+      >
+        {{ item.lb_nom }}
+      </a>
+      <span *ngIf="!last">/</span>
+    </span>
+  </div>
   <div class="Taxonomy__completeName">
     {{ taxon?.nom_complet }}
   </div>

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.scss
@@ -16,12 +16,16 @@
     a {
       color: inherit;
       text-decoration: none;
-      &:hover {
-        text-decoration: underline;
+      &:not(.active) {
+        color: var(--purple);
+        &:hover:not(.active) {
+          text-decoration: underline;
+        }
       }
       &.active {
         font-weight: bold;
       }
+      filter: brightness(70%);
     }
     span {
       margin: 0 0 0 5px;

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.scss
@@ -17,6 +17,7 @@
       color: inherit;
       text-decoration: none;
       &:not(.active) {
+        cursor: pointer;
         color: var(--purple);
         &:hover:not(.active) {
           text-decoration: underline;

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.scss
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.scss
@@ -9,4 +9,22 @@
     font-size: 1.5rem;
     font-weight: bold;
   }
+  &__breadcrumb {
+    font-size: 1rem;
+    color: #333;
+    margin-bottom: 10px;
+    a {
+      color: inherit;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+      &.active {
+        font-weight: bold;
+      }
+    }
+    span {
+      margin: 0 0 0 5px;
+    }
+  }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
 import { RouterModule } from '@librairies/@angular/router';
+import { RouteService } from '../../taxon-sheet.route.service';
 
 @Component({
   standalone: true,
@@ -15,6 +16,8 @@ export class TaxonomyComponent {
   @Input()
   taxon: Taxon | null = null;
 
+  constructor(private _rs: RouteService) {}
+
   get nomComplet(): string {
     for (const attributePath of TaxonomyComponent.PRIORITY) {
       if (this.taxon[attributePath]) {
@@ -23,5 +26,9 @@ export class TaxonomyComponent {
     }
 
     return '';
+  }
+
+  navigateToCDRef(cd_ref: number) {
+    this._rs.navigateToCDRef(cd_ref);
   }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
-import { DataFormService } from '@geonature_common/form/data-form.service';
 import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
 import { RouterModule } from '@librairies/@angular/router';
 
@@ -12,40 +11,17 @@ import { RouterModule } from '@librairies/@angular/router';
   imports: [CommonModule, RouterModule],
 })
 export class TaxonomyComponent {
+  static readonly PRIORITY = ['nom_vern', 'nom_valide', 'nom_complet', 'lb_nom'];
   @Input()
-  set taxon(taxon: Taxon | null) {
-    this.updateBreadcrumb(taxon);
-  }
-  breadcrumb: any[] = [];
+  taxon: Taxon | null = null;
 
-  constructor(private _ds: DataFormService) {}
-
-  updateBreadcrumb(taxon: Taxon) {
-    const breadcrumb = [];
-    const allowedRanks = ['KD', 'PH', 'CL', 'OR', 'FM', 'GN', 'ES'];
-
-    if (!taxon) {
-      return;
+  get nomComplet(): string {
+    for (const attributePath of TaxonomyComponent.PRIORITY) {
+      if (this.taxon[attributePath]) {
+        return this.taxon[attributePath];
+      }
     }
 
-    this._ds
-      .getTaxonInfo(taxon.cd_ref, ['cd_ref', 'id_rang', 'lb_nom', 'tree'])
-      .subscribe((data: Taxon) => {
-        if (!data.tree || !data.tree.parents) {
-          return;
-        }
-
-        data.tree.parents
-          .filter((parent) => allowedRanks.includes(parent.id_rang))
-          .forEach((parent) => {
-            breadcrumb.push({ cd_ref: parent.cd_ref, lb_nom: parent.lb_nom });
-          });
-
-        breadcrumb.sort(
-          (a, b) => allowedRanks.indexOf(a.id_rang) - allowedRanks.indexOf(b.id_rang)
-        );
-
-        this.breadcrumb = breadcrumb;
-      });
+    return '';
   }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.ts
@@ -1,8 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
-import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
+import { Taxon, TaxonParents } from '@geonature_common/form/taxonomy/taxonomy.component';
 import { RouterModule } from '@librairies/@angular/router';
 import { RouteService } from '../../taxon-sheet.route.service';
+import { DataFormService } from '@geonature_common/form/data-form.service';
 
 @Component({
   standalone: true,
@@ -13,10 +14,33 @@ import { RouteService } from '../../taxon-sheet.route.service';
 })
 export class TaxonomyComponent {
   static readonly PRIORITY = ['nom_vern', 'nom_valide', 'nom_complet', 'lb_nom'];
-  @Input()
-  taxon: Taxon | null = null;
+  private _taxon: Taxon | null = null;
+  linnaeanParents: TaxonParents = [];
 
-  constructor(private _rs: RouteService) {}
+  @Input()
+  set taxon(taxon: Taxon | null) {
+    if (taxon == this._taxon) {
+      return;
+    }
+    this._taxon = taxon;
+
+    if (taxon) {
+      this._ds.getTaxonLinnaeanParents(this.taxon).subscribe((parents) => {
+        this.linnaeanParents = parents['parents'];
+      });
+    } else {
+      this.linnaeanParents = [];
+    }
+  }
+
+  get taxon(): Taxon | null {
+    return this._taxon;
+  }
+
+  constructor(
+    private _rs: RouteService,
+    private _ds: DataFormService
+  ) {}
 
   get nomComplet(): string {
     for (const attributePath of TaxonomyComponent.PRIORITY) {

--- a/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/infos/taxonomy/taxonomy.component.ts
@@ -1,14 +1,50 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { DataFormService } from '@geonature_common/form/data-form.service';
 import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
+import { RouterModule } from '@librairies/@angular/router';
+
 @Component({
   standalone: true,
   selector: 'taxonomy',
   templateUrl: 'taxonomy.component.html',
   styleUrls: ['taxonomy.component.scss'],
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
 })
-export class TaxonomyComponent {
+export class TaxonomyComponent implements OnChanges {
   @Input()
   taxon: Taxon | null = null;
+  breadcrumb: any[] = [];
+
+  constructor(private _ds: DataFormService) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.taxon && changes.taxon.currentValue) {
+      this.buildBreadCrumb(this.taxon);
+    }
+  }
+
+  async buildBreadCrumb(taxon: Taxon) {
+    const breadcrumb = [];
+    let currentTaxon = taxon;
+    const allowedRanks = ['KD', 'PH', 'CL', 'OR', 'FM', 'GN', 'ES'];
+
+    while (currentTaxon) {
+      if (allowedRanks.includes(currentTaxon.id_rang)) {
+        breadcrumb.unshift({
+          cd_ref: currentTaxon.cd_ref,
+          name: currentTaxon.nom_complet,
+          lb_nom: currentTaxon.lb_nom,
+          rank: currentTaxon.id_rang,
+        });
+      }
+      if (currentTaxon.cd_sup) {
+        const parentTaxon = await this._ds.getTaxonInfo(currentTaxon.cd_sup).toPromise();
+        currentTaxon = parentTaxon;
+      } else {
+        currentTaxon = null;
+      }
+    }
+    this.breadcrumb = breadcrumb;
+  }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.route.service.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.route.service.ts
@@ -4,7 +4,7 @@ import {
   RouterStateSnapshot,
   Router,
   CanActivateChild,
-  CanActivate
+  CanActivate,
 } from '@angular/router';
 import { ConfigService } from '@geonature/services/config.service';
 import { Observable } from 'rxjs';
@@ -56,8 +56,8 @@ export class RouteService implements CanActivate, CanActivateChild {
       );
     }
   }
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean  {
-    if(!this._config.SYNTHESE.ENABLE_TAXON_SHEETS){
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    if (!this._config.SYNTHESE.ENABLE_TAXON_SHEETS) {
       this._router.navigate(['/404'], { skipLocationChange: true });
       return false;
     }
@@ -65,10 +65,7 @@ export class RouteService implements CanActivate, CanActivateChild {
     return true;
   }
 
-  canActivateChild(
-    childRoute: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot
-  ): boolean {
+  canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
     const targetedPath = childRoute.routeConfig.path;
     if (this.TAB_LINKS.map((tab) => tab.path).includes(targetedPath)) {
       return true;
@@ -76,5 +73,14 @@ export class RouteService implements CanActivate, CanActivateChild {
 
     this._router.navigate(['/404'], { skipLocationChange: true });
     return false;
+  }
+
+  navigateToCDRef(cd_ref: number) {
+    const url = this._router.url;
+    let new_url = `/synthese/taxon/${cd_ref}`;
+    if (this._router.url.startsWith('/synthese/taxon/')) {
+      new_url = `${new_url}/${url.split('/').pop()}`;
+    }
+    this._router.navigate([new_url]);
   }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
@@ -14,7 +14,7 @@ export class TaxonSheetService {
     if (taxon && taxon.cd_ref == cd_ref) {
       return;
     }
-    this._ds.getTaxonInfo(cd_ref).subscribe((taxon) => {
+    this._ds.getTaxonInfo(cd_ref, undefined, undefined, true).subscribe((taxon) => {
       this.taxon.next(taxon);
     });
   }


### PR DESCRIPTION
Closes [#2981](https://github.com/PnX-SI/GeoNature/issues/2981)

## Description
Cette PR implémente un fil d'Ariane permettant de naviguer visuellement dans la hiérarchie taxonomique des espèces.

## Fonctionnalités
- Navigation à travers les 7 niveaux linnéens :
```
règne → phylum → classe → ordre → famille → genre → espèce
```
- Visualisation claire du positionnement du taxon dans la classification
- Navigation interactive entre les différents niveaux

## Aperçu
![Capture d’écran du 2025-02-04 09-48-58](https://github.com/user-attachments/assets/cb142c1d-c9bd-4328-acf7-a7f0cc2cc303)
