### PR TITLE
Sérialisation des objets Pagination pour un usage simple et homogène de db.paginate

### DIFF
--- a/backend/geonature/app.py
+++ b/backend/geonature/app.py
@@ -2,17 +2,15 @@
 Démarrage de l'application
 """
 
-import logging, warnings, os, sys
+import logging, warnings, sys
 from itertools import chain
 from importlib import import_module
-from packaging import version
 
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
 else:
     from importlib.metadata import entry_points
 from flask import Flask, g, request, current_app, send_from_directory
-from flask.json.provider import DefaultJSONProvider
 from flask_mail import Message
 from flask_babel import Babel
 from flask_cors import CORS
@@ -22,18 +20,13 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.middleware.shared_data import SharedDataMiddleware
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.wrappers import Response
-import sqlalchemy as sa
-
-if version.parse(sa.__version__) >= version.parse("1.4"):
-    from sqlalchemy.engine import Row
-else:  # retro-compatibility SQLAlchemy 1.3
-    from sqlalchemy.engine import RowProxy as Row
 
 from geonature.utils.config import config
 
 from geonature.utils.env import MAIL, DB, db, MA, migrate, BACKEND_DIR
 from geonature.utils.logs import config_loggers
 from geonature.utils.module import iter_modules_dist
+from geonature.utils.json import MyJSONProvider
 from geonature.core.admin.admin import admin
 from geonature.middlewares import SchemeFix, RequestID
 
@@ -73,14 +66,6 @@ if config.get("SENTRY_DSN"):
         integrations=[FlaskIntegration(), RedisIntegration(), CeleryIntegration()],
         traces_sample_rate=1.0,
     )
-
-
-class MyJSONProvider(DefaultJSONProvider):
-    @staticmethod
-    def default(o):
-        if isinstance(o, Row):
-            return o._asdict()
-        return DefaultJSONProvider.default(o)
 
 
 def get_locale():

--- a/backend/geonature/tests/test_utils.py
+++ b/backend/geonature/tests/test_utils.py
@@ -1,11 +1,17 @@
 import tempfile
 
-from geonature.utils.config_schema import GnPySchemaConf
-from .fixtures import *
 import pytest
+import sqlalchemy as sa
+from flask import g
+
+from geonature.core.gn_commons.models import TModules
+from geonature.core.gn_commons.schemas import ModuleSchema
+from geonature.utils.env import db
+from geonature.utils.config_schema import GnPySchemaConf
 from geonature.utils.utilstoml import *
 from geonature.utils.errors import GeoNatureError, ConfigError
-from marshmallow.exceptions import ValidationError
+
+from .fixtures import *
 
 
 #############################################################################
@@ -125,3 +131,19 @@ class TestUtils:
                     config["SYNTHESE"]["TAXON_SHEET"]["ENABLE_TAB_PROFILE"]
                     == expected_enable_tab_profile
                 )
+
+
+class TestJSONProvider:
+    def test_serialize_row(self, app):
+        query = sa.select(TModules.__table__)
+        app.json.dumps(db.session.execute(query).fetchone())
+        app.json.dumps(db.session.execute(query).fetchall())
+
+    def test_serialize_pagination_asdict(self, app):
+        query = sa.select(TModules)
+        app.json.dumps(db.paginate(query))
+
+    def test_serialize_pagination_schema(self, app):
+        query = sa.select(TModules)
+        g.pagination_schema = ModuleSchema()
+        app.json.dumps(db.paginate(query))

--- a/backend/geonature/utils/json.py
+++ b/backend/geonature/utils/json.py
@@ -1,0 +1,33 @@
+from packaging import version
+
+from flask import g
+from flask.json.provider import DefaultJSONProvider
+from flask_sqlalchemy.pagination import Pagination
+import sqlalchemy as sa
+
+if version.parse(sa.__version__) >= version.parse("1.4"):
+    from sqlalchemy.engine import Row
+else:  # retro-compatibility SQLAlchemy 1.3
+    from sqlalchemy.engine import RowProxy as Row
+
+
+class MyJSONProvider(DefaultJSONProvider):
+    @staticmethod
+    def default(o):
+        if isinstance(o, Row):
+            return o._asdict()
+        if isinstance(o, Pagination):
+            if "pagination_schema" in g:
+                items = g.pagination_schema.dump(o.items, many=True)
+            else:
+                items = [item.as_dict() for item in o.items]
+            return {
+                "items": items,
+                "page": o.page,
+                "per_page": o.per_page,
+                "pages": o.pages,
+                "total": o.total,
+                "prev_num": o.prev_num,
+                "next_num": o.next_num,
+            }
+        return DefaultJSONProvider.default(o)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -867,6 +867,14 @@ Voici quelques conseils sur l’envoi de réponse dans vos routes.
 
 - Renvoyer une liste et sa longueur dans une structure de données non conventionnelle est strictement inutile, il est très simple d’accéder à la longueur de la liste en javascript via l’attribut ``length``.
 
+- Pagination : Flask-SQLAlchemy fournit l’utilitaire `db.paginate <https://flask-sqlalchemy.readthedocs.io/en/stable/api/#flask_sqlalchemy.SQLAlchemy.paginate>`_. Notons qu’il n’est pas nécessaire de récupérer les paramètres ``page`` et ``per_page`` de la requête puisque cela est fait automatiquement par ``db.paginate``. Par ailleurs, l’objet `Pagination <https://flask-sqlalchemy.readthedocs.io/en/stable/api/#flask_sqlalchemy.pagination.Pagination>`_ créé par ``db.paginate`` peut directement être renvoyé passé à ``jsonify`` par votre route ; il sera sérialisé dans `une structure commune à l’ensemble de l’application <https://github.com/PnX-SI/GeoNature/blob/master/backend/geonature/utils/json.py>`_. Ce mécanisme nécessite que le schéma Marshmallow nécessaire à la sérialisation des objets paginés soit indiqué dans la variable ``g.pagination_schema``. À défaut, GeoNature essayera d’appeler la méthode ``as_dict()`` sur vos objets.
+    .. code-block:: python
+
+        def my_route():
+            query = sa.select(Item).where(Item.a.like("%foo%"))
+            g.pagination_schema = ItemSchema(only=["a", "b"])
+            return jsonify(db.paginate(query))
+
 - Traitement des erreurs : utiliser `les exceptions prévues à cet effet <https://werkzeug.palletsprojects.com/en/2.0.x/exceptions/>`_ :
     .. code-block:: python
 
@@ -924,7 +932,7 @@ Le décorateur ``@json_resp``
 
 Historiquement, beaucoup de vues sont décorées avec le décorateur ``@json_resp``.
 
-Celui-ci apparait aujourd’hui superflu par rapport à l’usage directement de la fonction ``jsonify`` fournie par Flask.
+Celui-ci apparait aujourd’hui superflu en raison de la jsonification automatique par Flask des listes et des dictionnaires. Pour les autres structures de données, Flask fournit l’utilitaire ``jsonify()``.
 
 - ``utils_flask_sqla_geo.serializers.json_resp``
 


### PR DESCRIPTION
Pagination : Flask-SQLAlchemy fournit l’utilitaire [`db.paginate`](https://flask-sqlalchemy.readthedocs.io/en/stable/api/#flask_sqlalchemy.SQLAlchemy.paginate). Notons qu’il n’est pas nécessaire de récupérer les paramètres ``page`` et ``per_page`` de la requête puisque cela est fait automatiquement par ``db.paginate``. Par ailleurs, l’objet [Pagination](https://flask-sqlalchemy.readthedocs.io/en/stable/api/#flask_sqlalchemy.pagination.Pagination) créé par ``db.paginate`` peut directement être renvoyé passé à ``jsonify`` par votre route ; il sera sérialisé dans [une structure commune à l’ensemble de l’application](https://github.com/PnX-SI/GeoNature/blob/feat/json-pagination/backend/geonature/utils/json.py). Ce mécanisme nécessite que le schéma Marshmallow nécessaire à la sérialisation des objets paginés soit indiqué dans la variable ``g.pagination_schema``. À défaut, GeoNature essayera d’appeler la méthode ``as_dict()`` sur vos objets.