### PR TITLE
Feat/import - permission per entity

### DIFF
--- a/backend/geonature/core/imports/models.py
+++ b/backend/geonature/core/imports/models.py
@@ -213,9 +213,16 @@ class Destination(db.Model):
         if not user:
             user = g.current_user
 
-        max_scope = get_scopes_by_action(id_role=user.id_role, module_code=self.module.module_code)[
-            action_code
-        ]
+        scopes = [0]
+        for entity in self.entities:
+            scopes.append(
+                get_scopes_by_action(
+                    id_role=user.id_role,
+                    module_code=self.module.module_code,
+                    object_code=entity.object.code_object,
+                )[action_code]
+            )
+        max_scope = max(scopes)
         return max_scope > 0
 
     def __repr__(self):
@@ -279,6 +286,9 @@ class Entity(db.Model):
     childs = relationship("Entity", back_populates="parent")
     fields = relationship("EntityField", back_populates="entity")
     unique_column = relationship("BibFields")
+
+    id_object = db.Column(db.Integer, db.ForeignKey("gn_permissions.t_objects.id_object"))
+    object = relationship("PermObject")
 
     def get_destination_table(self):
         return Table(

--- a/backend/geonature/migrations/versions/f59ccdee8f86_import_add_permissions_by_entities.py
+++ b/backend/geonature/migrations/versions/f59ccdee8f86_import_add_permissions_by_entities.py
@@ -1,0 +1,48 @@
+"""[import] add permissions by entities
+
+Revision ID: f59ccdee8f86
+Revises: 51ee1572f71f
+Create Date: 2025-03-24 14:59:08.659272
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f59ccdee8f86"
+down_revision = "51ee1572f71f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    metadata = sa.MetaData(bind=conn)
+    all_default_value = conn.execute(
+        "SELECT id_object FROM gn_permissions.t_objects where code_object = 'ALL'"
+    ).fetchall()[0][0]
+
+    op.add_column(
+        schema="gn_imports",
+        table_name="bib_entities",
+        column=sa.Column(
+            "id_object",
+            sa.Integer,
+            sa.ForeignKey("gn_permissions.t_objects.id_object"),
+            nullable=True,
+            server_default=str(all_default_value),
+        ),
+    )
+    op.execute(
+        "ALTER TABLE gn_imports.bib_entities ADD CONSTRAINT bib_entities_t_objects_fk FOREIGN KEY (id_object) REFERENCES gn_permissions.t_objects(id_object) ON DELETE CASCADE;"
+    )
+
+
+def downgrade():
+    op.drop_column(
+        schema="gn_imports",
+        table_name="bib_entities",
+        column_name="id_object",
+    )

--- a/backend/geonature/migrations/versions/f59ccdee8f86_import_add_permissions_by_entities.py
+++ b/backend/geonature/migrations/versions/f59ccdee8f86_import_add_permissions_by_entities.py
@@ -36,7 +36,7 @@ def upgrade():
         ),
     )
     op.execute(
-        "ALTER TABLE gn_imports.bib_entities ADD CONSTRAINT bib_entities_t_objects_fk FOREIGN KEY (id_object) REFERENCES gn_permissions.t_objects(id_object) ON DELETE CASCADE;"
+        "ALTER TABLE gn_imports.bib_entities ADD CONSTRAINT bib_entities_t_objects_fk FOREIGN KEY (id_object) REFERENCES gn_permissions.t_objects(id_object);"
     )
 
 


### PR DESCRIPTION
Contrairement à la Synthèse et à Occhab, aucune permission (action = C , object_code = 'ALL') n'existe ! Malheureusement, c'est cette dernière qui était utilisée pour permettre à une personne de créer un import dans la destination !

Cette PR permet d'associer chaque entité à un object_code  par défaut est égale à 'ALL'. Dans le cas de l'import monitorings, cela permet pour les entités sites d'indiquer le object_code `MONITORINGS_VISITES` par exemple.

Perspective: Cela permettra, si le besoin est exprimé, d’empêcher les imports de données pour certaines entités d'une destination. Par exemple, un utilisateur ne pourra qu'importer des stations (occhab) ou que des visites+observations (monitoring)