### PR TITLE
Refacto: fix on taxonomy status

### DIFF
--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.html
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.html
@@ -1,7 +1,7 @@
 <div class="Taxonomy">
   <h5 class="Taxonomy__subtitle">Classification</h5>
   <table
-    *ngIf="taxon; else noClassification"
+    *ngIf="observedTaxon; else noClassification"
     class="Classification font-xs table table-striped table-sm"
   >
     <tbody>
@@ -13,27 +13,27 @@
           class="Classification__value"
           [attr.data-qa]="'taxonomy-detail-taxo-' + information.field"
         >
-          {{ taxon[information.field] }}
+          {{ observedTaxon[information.field] }}
         </td>
       </tr>
     </tbody>
   </table>
   <ng-template #noClassification><p>Aucune</p></ng-template>
 
-  <div *ngIf="taxon?.attributs && (taxon.status.length || !hideLocalAttributesOnEmpty)">
+  <div *ngIf="!isAttributesEmpty || !hideLocalAttributesOnEmpty">
     <h5 class="Taxonomy__subtitle">Attribut(s) Taxonomique(s) locaux</h5>
     <table
-      *ngIf="taxon?.attributs && taxon.status.length; else noLocalAttributes"
+      *ngIf="!isAttributesEmpty; else noLocalAttributes"
       class="font-xs table table-striped table-sm"
     >
       <tr
         class="font-xs"
-        *ngFor="let attr of taxon?.attributs"
+        *ngFor="let attr of observedTaxon?.attributs"
       >
         <td>
-          <b>{{ attr.label_attribut }}</b>
+          <b>{{ attr?.bib_attribut?.label_attribut }}</b>
         </td>
-        <td>{{ attr.valeur_attribut }}</td>
+        <td style="width: 100%">{{ attr.valeur_attribut }}</td>
       </tr>
     </table>
     <ng-template #noLocalAttributes><p>Aucun</p></ng-template>
@@ -41,9 +41,9 @@
   <h5 class="Taxonomy__subtitle">Statuts</h5>
   <table
     class="font-xs table table-sm"
-    *ngIf="taxon?.status && !isStatusEmpty; else noStatus"
+    *ngIf="!isStatusEmpty; else noStatus"
   >
-    <ng-container *ngFor="let status of taxon.status | keyvalue">
+    <ng-container *ngFor="let status of observedTaxon.status | keyvalue">
       <tr class="table-primary">
         <th>{{ status.value.display }}</th>
       </tr>

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/taxonomy/taxonomy.component.ts
@@ -11,23 +11,30 @@ interface TaxonInformation {
   templateUrl: 'taxonomy.component.html',
   styleUrls: ['taxonomy.component.scss'],
 })
-export class TaxonomyComponent implements OnInit {
+export class TaxonomyComponent {
+  observedTaxon: ObservedTaxon | null = null;
+  isStatusEmpty: boolean = true;
+  isAttributesEmpty: boolean = true;
+  informationsFiltered: TaxonInformation[] = [];
+
   @Input()
-  taxon: ObservedTaxon | null = null;
-  isStatusEmpty: boolean = false;
+  set taxon(taxon: ObservedTaxon | null) {
+    this.observedTaxon = taxon;
+    if (!this.observedTaxon) {
+      this.isStatusEmpty = true;
+      this.isAttributesEmpty = true;
+      this.informationsFiltered = [];
+      return;
+    }
+    this.isStatusEmpty = Object.keys(this.observedTaxon.status).length == 0;
+    this.isAttributesEmpty = this.observedTaxon.attributs.length == 0;
+    this.informationsFiltered = this.INFORMATIONS.filter(
+      (information) => this.observedTaxon[information.field]
+    );
+  }
 
   @Input()
   hideLocalAttributesOnEmpty: boolean = false;
-
-  checkStatus() {
-    this.isStatusEmpty = Object.keys(this.taxon?.status || {}).length === 0;
-  }
-  ngOnInit() {
-    this.checkStatus();
-  }
-  ngOnChanges() {
-    this.checkStatus();
-  }
 
   readonly INFORMATIONS: Array<TaxonInformation> = [
     {
@@ -63,8 +70,4 @@ export class TaxonomyComponent implements OnInit {
       field: 'nom_cite',
     },
   ];
-
-  get informationsFiltered() {
-    return this.INFORMATIONS.filter((information) => this.taxon[information.field]);
-  }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
@@ -14,7 +14,8 @@ export class TaxonSheetService {
     if (taxon && taxon.cd_ref == cd_ref) {
       return;
     }
-    this._ds.getTaxonInfo(cd_ref).subscribe((taxon) => {
+    const taxhubFields = ['attributs.bib_attribut.label_attribut'];
+    this._ds.getTaxonInfo(cd_ref, taxhubFields).subscribe((taxon) => {
       this.taxon.next(taxon);
     });
   }

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.service.ts
@@ -14,7 +14,7 @@ export class TaxonSheetService {
     if (taxon && taxon.cd_ref == cd_ref) {
       return;
     }
-    const taxhubFields = ['attributs.bib_attribut.label_attribut'];
+    const taxhubFields = ['attributs', 'attributs.bib_attribut.label_attribut', 'status'];
     this._ds.getTaxonInfo(cd_ref, taxhubFields).subscribe((taxon) => {
       this.taxon.next(taxon);
     });


### PR DESCRIPTION
Un fix a été fait dans la PR: #3384 (https://github.com/PnX-SI/GeoNature/pull/3384)

Sur demande de Camille, j'ai fait un ptit passage sur le fix réalisé. 

J'ai changé l'approche ngChange + ngInit par un accesseur en ecriture sur le taxon.

Comme on a deja l'input comme évènement déclencheur, il suffit de rajouter un traitement à cet endroit la. Pas besoin de la lourdeur d'un watcher supplémentaire. 

Au passage, j'ai corrigé l'affichage des attributs, qui n'était pas bon. 
- champs affiché dans le html (synthese + fiche espèce)
- ajout du label dans la requête (fiche espèce)
