### PR TITLE
fix: Put Update permission on publishing AF instead of export

### DIFF
--- a/backend/geonature/core/gn_meta/routes.py
+++ b/backend/geonature/core/gn_meta/routes.py
@@ -989,7 +989,7 @@ def publish_acquisition_framework_mail(af):
 
 
 @routes.route("/acquisition_framework/publish/<int:af_id>", methods=["GET"])
-@permissions.check_cruved_scope("E", module_code="METADATA")
+@permissions.check_cruved_scope("U", module_code="METADATA")
 @json_resp
 def publish_acquisition_framework(af_id):
     """

--- a/frontend/src/app/metadataModule/metadata.component.html
+++ b/frontend/src/app/metadataModule/metadata.component.html
@@ -173,7 +173,7 @@
                       *ngIf="config.METADATA?.ENABLE_CLOSE_AF"
                       type="button"
                       mat-icon-button
-                      [disabled]="!af.opened"
+                      [disabled]="!af.opened || !af.cruved.U"
                       (click)="
                         openPublishModalAf($event, af.id_acquisition_framework, publishModal)
                       "


### PR DESCRIPTION
At the moment the only permission needed for publishing an AF is export. However, publishing an AF close it, so it effectively update it. 