### PR TITLE
Refact: fix on taxonomy status [PR: 3384]

### DIFF
--- a/.github/ISSUE_TEMPLATE/rapport-de-bug.md
+++ b/.github/ISSUE_TEMPLATE/rapport-de-bug.md
@@ -1,23 +1,27 @@
 ---
 name: Rapport de bug
 about: Un rapport de bug pour nous aider à le corriger.
-title: ''
-labels: bug
-assignees: ''
-
+title: ""
+type: Bug
+assignees: ""
 ---
 
-**Version**
-Version de GeoNature affectée par le bug.
+## Version
 
-**Description du bug**
-Description du problème rencontré (message d’erreur, code HTTP de retour inattendu, …).
+<!-- version de GeoNature, par exemple : `2.15.0` -->
 
-**Comportement attendu**
-Description du comportement attendu en lieu et place du problème rencontré.
+## Description du bug
 
-**Comment reproduire**
-Étapes à suivre pour reproduire le problème (sur quelle page se rendre, sur quel bouton cliquer, avec quelles données présentes, …).
+<!-- Description du problème rencontré (message d’erreur, code HTTP de retour inattendu, …). -->
 
-**Logs**
-Extrait du fichier ``/var/log/geonature.log`` dans le cas d’une erreur 500.
+## Comment reproduire le bug
+
+<!-- Étapes à suivre pour reproduire le problème (sur quelle page se rendre, sur quel bouton cliquer, avec quelles données présentes, …). -->
+
+## Comportement attendu
+
+<!-- Description du comportement attendu en lieu et place du problème rencontré. -->
+
+## Logs
+
+<!-- Extrait du fichier `/var/log/geonature.log` dans le cas d’une erreur 500. -->

--- a/backend/geonature/core/gn_commons/repositories.py
+++ b/backend/geonature/core/gn_commons/repositories.py
@@ -357,7 +357,7 @@ class TMediumRepository:
         """
 
         # delete media temp > 24h
-        res_medias_temp = DB.session.scalars(
+        id_medias_temp = DB.session.scalars(
             select(TMedias.id_media).where(
                 and_(
                     TMedias.meta_update_date
@@ -366,8 +366,6 @@ class TMediumRepository:
                 )
             )
         ).all()
-
-        id_medias_temp = [res.id_media for res in res_medias_temp]
 
         if id_medias_temp:
             print("sync media remove temp media with ids : ", id_medias_temp)

--- a/backend/geonature/core/gn_synthese/utils/blurring.py
+++ b/backend/geonature/core/gn_synthese/utils/blurring.py
@@ -91,7 +91,7 @@ def build_blurred_precise_geom_queries(
     ]
     # size hierarchy is the size of the joined blurring area
     if select_size_hierarchy:
-        columns.append(BibAreasTypes.size_hierarchy.label("size_hierarchy"))
+        columns.append(BibAreasTypesAlias.size_hierarchy.label("size_hierarchy"))
     blurred_geom_query = SyntheseQuery(
         Synthese,
         sa.select(*columns)

--- a/backend/geonature/core/imports/config_schema.py
+++ b/backend/geonature/core/imports/config_schema.py
@@ -95,7 +95,7 @@ class ImportConfigSchema(Schema):
     #   for the id_dataset field belonging to synthese destination.
     PER_DATASET_UUID_CHECK = fields.Boolean(load_default=False)
 
-    CHECK_PRIVATE_JDD_BLURING = fields.Boolean(load_default=True)
+    CHECK_PRIVATE_JDD_BLURING = fields.Boolean(load_default=False)
     CHECK_REF_BIBLIO_LITTERATURE = fields.Boolean(load_default=True)
     CHECK_EXIST_PROOF = fields.Boolean(load_default=True)
     DEFAULT_GENERATE_MISSING_UUID = fields.Boolean(load_default=True)

--- a/backend/geonature/core/imports/templates/import_template_pdf.html
+++ b/backend/geonature/core/imports/templates/import_template_pdf.html
@@ -20,7 +20,7 @@
     />
     <img
       class="logo"
-      src="{{url_for('static', filename='images/logo_structure.jpg')}}"
+      src="{{url_for('static', filename='images/logo_structure.png')}}"
       alt="Logo"
     />
   </head>

--- a/backend/geonature/migrations/versions/22cb0ffdff6d_add_index_on_id_import_on_the_synthese.py
+++ b/backend/geonature/migrations/versions/22cb0ffdff6d_add_index_on_id_import_on_the_synthese.py
@@ -1,0 +1,34 @@
+"""add index on id_import on the synthese
+
+Revision ID: 22cb0ffdff6d
+Revises: 54e5b4a96add
+Create Date: 2025-02-24 17:13:50.963764
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "22cb0ffdff6d"
+down_revision = "54e5b4a96add"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "synthese_id_import_idx",
+        "synthese",
+        ["id_import"],
+        schema="gn_synthese",
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "synthese_id_import_idx",
+        table_name="synthese",
+        schema="gn_synthese",
+    )

--- a/backend/geonature/migrations/versions/54e5b4a96add_modifiy_validation_status_trigger.py
+++ b/backend/geonature/migrations/versions/54e5b4a96add_modifiy_validation_status_trigger.py
@@ -1,0 +1,98 @@
+"""modifiy validation status trigger
+
+Revision ID: 54e5b4a96add
+Revises: 5cf0ce9e669c
+Create Date: 2025-02-24 11:53:22.915133
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "54e5b4a96add"
+down_revision = "5cf0ce9e669c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+    CREATE OR REPLACE FUNCTION gn_commons.fct_trg_update_synthese_validation_status()
+    RETURNS trigger AS
+    $BODY$
+    -- This trigger function update validation informations in corresponding row in synthese table
+    BEGIN
+        UPDATE gn_synthese.synthese 
+        SET id_nomenclature_valid_status = NEW.id_nomenclature_valid_status,
+        validation_comment = NEW.validation_comment,
+        meta_validation_date = NEW.validation_date,
+        validator = (SELECT nom_role || ' ' || prenom_role FROM utilisateurs.t_roles WHERE id_role = NEW.id_validator)::text
+        WHERE unique_id_sinp = NEW.uuid_attached_row;
+        RETURN NEW;
+    END;
+    $BODY$
+        LANGUAGE plpgsql VOLATILE
+        COST 100;
+    """
+    )
+
+    op.execute(
+        """
+        WITH cte_max_date AS (
+            SELECT
+                uuid_attached_row,
+                MAX(validation_date) AS validation_date
+            FROM
+                gn_commons.t_validations
+            GROUP BY
+                uuid_attached_row
+        )
+        UPDATE
+            gn_synthese.synthese
+        SET
+            meta_validation_date = cte_max_date.validation_date
+        FROM
+            cte_max_date
+        WHERE
+            gn_synthese.synthese.unique_id_sinp = cte_max_date.uuid_attached_row;
+        """
+    )
+
+    op.alter_column(
+        table_name="t_validations",
+        column_name="validation_date",
+        server_default=sa.func.now(),
+        schema="gn_commons",
+    )
+
+
+def downgrade():
+    op.alter_column(
+        table_name="t_validations",
+        column_name="validation_date",
+        server_default=sa.null(),
+        schema="gn_commons",
+    )
+
+    op.execute(
+        """
+    CREATE OR REPLACE FUNCTION fct_trg_update_synthese_validation_status()
+    RETURNS trigger AS
+    $BODY$
+    -- This trigger function update validation informations in corresponding row in synthese table
+    BEGIN
+        UPDATE gn_synthese.synthese 
+        SET id_nomenclature_valid_status = NEW.id_nomenclature_valid_status,
+        validation_comment = NEW.validation_comment,
+        validator = (SELECT nom_role || ' ' || prenom_role FROM utilisateurs.t_roles WHERE id_role = NEW.id_validator)::text
+        WHERE unique_id_sinp = NEW.uuid_attached_row;
+        RETURN NEW;
+    END;
+    $BODY$
+        LANGUAGE plpgsql VOLATILE
+        COST 100;
+    """
+    )

--- a/backend/geonature/migrations/versions/54e5b4a96add_modify_validation_status_trigger.py
+++ b/backend/geonature/migrations/versions/54e5b4a96add_modify_validation_status_trigger.py
@@ -1,4 +1,4 @@
-"""modifiy validation status trigger
+"""modify validation status trigger
 
 Revision ID: 54e5b4a96add
 Revises: 5cf0ce9e669c

--- a/backend/geonature/tests/benchmarks/test_benchmark_synthese.py
+++ b/backend/geonature/tests/benchmarks/test_benchmark_synthese.py
@@ -7,6 +7,7 @@ from geonature.core.gn_synthese.models import Synthese
 from .utils import activate_profiling_sql
 
 from .benchmark_generator import BenchmarkTest, CLater
+from geonature.tests.fixtures import users
 
 
 logging.basicConfig()
@@ -105,4 +106,4 @@ for url, label in [
             ),
         )
 
-add_bluring_to_benchmark_test_class(TestBenchmarkSynthese)
+add_bluring_to_benchmark_test_class(TestBenchmarkSynthese, "user_with_blurring")

--- a/backend/geonature/tests/benchmarks/utils.py
+++ b/backend/geonature/tests/benchmarks/utils.py
@@ -11,6 +11,7 @@ from .benchmark_generator import CLater, BenchmarkTest
 from geonature.tests.test_synthese import blur_sensitive_observations
 import traceback
 from geonature.tests.fixtures import app
+from pypnusershub.db.models import User
 
 logging.basicConfig()
 logger = logging.getLogger("logger-name")
@@ -62,7 +63,7 @@ def activate_profiling_sql(sqllogfilename: pytest.FixtureDef, app: pytest.Fixtur
     event.listen(db.engine, "after_cursor_execute", after_cursor_execute)
 
 
-def add_bluring_to_benchmark_test_class(benchmark_cls: type):
+def add_bluring_to_benchmark_test_class(benchmark_cls: type, different_user: str = None):
     """
     Add the blurring enabling fixture to all benchmark tests declared in the given class.
 
@@ -86,6 +87,8 @@ def add_bluring_to_benchmark_test_class(benchmark_cls: type):
                 if "fixtures" in kwargs
                 else [blur_sensitive_observations]
             )
+            if different_user:
+                kwargs["user_profile"] = different_user
             # Recreate BenchmarkTest object including the blurring enabling fixture
             setattr(
                 benchmark_cls,

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -1643,7 +1643,7 @@ class TestSyntheseBlurring:
         # So that all burred geoms will not appear on the aggregated areas
         monkeypatch.setitem(current_app.config["SYNTHESE"], "AREA_AGGREGATION_TYPE", "M1")
 
-        current_user = users["stranger_user"]
+        current_user = users["noright_user"]
         set_logged_user(self.client, current_user)
         # None is 3
         synthese_read_permissions(current_user, None, sensitivity_filter=True)
@@ -1669,7 +1669,6 @@ class TestSyntheseBlurring:
                 synthese_sensitive_data["obs_sensitive_2"],
             )
         ]
-
         # If an observation is blurred and the AREA_AGGREGATION_TYPE is smaller in
         # size than the blurred observation then the observation should not appear
         assert all(

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -647,7 +647,7 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
     FILL_MISSING_NOMENCLATURE_WITH_DEFAULT_VALUE = false
 
     # Active la vérification de l'existence du champs "floutage" si le JDD est privé
-    CHECK_PRIVATE_JDD_BLURING = true
+    CHECK_PRIVATE_JDD_BLURING = false
 
     # Active la vérification qu'une ref biblio est fournie si la valeur du champs source = "litterature"
     CHECK_REF_BIBLIO_LITTERATURE = true

--- a/contrib/gn_module_occhab/backend/gn_module_occhab/migrations/b4e1e402ece1_add_index_on_id_import_on_occhab_.py
+++ b/contrib/gn_module_occhab/backend/gn_module_occhab/migrations/b4e1e402ece1_add_index_on_id_import_on_occhab_.py
@@ -1,0 +1,45 @@
+"""add index on id_import on occhab station and habitat
+
+Revision ID: b4e1e402ece1
+Revises: 9c3e1f98361f
+Create Date: 2025-02-24 17:14:30.833647
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b4e1e402ece1"
+down_revision = "9c3e1f98361f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "occhab_station_id_import_idx",
+        "t_stations",
+        ["id_import"],
+        schema="pr_occhab",
+    )
+    op.create_index(
+        "occhab_habitat_id_import_idx",
+        "t_habitats",
+        ["id_import"],
+        schema="pr_occhab",
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "occhab_habitat_id_import_idx",
+        table_name="t_habitats",
+        schema="pr_occhab",
+    )
+    op.drop_index(
+        "occhab_station_id_import_idx",
+        table_name="t_stations",
+        schema="pr_occhab",
+    )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2.15.4 (2025-02-xx)
+
+**🐛 Corrections**
+
+- [Synthese] Correction de la prise en compte de `size_hierarchy` dans le mode maille de la synthèse (#3380 par @Pierre-Narcisi)
+-
+
 ## 2.15.3 (2025-02-14)
 
 **🚀 Nouveautés**
@@ -25,6 +32,10 @@
 - [Métadonnées] Correction du rafraichissement du formulaire de recherche (#3365 par @jacquesfize)
 - [Documentation] Réintégration de la documentation sur l'authentification avec un fournisseur d'identité externe (#3338 par @jacquesfize)
 - [Développement] Correction des modèles SQLAlchemy pour pouvoir utiliser le mode debug (#3346 par @jacquesfize)
+
+**⚠️ Notes de version**
+
+Enlever les paramètres `INSTANCE_BOUNDING_BOX`, `ENABLE_BOUNDING_BOX_CHECK`, `ALLOW_FIELD_MAPPING`, `DEFAULT_FIELD_MAPPING_ID`, `DISPLAY_CHECK_BOX_MAPPED_FIELD` de votre fichier de configuration. Ces derniers ne sont plus pris en compte depuis la 2.15.x.
 
 ## 2.15.2 (2025-01-16)
 

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.ts
@@ -229,7 +229,6 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
         this.filterTabs();
         this.selectedTab = this.selectedTab ? this.selectedTab : this.defaultTab;
         this.selectTab(this.selectedTab);
-        console.log(this.selectedObs);
       });
 
     this._gnDataService.getProfileConsistancyData(this.idSynthese).subscribe((dataChecks) => {

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.html
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.html
@@ -41,7 +41,7 @@
   <h5 class="Taxonomy__subtitle">Statuts</h5>
   <table
     class="font-xs table table-sm"
-    *ngIf="taxon?.status && taxon.status.length > 0; else noStatus"
+    *ngIf="taxon?.status && !isStatusEmpty; else noStatus"
   >
     <ng-container *ngFor="let status of taxon.status | keyvalue">
       <tr class="table-primary">

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.html
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.html
@@ -1,7 +1,7 @@
 <div class="Taxonomy">
   <h5 class="Taxonomy__subtitle">Classification</h5>
   <table
-    *ngIf="taxon; else noClassification"
+    *ngIf="observedTaxon; else noClassification"
     class="Classification font-xs table table-striped table-sm"
   >
     <tbody>
@@ -13,27 +13,27 @@
           class="Classification__value"
           [attr.data-qa]="'taxonomy-detail-taxo-' + information.field"
         >
-          {{ taxon[information.field] }}
+          {{ observedTaxon[information.field] }}
         </td>
       </tr>
     </tbody>
   </table>
   <ng-template #noClassification><p>Aucune</p></ng-template>
 
-  <div *ngIf="taxon?.attributs && (taxon.status.length || !hideLocalAttributesOnEmpty)">
+  <div *ngIf="!isAttributesEmpty || !hideLocalAttributesOnEmpty">
     <h5 class="Taxonomy__subtitle">Attribut(s) Taxonomique(s) locaux</h5>
     <table
-      *ngIf="taxon?.attributs && taxon.status.length; else noLocalAttributes"
+      *ngIf="!isAttributesEmpty; else noLocalAttributes"
       class="font-xs table table-striped table-sm"
     >
       <tr
         class="font-xs"
-        *ngFor="let attr of taxon?.attributs"
+        *ngFor="let attr of observedTaxon?.attributs"
       >
         <td>
-          <b>{{ attr.label_attribut }}</b>
+          <b>{{ attr?.bib_attribut?.label_attribut }}</b>
         </td>
-        <td>{{ attr.valeur_attribut }}</td>
+        <td style="width: 100%">{{ attr.valeur_attribut }}</td>
       </tr>
     </table>
     <ng-template #noLocalAttributes><p>Aucun</p></ng-template>
@@ -41,9 +41,9 @@
   <h5 class="Taxonomy__subtitle">Statuts</h5>
   <table
     class="font-xs table table-sm"
-    *ngIf="taxon?.status && !isStatusEmpty; else noStatus"
+    *ngIf="!isStatusEmpty; else noStatus"
   >
-    <ng-container *ngFor="let status of taxon.status | keyvalue">
+    <ng-container *ngFor="let status of observedTaxon.status | keyvalue">
       <tr class="table-primary">
         <th>{{ status.value.display }}</th>
       </tr>

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.ts
@@ -11,14 +11,23 @@ interface TaxonInformation {
   templateUrl: 'taxonomy.component.html',
   styleUrls: ['taxonomy.component.scss'],
 })
-export class TaxonomyComponent {
+export class TaxonomyComponent implements OnInit {
   @Input()
   taxon: ObservedTaxon | null = null;
+  isStatusEmpty: boolean = false;
 
   @Input()
   hideLocalAttributesOnEmpty: boolean = false;
 
-  constructor() {}
+  checkStatus() {
+    this.isStatusEmpty = Object.keys(this.taxon?.status || {}).length === 0;
+  }
+  ngOnInit() {
+    this.checkStatus();
+  }
+  ngOnChanges() {
+    this.checkStatus();
+  }
 
   readonly INFORMATIONS: Array<TaxonInformation> = [
     {

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.ts
@@ -11,23 +11,30 @@ interface TaxonInformation {
   templateUrl: 'taxonomy.component.html',
   styleUrls: ['taxonomy.component.scss'],
 })
-export class TaxonomyComponent implements OnInit {
+export class TaxonomyComponent {
+  observedTaxon: ObservedTaxon | null = null;
+  isStatusEmpty: boolean = true;
+  isAttributesEmpty: boolean = true;
+  informationsFiltered: TaxonInformation[] = [];
+
   @Input()
-  taxon: ObservedTaxon | null = null;
-  isStatusEmpty: boolean = false;
+  set taxon(taxon: ObservedTaxon | null) {
+    this.observedTaxon = taxon;
+    if (!this.observedTaxon) {
+      this.isStatusEmpty = true;
+      this.isAttributesEmpty = true;
+      this.informationsFiltered = [];
+      return;
+    }
+    this.isStatusEmpty = Object.keys(this.observedTaxon.status).length == 0;
+    this.isAttributesEmpty = this.observedTaxon.attributs.length == 0;
+    this.informationsFiltered = this.INFORMATIONS.filter(
+      (information) => this.observedTaxon[information.field]
+    );
+  }
 
   @Input()
   hideLocalAttributesOnEmpty: boolean = false;
-
-  checkStatus() {
-    this.isStatusEmpty = Object.keys(this.taxon?.status || {}).length === 0;
-  }
-  ngOnInit() {
-    this.checkStatus();
-  }
-  ngOnChanges() {
-    this.checkStatus();
-  }
 
   readonly INFORMATIONS: Array<TaxonInformation> = [
     {
@@ -63,8 +70,4 @@ export class TaxonomyComponent implements OnInit {
       field: 'nom_cite',
     },
   ];
-
-  get informationsFiltered() {
-    return this.INFORMATIONS.filter((information) => this.taxon[information.field]);
-  }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
@@ -14,7 +14,8 @@ export class TaxonSheetService {
     if (taxon && taxon.cd_ref == cd_ref) {
       return;
     }
-    this._ds.getTaxonInfo(cd_ref).subscribe((taxon) => {
+    const taxhubFields = ['attributs.bib_attribut.label_attribut'];
+    this._ds.getTaxonInfo(cd_ref, taxhubFields).subscribe((taxon) => {
       this.taxon.next(taxon);
     });
   }


### PR DESCRIPTION
Un fix a été fait dans la PR: https://github.com/PnX-SI/GeoNature/pull/3384

Sur demande de Camille, j'ai fait un ptit passage sur le fix réalisé. 

J'ai changé l'approche ngChange + ngInit par un accesseur en ecriture sur le taxon.

Comme on a deja l'input comme évènement déclencheur, il suffit de rajouter un traitement à cet endroit la. Pas besoin de la lourdeur d'un watcher supplémentaire. 

Au passage, j'ai corrigé l'affichage des attributs, qui n'était pas bon. 
- champs affiché dans le html (synthese + fiche espèce)
- ajout du label dans la requête (fiche espèce)
