### PR TITLE
use all-scope temporary transactions

### DIFF
--- a/backend/geonature/tests/conftest.py
+++ b/backend/geonature/tests/conftest.py
@@ -1,5 +1,5 @@
 # force discovery of some fixtures
-from .fixtures import app, users, _session
+from .fixtures import app, users, _session, _app
 from pypnusershub.tests.fixtures import teardown_logout_user
 import pytest
 

--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -139,7 +139,7 @@ def create_module(module_code, module_label, module_path, active_frontend, activ
     )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def modules():
     dict_module_to_create = {
         0: {
@@ -173,7 +173,7 @@ def modules():
     return modules
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="class")
 def module(users):
     other_module = db.session.execute(
         select(TModules).filter_by(module_code="GEONATURE")
@@ -197,7 +197,7 @@ def module(users):
     return new_module
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="class")
 def perm_object():
     with db.session.begin_nested():
         new_object = PermObject(code_object="TEST_OBJECT")
@@ -380,7 +380,7 @@ def celery_eager(app, monkeypatch):
     monkeypatch.setattr(celery_app.conf, "task_eager_propagates", True)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="class")
 def acquisition_frameworks(users):
     principal_actor_role = db.session.execute(
         select(TNomenclatures)
@@ -431,7 +431,7 @@ def acquisition_frameworks(users):
     return afs
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="class")
 def datasets(users, acquisition_frameworks, module):
     principal_actor_role = db.session.execute(
         select(TNomenclatures)
@@ -523,7 +523,7 @@ def datasets(users, acquisition_frameworks, module):
     return datasets
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def source():
     with db.session.begin_nested():
         source = TSources(name_source="Fixture", desc_source="Synthese data from fixture")
@@ -531,7 +531,7 @@ def source():
     return source
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def sources_modules(modules):
     sources = []
     for name_source, module in [("source test 1", modules[0]), ("source test 2", modules[1])]:
@@ -583,7 +583,7 @@ def create_synthese(
     )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def synthese_data(app, users, datasets, source, sources_modules):
     point1 = Point(5.92, 45.56)
     point2 = Point(-1.54, 46.85)

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -1167,16 +1167,6 @@ class TestGNMeta:
         assert response.status_code == Conflict.code, response.json
         mocked_publish_mail.assert_not_called()
 
-        af = acquisition_frameworks["orphan_af"]
-        response = self.client.get(
-            url_for(
-                "gn_meta.publish_acquisition_framework",
-                af_id=af.id_acquisition_framework,
-            )
-        )
-        assert response.status_code == Conflict.code, response.json
-        mocked_publish_mail.assert_not_called()
-
     def test_publish_acquisition_framework_with_data(
         self, mocked_publish_mail, users, acquisition_frameworks, synthese_data
     ):

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -56,14 +56,6 @@ def unexisted_id():
 
 
 @pytest.fixture()
-def source():
-    source = TSources(name_source="test source")
-    with db.session.begin_nested():
-        db.session.add(source)
-    return source
-
-
-@pytest.fixture()
 def unexisted_id_source(source):
     return (
         db.session.execute(select(func.max(TSources.id_source)).select_from(TSources)).scalar_one()


### PR DESCRIPTION
Cette PR intègre à GeoNature ce qui a été fait dans https://github.com/PnX-SI/Utils-Flask-SQLAlchemy/pull/36

Une limitation de longue date à la fixture `temporary_transaction` est qu’elle ne s’applique qu’au niveau du scope `function`. Cela veut dire que toutes les modifications de la base effectuées dans des fixtures ayant toute autre scope que `fixture` sont conservées entre les tests. Elles sont seulement supprimées à la fin de l’ensemble des tests grâce à ce « hack » dans la fixture `app` : https://github.com/PnX-SI/GeoNature/blob/f23db179c81f76128be4ba7fa112934eda0c1876/backend/geonature/tests/fixtures.py#L119-L121

Or souvent il est utile de réutiliser des fixtures pour l’ensemble d’une classe ou d’un module de tests. Par exemple les utilisateurs, modules, objets, JDD et CA dans les tests du module méta-données. Ainsi, il a été nécessaire de passer le scope des fixtures de scope `module` à `function` comme par exemple dans le commit ea7702dc49bdb52060b9af58c500724411e94e11. En conséquence, **un grand nombre de fixtures sont inutilement recréées entre chaque tests au lieu d’être réutilisées**.

Cette PR permet de correctement rollback les modifications effectuées par les fixtures, quelque que soit leur scope.

Il pourra être intéressant de regarder quelles fixtures peuvent être changées de scope afin d’éviter leur recréation et ainsi accélérer l’exécution des tests.