### PR TITLE
fix(benchmark): fix construct of synthese bench tests for admin

### DIFF
--- a/backend/geonature/tests/benchmarks/utils.py
+++ b/backend/geonature/tests/benchmarks/utils.py
@@ -81,7 +81,7 @@ def add_bluring_to_benchmark_test_class(benchmark_cls: type, different_user: str
                 continue
 
             # Include blurring fixture
-            kwargs = b_test.function_kwargs
+            kwargs = b_test.function_kwargs.copy()
             kwargs["fixtures"] = (
                 kwargs["fixtures"] + [blur_sensitive_observations]
                 if "fixtures" in kwargs


### PR DESCRIPTION
The function `add_bluring_to_benchmark_test_class` - used in "test_benchmark_synthese.py" - does not only add tests for `user_with_blurring`, but it also finalizes the declaration of the synthese benchmark tests for the user admin_user. But, before the current commit, the `"user_profile"` was unwishingly changed from `admin_user` to `user_with_blurring` before the declaration of the tests for admin_user, thus breaking the execution of those lasts tests.