### PR TITLE
add Debian 13 to test matrix

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        debian-version: ["11", "12"]
+        debian-version: ["11", "12", "13"]
         include:
           - debian-version: "11"
             python-version: "3.9"
@@ -28,6 +28,10 @@ jobs:
             python-version: "3.11"
             postgres-version: "15"
             postgis-version: "3.3"
+          - debian-version: "13"
+            python-version: "3.13"
+            postgres-version: "17"
+            postgis-version: "3.5"
 
     name: Debian ${{ matrix.debian-version }}
 


### PR DESCRIPTION
Debian 13 sortira sans doute cet été. C’est cool si la prochaine version de GeoNature est compatible. Petite PR pour voir si c’est le cas ou s’il y a des choses à corriger.