### PR TITLE
add route to check API health #3417

### DIFF
--- a/backend/geonature/app.py
+++ b/backend/geonature/app.py
@@ -208,6 +208,7 @@ def create_app(with_external_mods=True):
         ("pypnusershub.routes_register:bp", "/pypn/register"),
         ("pypnnomenclature.routes:routes", "/nomenclatures"),
         ("ref_geo.routes:routes", "/geo"),
+        ("geonature.core.health.routes:routes", "/"),
         ("geonature.core.gn_commons.routes:routes", "/gn_commons"),
         ("geonature.core.gn_permissions.routes:routes", "/permissions"),
         ("geonature.core.users.routes:routes", "/users"),

--- a/backend/geonature/core/health/routes.py
+++ b/backend/geonature/core/health/routes.py
@@ -1,20 +1,50 @@
+from celery import Celery
 from flask import Blueprint
+from geonature.utils.env import db
+import redis
+from flask import current_app
 
 routes = Blueprint("health", __name__)
 
 
 def check_all_dependencies():
     """
-    check TODO :
-    - connection to DB is OK
-    - REDIS connection is OK
+    Check all dependencies are available.
+
+    This function checks that the database and the redis server are available.
+
+    Returns
+    -------
+    dict
+       The value for each key is a boolean indicating if the connection is available or not.
     """
-    return True
+    check = {
+        "database_connection": True,
+        "redis_connection": True,
+        "celery_worker": True,
+    }
+    try:
+        db.session.execute("SELECT 1")
+    except Exception as e:
+        check["database_connection"] = False
+    try:
+        if "CELERY" in current_app.config:
+            r = redis.from_url(current_app.config["CELERY"]["broker_url"])
+            r.ping()
+    except redis.ConnectionError:
+        check["redis_connection"] = False
+
+    if "CELERY" in current_app.config:
+        celery_app = Celery("geonature_test")
+        celery_app.config_from_object(current_app.config["CELERY"])
+        if not celery_app.control.inspect().active():
+            check["celery_worker"] = False
+    return check
 
 
 @routes.route("/healthz", methods=["GET"])
 def health_check():
-    if check_all_dependencies():
+    if all(check_all_dependencies().values()):
         return "OK", 200
-    else:
-        return "Service Unavailable", 500
+
+    return "Service Unavailable", 500

--- a/backend/geonature/core/health/routes.py
+++ b/backend/geonature/core/health/routes.py
@@ -1,0 +1,20 @@
+from flask import Blueprint
+
+routes = Blueprint("health", __name__)
+
+
+def check_all_dependencies():
+    """
+    check TODO :
+    - connection to DB is OK
+    - REDIS connection is OK
+    """
+    return True
+
+
+@routes.route("/healthz", methods=["GET"])
+def health_check():
+    if check_all_dependencies():
+        return "OK", 200
+    else:
+        return "Service Unavailable", 500

--- a/backend/geonature/core/health/routes.py
+++ b/backend/geonature/core/health/routes.py
@@ -19,33 +19,50 @@ def check_all_dependencies():
        The value for each key is a boolean indicating if the connection is available or not.
     """
     check = {
-        "database_connection": True,
-        "redis_connection": True,
-        "celery_worker": True,
+        "database_connection": {"status": True, "message": "The database is available"},
+        "redis_connection": {"status": True, "message": "The redis server is available"},
+        "celery_worker": {"status": True, "message": "The celery worker is available"},
     }
+
     try:
         db.session.execute("SELECT 1")
     except Exception as e:
-        check["database_connection"] = False
+        check["database_connection"] = {
+            "status": False,
+            "message": f"The database is not available",
+        }
     try:
         if "CELERY" in current_app.config:
             r = redis.from_url(current_app.config["CELERY"]["broker_url"])
             r.ping()
     except redis.ConnectionError:
-        check["redis_connection"] = False
+        check["redis_connection"] = {
+            "status": False,
+            "message": "The redis server is not available",
+        }
 
     if "CELERY" in current_app.config:
-        celery_app = Celery("geonature_test")
-        celery_app.config_from_object(current_app.config["CELERY"])
-        is_pytest = current_app.config["CELERY"].get("task_always_eager", False)
-        if not is_pytest and not celery_app.control.inspect().active():
-            check["celery_worker"] = False
+        if check["redis_connection"]["status"]:
+            celery_app = Celery("geonature_test")
+            celery_app.config_from_object(current_app.config["CELERY"])
+            is_pytest = current_app.config["CELERY"].get("task_always_eager", False)
+            if not is_pytest and not celery_app.control.inspect().active():
+                check["celery_worker"] = {
+                    "status": False,
+                    "message": "The celery worker is not running",
+                }
+        else:
+            check["celery_worker"] = {
+                "status": False,
+                "message": "The celery worker is not accessible because the redis server is not available",
+            }
     return check
 
 
 @routes.route("/healthz", methods=["GET"])
 def health_check():
-    if all(check_all_dependencies().values()):
+    services_status = [status_data["status"] for _, status_data in check_all_dependencies().items()]
+    if all(services_status):
         return "OK", 200
 
     return "Service Unavailable", 500
@@ -55,7 +72,11 @@ def health_check():
 def services_status():
     return {
         "services": [
-            {"name": service_name, "status": "ONLINE" if service_status else "OFFLINE"}
+            {
+                "name": service_name,
+                "status": "ONLINE" if service_status["status"] else "OFFLINE",
+                "message": service_status["message"],
+            }
             for service_name, service_status in check_all_dependencies().items()
         ]
     }

--- a/backend/geonature/tests/test_health.py
+++ b/backend/geonature/tests/test_health.py
@@ -1,0 +1,13 @@
+import pytest
+
+from geonature.utils.config import config
+from .fixtures import *
+
+
+@pytest.mark.usefixtures("client_class")
+class TestHealth:
+    def test_healthz_endpoint(self):
+        # do not use url_for to be sur the endpoint is always behind API_ENDPOINT / healthz
+        url = f"{config['API_ENDPOINT']}/healthz"
+        response = self.client.get(url)
+        assert response.status_code == 200


### PR DESCRIPTION
https://github.com/PnX-SI/GeoNature/issues/3417

- Add `/healthz` that indicates if redis, celery worker and the database connection are good
- add `/services_status` that give detailed informations on which related services works or not
Example : 
```JSON
{
  "services": [
    {
      "message": "The database is available",
      "name": "database_connection",
      "status": "ONLINE"
    },
    {
      "message": "The redis server is available",
      "name": "redis_connection",
      "status": "ONLINE"
    },
    {
      "message": "The celery worker is available",
      "name": "celery_worker",
      "status": "ONLINE"
    }
  ]
}
``` 

TODO 

- [x] fix backend test -> caused by Celery worker test
- [x] add route to return detailed status 