### PR TITLE
fix(import): fix wrong object sent to report error method when checking WKT

### DIFF
--- a/backend/geonature/core/imports/checks/dataframe/geometry.py
+++ b/backend/geonature/core/imports/checks/dataframe/geometry.py
@@ -152,7 +152,7 @@ def check_geometry(
         wkt_mask = df[wkt_col].notnull()
         if wkt_mask.any():
             geom.loc[wkt_mask] = df[wkt_mask][wkt_col].apply(wkt_to_geometry)
-            invalid_wkt = geom[wkt_mask & geom.isnull()]
+            invalid_wkt = df[wkt_mask & geom.isnull()]
             if not invalid_wkt.empty:
                 yield {
                     "error_code": ImportCodeError.INVALID_WKT,


### PR DESCRIPTION
When a badly formated WKT is imported, a wrong object is given to the reporting method.

This PR resolves #3433 