### PR TITLE
[Workshop2025] Synthese export celery

### DIFF
--- a/backend/geonature/core/gn_commons/routes.py
+++ b/backend/geonature/core/gn_commons/routes.py
@@ -18,7 +18,9 @@ from geonature.core.gn_commons.models import (
     TMobileApps,
     TPlaces,
     TAdditionalFields,
+    Task,
 )
+from geonature.core.gn_commons.schemas import TaskSchema
 from geonature.core.gn_commons.repositories import TMediaRepository
 from geonature.core.gn_commons.repositories import get_table_location_id
 from geonature.utils.env import DB, db, BACKEND_DIR
@@ -306,6 +308,20 @@ def delete_place(id_place):
     db.session.delete(place)
     db.session.commit()
     return "", 204
+
+
+@routes.route("/tasks", methods=["GET"])
+@login_required
+def get_tasks():
+    query = db.select(Task).filter_by(id_role=g.current_user.id_role)
+    if "uuid" in request.args:
+        uuid_list = request.args.getlist("uuid")
+        query = query.filter(Task.uuid_celery.in_(uuid_list))
+    if "module_code" in request.args:
+        query = query.filter(Task.module.has(module_code=request.args["module_code"]))
+    tasks = db.session.scalars(query).all()
+    task_schema = TaskSchema()
+    return task_schema.jsonify(tasks, many=True)
 
 
 ##############################

--- a/backend/geonature/core/gn_commons/schemas.py
+++ b/backend/geonature/core/gn_commons/schemas.py
@@ -1,4 +1,5 @@
 import logging
+from flask import url_for
 from marshmallow import Schema, pre_load, fields, EXCLUDE
 
 from utils_flask_sqla.schema import SmartRelationshipsMixin
@@ -13,6 +14,7 @@ from geonature.core.gn_commons.models import (
     TValidations,
     TAdditionalFields,
     BibWidgets,
+    Task,
 )
 from geonature.core.gn_permissions.schemas import PermObjectSchema
 
@@ -69,6 +71,22 @@ class BibWidgetSchema(MA.SQLAlchemyAutoSchema):
     class Meta:
         model = BibWidgets
         load_instance = True
+
+
+class TaskSchema(MA.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Task
+        load_instance = True
+        include_fk = True
+
+    url = fields.Method("get_url")
+
+    def get_url(self, obj):
+        if obj.file_name:
+            return url_for(
+                "media", filename="exports/usr_generated/" + obj.file_name, _external=True
+            )
+        return None
 
 
 class LabelValueDict(Schema):

--- a/backend/geonature/core/gn_commons/tasks.py
+++ b/backend/geonature/core/gn_commons/tasks.py
@@ -1,7 +1,14 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
 from celery.schedules import crontab
 from celery.utils.log import get_task_logger
+from flask import current_app
+from sqlalchemy import delete
 
 from geonature.core.gn_commons.repositories import TMediumRepository
+from geonature.core.gn_commons.models import Task
+from geonature.utils.env import db
 from geonature.utils.celery import celery_app
 from geonature.utils.config import config
 
@@ -25,9 +32,40 @@ def setup_periodic_tasks(sender, **kwargs):
             name="clean medias",
         )
 
+    sender.add_periodic_task(
+        crontab(minute="0", hour="0"),
+        delete_file_and_tasks_celery.s(),
+        name="Clean export files",
+    )
+
 
 @celery_app.task(bind=True)
 def clean_attachments(self):
     logger.info("Cleaning medias...")
     TMediumRepository.sync_medias()
     logger.info("Medias cleaned")
+
+
+def delete_file_and_tasks():
+    """
+    Fonction permettant de supprimer les fichiers générés
+    par le module export ayant plus de X jours
+
+    .. :quickref: Fonction permettant de supprimer les
+        fichiers générés par le module export ayant plus de X jours
+
+    """
+    limit_date = datetime.today() - timedelta(days=15)
+    path_to_delete = Path(current_app.config["MEDIA_FOLDER"]) / "exports/usr_generated"
+    for item in path_to_delete.glob("**/*"):
+        item_time = item.stat().st_mtime
+        if item_time < datetime.timestamp(limit_date):
+            if item.is_file():
+                item.unlink()
+    # delete tasks
+    db.session.execute(delete(Task).where(Task.end < limit_date))
+
+
+@celery_app.task(bind=True)
+def delete_file_and_tasks_celery(self):
+    delete_file_and_tasks()

--- a/backend/geonature/core/gn_synthese/blueprints/exports.py
+++ b/backend/geonature/core/gn_synthese/blueprints/exports.py
@@ -1,51 +1,14 @@
-import datetime
-import json
-import re
-from collections import OrderedDict
-
 from flask import (
     Blueprint,
-    current_app,
     g,
-    render_template,
     request,
-    send_from_directory,
 )
 
-from geojson import Feature, FeatureCollection
 from geonature.core.gn_permissions.decorators import permissions_required
-from geonature.core.gn_synthese.models import (
-    CorAreaSynthese,
-    Synthese,
-    VSyntheseForWebApp,
-)
-from geonature.core.gn_synthese.synthese_config import MANDATORY_COLUMNS
-from geonature.core.gn_synthese.utils.blurring import (
-    build_allowed_geom_cte,
-    build_blurred_precise_geom_queries,
-    split_blurring_precise_permissions,
-)
-from geonature.core.gn_synthese.utils.query_select_sqla import SyntheseQuery
-from geonature.utils import filemanager
-from geonature.utils.env import DB, db
-from geonature.utils.errors import GeonatureApiError
-from geonature.utils.utilsgeometrytools import export_as_geo_file
 
-from apptax.taxonomie.models import (
-    Taxref,
-    TaxrefBdcStatutCorTextValues,
-    TaxrefBdcStatutTaxon,
-    TaxrefBdcStatutText,
-    TaxrefBdcStatutType,
-    TaxrefBdcStatutValues,
-    bdc_statut_cor_text_area,
+from geonature.core.gn_synthese.tasks.exports import (
+    export_synthese_task,
 )
-
-from sqlalchemy import distinct, func, select
-from utils_flask_sqla.generic import GenericTable, serializeQuery
-from utils_flask_sqla.response import to_csv_resp, to_json_resp
-from utils_flask_sqla_geo.generic import GenericTableGeo
-from werkzeug.exceptions import BadRequest, Forbidden
 
 export_routes = Blueprint("exports", __name__)
 
@@ -66,63 +29,19 @@ def export_taxon_web(permissions):
     :query str export_format: str<'csv'>
 
     """
-    taxon_view = GenericTable(
-        tableName="v_synthese_taxon_for_export_view",
-        schemaName="gn_synthese",
-        engine=DB.engine,
-    )
-    columns = taxon_view.tableDef.columns
 
-    # Test de conformité de la vue v_synthese_for_export_view
-    try:
-        assert hasattr(taxon_view.tableDef.columns, "cd_ref")
-    except AssertionError as e:
-        return (
-            {
-                "msg": """
-                        View v_synthese_taxon_for_export_view
-                        must have a cd_ref column \n
-                        trace: {}
-                        """.format(
-                    str(e)
-                )
-            },
-            500,
-        )
+    params = request.args
+    json_params = request.get_json()
+    all_params = {**params, **json_params}
 
-    id_list = request.get_json()
-
-    sub_query = (
-        select(
-            VSyntheseForWebApp.cd_ref,
-            func.count(distinct(VSyntheseForWebApp.id_synthese)).label("nb_obs"),
-            func.min(VSyntheseForWebApp.date_min).label("date_min"),
-            func.max(VSyntheseForWebApp.date_max).label("date_max"),
-        )
-        .where(VSyntheseForWebApp.id_synthese.in_(id_list))
-        .group_by(VSyntheseForWebApp.cd_ref)
+    uuid_task = export_synthese_task.delay(
+        export_type="taxons",
+        id_permissions=[p.id_permission for p in permissions],
+        params=all_params,
+        id_role=g.current_user.id_role,
     )
 
-    synthese_query_class = SyntheseQuery(
-        VSyntheseForWebApp,
-        sub_query,
-        {},
-    )
-
-    synthese_query_class.filter_query_all_filters(g.current_user, permissions)
-
-    subq = synthese_query_class.query.alias("subq")
-
-    query = select(*columns, subq.c.nb_obs, subq.c.date_min, subq.c.date_max).join(
-        subq, subq.c.cd_ref == columns.cd_ref
-    )
-
-    return to_csv_resp(
-        datetime.datetime.now().strftime("%Y_%m_%d_%Hh%Mm%S"),
-        data=serializeQuery(db.session.execute(query).all(), query.column_descriptions),
-        separator=";",
-        columns=[db_col.key for db_col in columns] + ["nb_obs", "date_min", "date_max"],
-    )
+    return {"msg": "task en cours", "uuid_task": str(uuid_task)}
 
 
 @export_routes.route("/export_observations", methods=["POST"])
@@ -142,186 +61,17 @@ def export_observations_web(permissions):
 
     """
     params = request.args
-    # set default to csv
-    export_format = params.get("export_format", "csv")
-    view_name_param = params.get("view_name", "gn_synthese.v_synthese_for_export")
-    # Test export_format
-    if export_format not in current_app.config["SYNTHESE"]["EXPORT_FORMAT"]:
-        raise BadRequest("Unsupported format")
-    config_view = {
-        "view_name": "gn_synthese.v_synthese_for_web_app",
-        "geojson_4326_field": "geojson_4326",
-        "geojson_local_field": "geojson_local",
-    }
-    # Test export view name is config params for security reason
-    if view_name_param != "gn_synthese.v_synthese_for_export":
-        try:
-            config_view = next(
-                _view
-                for _view in current_app.config["SYNTHESE"]["EXPORT_OBSERVATIONS_CUSTOM_VIEWS"]
-                if _view["view_name"] == view_name_param
-            )
-        except StopIteration:
-            raise Forbidden("This view is not available for export")
+    json_params = request.get_json()
+    all_params = {**params, **json_params}
 
-    geojson_4326_field = config_view["geojson_4326_field"]
-    geojson_local_field = config_view["geojson_local_field"]
-    try:
-        schema_name, view_name = view_name_param.split(".")
-    except ValueError:
-        raise BadRequest("view_name parameter must be a string with schema dot view_name")
-
-    # get list of id synthese from POST
-    id_list = request.get_json()
-
-    # Get the SRID for the export
-    local_srid = DB.session.execute(
-        func.Find_SRID("gn_synthese", "synthese", "the_geom_local")
-    ).scalar()
-
-    blurring_permissions, precise_permissions = split_blurring_precise_permissions(permissions)
-
-    # Get the view for export
-    # Useful to have geom column so that they can be replaced by blurred geoms
-    # (only if the user has sensitive permissions)
-    export_view = GenericTableGeo(
-        tableName=view_name,
-        schemaName=schema_name,
-        engine=DB.engine,
-        geometry_field=None,
-        srid=local_srid,
-    )
-    mandatory_columns = {"id_synthese", geojson_4326_field, geojson_local_field}
-    if not mandatory_columns.issubset(set(map(lambda col: col.name, export_view.db_cols))):
-        print(set(map(lambda col: col.name, export_view.db_cols)))
-        raise BadRequest(
-            f"The view {view_name} miss one of required columns {str(mandatory_columns)}"
-        )
-
-    # If there is no sensitive permissions => same path as before blurring implementation
-    if not blurring_permissions:
-        # Get the CTE for synthese filtered by user permissions
-        synthese_query_class = SyntheseQuery(
-            Synthese,
-            select(Synthese.id_synthese),
-            {},
-        )
-        synthese_query_class.filter_query_all_filters(g.current_user, permissions)
-        cte_synthese_filtered = synthese_query_class.build_query().cte("cte_synthese_filtered")
-        selectable_columns = [export_view.tableDef]
-    else:
-        # Use slightly the same process as for get_observations_for_web()
-        # Add a where_clause to filter the id_synthese provided to reduce the
-        # UNION queries
-        where_clauses = [Synthese.id_synthese.in_(id_list)]
-        blurred_geom_query, precise_geom_query = build_blurred_precise_geom_queries(
-            filters={}, where_clauses=where_clauses
-        )
-
-        cte_synthese_filtered = build_allowed_geom_cte(
-            blurring_permissions=blurring_permissions,
-            precise_permissions=precise_permissions,
-            blurred_geom_query=blurred_geom_query,
-            precise_geom_query=precise_geom_query,
-            limit=current_app.config["SYNTHESE"]["NB_MAX_OBS_EXPORT"],
-        )
-
-        # Overwrite geometry columns to compute the blurred geometry from the blurring cte
-        columns_with_geom_excluded = [
-            col
-            for col in export_view.tableDef.columns
-            if col.name
-            not in [
-                "geometrie_wkt_4326",  # FIXME: hardcoded column names?
-                "x_centroid_4326",
-                "y_centroid_4326",
-                geojson_4326_field,
-                geojson_local_field,
-            ]
-        ]
-        # Recomputed the blurred geometries
-        blurred_geom_columns = [
-            func.st_astext(cte_synthese_filtered.c.geom).label("geometrie_wkt_4326"),
-            func.st_x(func.st_centroid(cte_synthese_filtered.c.geom)).label("x_centroid_4326"),
-            func.st_y(func.st_centroid(cte_synthese_filtered.c.geom)).label("y_centroid_4326"),
-            func.st_asgeojson(cte_synthese_filtered.c.geom).label(geojson_4326_field),
-            func.st_asgeojson(func.st_transform(cte_synthese_filtered.c.geom, local_srid)).label(
-                geojson_local_field
-            ),
-        ]
-
-        # Finally provide all the columns to be selected in the export query
-        selectable_columns = columns_with_geom_excluded + blurred_geom_columns
-
-    # Get the query for export
-    export_query = (
-        select(*selectable_columns)
-        .select_from(
-            export_view.tableDef.join(
-                cte_synthese_filtered,
-                cte_synthese_filtered.c.id_synthese == export_view.tableDef.columns["id_synthese"],
-            )
-        )
-        .where(export_view.tableDef.columns["id_synthese"].in_(id_list))
-        .distinct(export_view.tableDef.columns["id_synthese"])
+    uuid_task = export_synthese_task.delay(
+        export_type="observations",
+        id_permissions=[p.id_permission for p in permissions],
+        params=all_params,
+        id_role=g.current_user.id_role,
     )
 
-    # Get the results for export
-    results = DB.session.execute(
-        export_query.limit(current_app.config["SYNTHESE"]["NB_MAX_OBS_EXPORT"])
-    )
-
-    db_cols_for_shape = []
-    columns_to_serialize = []
-    # loop over synthese config to exclude columns if its default export
-    for db_col in export_view.db_cols:
-        if view_name_param == "gn_synthese.v_synthese_for_export":
-            if db_col.key in current_app.config["SYNTHESE"]["EXPORT_COLUMNS"]:
-                db_cols_for_shape.append(db_col)
-                columns_to_serialize.append(db_col.key)
-        else:
-            # remove geojson fields of serialization
-            if db_col.key not in [geojson_4326_field, geojson_local_field]:
-                db_cols_for_shape.append(db_col)
-                columns_to_serialize.append(db_col.key)
-
-    file_name = datetime.datetime.now().strftime("%Y_%m_%d_%Hh%Mm%S")
-    file_name = filemanager.removeDisallowedFilenameChars(file_name)
-
-    if export_format == "csv":
-        formated_data = [export_view.as_dict(d, fields=columns_to_serialize) for d in results]
-        return to_csv_resp(file_name, formated_data, separator=";", columns=columns_to_serialize)
-    elif export_format == "geojson":
-        features = []
-        for r in results:
-            geometry = json.loads(getattr(r, geojson_4326_field))
-            feature = Feature(
-                geometry=geometry,
-                properties=export_view.as_dict(r, fields=columns_to_serialize),
-            )
-            features.append(feature)
-        results = FeatureCollection(features)
-        return to_json_resp(results, as_file=True, filename=file_name, indent=4)
-    else:
-        try:
-            dir_name, file_name = export_as_geo_file(
-                export_format=export_format,
-                export_view=export_view,
-                db_cols=db_cols_for_shape,
-                geojson_col=geojson_local_field,
-                data=results,
-                file_name=file_name,
-            )
-            return send_from_directory(dir_name, file_name, as_attachment=True)
-
-        except GeonatureApiError as e:
-            message = str(e)
-
-        return render_template(
-            "error.html",
-            error=message,
-            redirect=current_app.config["URL_APPLICATION"] + "/#/synthese",
-        )
+    return {"msg": "task en cours", "uuid_task": str(uuid_task)}
 
 
 # TODO: Change the following line to set method as "POST" only ?
@@ -340,65 +90,14 @@ def export_metadata(permissions):
     """
     filters = request.json if request.is_json else {}
 
-    metadata_view = GenericTable(
-        tableName="v_metadata_for_export",
-        schemaName="gn_synthese",
-        engine=DB.engine,
+    uuid_task = export_synthese_task.delay(
+        export_type="metadata",
+        id_permissions=[p.id_permission for p in permissions],
+        params=filters,
+        id_role=g.current_user.id_role,
     )
 
-    # Test de conformité de la vue v_metadata_for_export
-    try:
-        assert hasattr(metadata_view.tableDef.columns, "jdd_id")
-    except AssertionError as e:
-        return (
-            {
-                "msg": """
-                        View v_metadata_for_export
-                        must have a jdd_id column \n
-                        trace: {}
-                        """.format(
-                    str(e)
-                )
-            },
-            500,
-        )
-
-    q = select(distinct(VSyntheseForWebApp.id_dataset), metadata_view.tableDef)
-
-    synthese_query_class = SyntheseQuery(
-        VSyntheseForWebApp,
-        q,
-        filters,
-    )
-    synthese_query_class.add_join(
-        metadata_view.tableDef,
-        getattr(
-            metadata_view.tableDef.columns,
-            current_app.config["SYNTHESE"]["EXPORT_METADATA_ID_DATASET_COL"],
-        ),
-        VSyntheseForWebApp.id_dataset,
-    )
-
-    # Filter query with permissions (scope, sensitivity, ...)
-    synthese_query_class.filter_query_all_filters(g.current_user, permissions)
-
-    data = DB.session.execute(synthese_query_class.query)
-
-    # Define the header of the csv file
-    columns = [db_col.key for db_col in metadata_view.tableDef.columns]
-    columns[columns.index("nombre_obs")] = "nombre_total_obs"
-
-    # Retrieve the data to write in the csv file
-    data = [metadata_view.as_dict(d) for d in data]
-    for d in data:
-        d["nombre_total_obs"] = d.pop("nombre_obs")
-
-    return to_csv_resp(
-        datetime.datetime.now().strftime("%Y_%m_%d_%Hh%Mm%S"),
-        data=data,
-        separator=";",
-        columns=columns,
-    )
+    return {"msg": "task en cours", "uuid_task": str(uuid_task)}
 
 
 @export_routes.route("/export_statuts", methods=["POST"])
@@ -415,108 +114,11 @@ def export_status(permissions):
         - HTTP-GET: the same that the /synthese endpoint (all the filter in web app)
     """
     filters = request.json if request.is_json else {}
-
-    # Initalize the select object
-    query = select(
-        distinct(VSyntheseForWebApp.cd_nom).label("cd_nom"),
-        Taxref.cd_ref,
-        Taxref.nom_complet,
-        Taxref.nom_vern,
-        TaxrefBdcStatutTaxon.rq_statut,
-        TaxrefBdcStatutType.regroupement_type,
-        TaxrefBdcStatutType.lb_type_statut,
-        TaxrefBdcStatutText.cd_sig,
-        TaxrefBdcStatutText.full_citation,
-        TaxrefBdcStatutText.doc_url,
-        TaxrefBdcStatutValues.code_statut,
-        TaxrefBdcStatutValues.label_statut,
-    )
-    # Initialize SyntheseQuery class
-    synthese_query = SyntheseQuery(VSyntheseForWebApp, query, filters)
-
-    # Filter query with permissions
-    synthese_query.filter_query_all_filters(g.current_user, permissions)
-
-    # Add join
-    synthese_query.add_join(Taxref, Taxref.cd_nom, VSyntheseForWebApp.cd_nom)
-    synthese_query.add_join(
-        CorAreaSynthese,
-        CorAreaSynthese.id_synthese,
-        VSyntheseForWebApp.id_synthese,
-    )
-    synthese_query.add_join(
-        bdc_statut_cor_text_area, bdc_statut_cor_text_area.c.id_area, CorAreaSynthese.id_area
-    )
-    synthese_query.add_join(TaxrefBdcStatutTaxon, TaxrefBdcStatutTaxon.cd_ref, Taxref.cd_ref)
-    synthese_query.add_join(
-        TaxrefBdcStatutCorTextValues,
-        TaxrefBdcStatutCorTextValues.id_value_text,
-        TaxrefBdcStatutTaxon.id_value_text,
-    )
-    synthese_query.add_join_multiple_cond(
-        TaxrefBdcStatutText,
-        [
-            TaxrefBdcStatutText.id_text == TaxrefBdcStatutCorTextValues.id_text,
-            TaxrefBdcStatutText.id_text == bdc_statut_cor_text_area.c.id_text,
-        ],
-    )
-    synthese_query.add_join(
-        TaxrefBdcStatutType,
-        TaxrefBdcStatutType.cd_type_statut,
-        TaxrefBdcStatutText.cd_type_statut,
-    )
-    synthese_query.add_join(
-        TaxrefBdcStatutValues,
-        TaxrefBdcStatutValues.id_value,
-        TaxrefBdcStatutCorTextValues.id_value,
+    uuid_task = export_synthese_task.delay(
+        export_type="status",
+        id_permissions=[p.id_permission for p in permissions],
+        params=filters,
+        id_role=g.current_user.id_role,
     )
 
-    # Build query
-    query = synthese_query.build_query()
-
-    # Set enable status texts filter
-    query = query.where(TaxrefBdcStatutText.enable == True)
-
-    protection_status = []
-    data = DB.session.execute(query)
-
-    for d in data:
-        d = d._mapping
-        row = OrderedDict(
-            [
-                ("cd_nom", d["cd_nom"]),
-                ("cd_ref", d["cd_ref"]),
-                ("nom_complet", d["nom_complet"]),
-                ("nom_vern", d["nom_vern"]),
-                ("type_regroupement", d["regroupement_type"]),
-                ("type", d["lb_type_statut"]),
-                ("territoire_application", d["cd_sig"]),
-                ("intitule_doc", re.sub("<[^<]+?>", "", d["full_citation"])),
-                ("code_statut", d["code_statut"]),
-                ("intitule_statut", d["label_statut"]),
-                ("remarque", d["rq_statut"]),
-                ("url_doc", d["doc_url"]),
-            ]
-        )
-        protection_status.append(row)
-    export_columns = [
-        "nom_complet",
-        "nom_vern",
-        "cd_nom",
-        "cd_ref",
-        "type_regroupement",
-        "type",
-        "territoire_application",
-        "intitule_doc",
-        "code_statut",
-        "intitule_statut",
-        "remarque",
-        "url_doc",
-    ]
-
-    return to_csv_resp(
-        datetime.datetime.now().strftime("%Y_%m_%d_%Hh%Mm%S"),
-        protection_status,
-        separator=";",
-        columns=export_columns,
-    )
+    return {"msg": "task en cours", "uuid_task": str(uuid_task)}

--- a/backend/geonature/core/gn_synthese/schemas.py
+++ b/backend/geonature/core/gn_synthese/schemas.py
@@ -1,3 +1,5 @@
+from marshmallow import Schema, fields
+
 from geonature.utils.env import db, ma
 from geonature.utils.config import config
 
@@ -70,3 +72,17 @@ class SyntheseSchema(SmartRelationshipsMixin, GeoAlchemyAutoSchema):
     last_validation = ma.Nested(TValidationSchema, dump_only=True)
     reports = ma.Nested(ReportSchema, many=True)
     # Missing nested schemas: taxref
+
+
+class ExportStatusSchema(Schema):
+    cd_ref = fields.Integer(dump_only=True)
+    nom_valide = fields.Str(dump_only=True)
+    nom_vern = fields.Str(dump_only=True)
+    rq_statut = fields.Str(dump_only=True)
+    regroupement_type = fields.Str(dump_only=True)
+    lb_type_statut = fields.Str(dump_only=True)
+    cd_sig = fields.Str(dump_only=True)
+    full_citation = fields.Str(dump_only=True)
+    doc_url = fields.Str(dump_only=True)
+    code_statut = fields.Str(dump_only=True)
+    label_statut = fields.Str(dump_only=True)

--- a/backend/geonature/core/gn_synthese/tasks/exports.py
+++ b/backend/geonature/core/gn_synthese/tasks/exports.py
@@ -1,0 +1,455 @@
+import os
+from pathlib import Path
+from datetime import datetime
+from typing import List, Optional
+from celery.utils.log import get_task_logger
+
+from flask import current_app
+from geoalchemy2 import Geometry
+from sqlalchemy import distinct, func, select
+from flask_sqlalchemy.query import Query
+from marshmallow import fields, Schema
+from werkzeug.exceptions import BadRequest, Forbidden
+
+from utils_flask_sqla_geo.generic import GenericQueryGeo
+from utils_flask_sqla_geo.export import (
+    export_csv,
+    export_geojson,
+    export_geopackage,
+    export_json,
+)
+
+from ref_geo.utils import get_local_srid
+
+from apptax.taxonomie.models import VBdcStatus
+
+from pypnusershub.db.models import User
+
+from geonature.utils.env import DB, db
+from geonature.utils.celery import celery_app
+
+from geonature.core.gn_permissions.models import Permission
+from geonature.core.gn_commons.models import Task
+from geonature.core.gn_commons.schemas import TaskSchema
+
+from geonature.core.gn_synthese.models import (
+    Synthese,
+    VSyntheseForWebApp,
+)
+from geonature.core.gn_synthese.schemas import ExportStatusSchema
+from geonature.core.gn_synthese.synthese_config import MANDATORY_COLUMNS
+from geonature.core.gn_synthese.utils.blurring import (
+    build_allowed_geom_cte,
+    build_blurred_precise_geom_queries,
+    split_blurring_precise_permissions,
+)
+from geonature.core.gn_synthese.utils.query_select_sqla import SyntheseQuery
+
+
+logger = get_task_logger(__name__)
+
+
+@celery_app.task(bind=True)
+def export_synthese_task(self, export_type, id_permissions, params, id_role):
+    db_task = Task.create_pending_task(id_role, self.request.id, "SYNTHESE")
+    try:
+        current_user = db.session.scalar(select(User).where(User.id_role == id_role))
+        permissions = db.session.scalars(
+            select(Permission).where(Permission.id_permission.in_(id_permissions))
+        ).all()
+        geometry_field_name = None
+        local_srid = None
+        if "ids" in params:
+            params["id_list"] = params.pop("ids")
+
+        export_format = params.get("export_format", "csv")
+        if export_type == "taxons":
+            ExportSchema, query, columns = export_taxons(permissions, current_user, params)
+        elif export_type == "observations":
+            ExportSchema, query, columns, geometry_field_name, local_srid = export_observations(
+                permissions, current_user, params
+            )
+        elif export_type == "status":
+            ExportSchema, query, columns = export_status(permissions, current_user, params)
+        elif export_type == "metadata":
+            ExportSchema, query, columns = export_metadata(permissions, current_user, params)
+        else:
+            # TODO raise
+            return
+
+        export_dir = Path(current_app.config["MEDIA_FOLDER"]) / "exports/usr_generated"
+        current_timestamp = datetime.now().strftime("%Y_%m_%d_%Hh%Mm%S")
+        export_file_name = f"export_{export_type}_{current_timestamp}.{export_format}"
+
+        full_file_path = f"{export_dir}/{export_file_name}"
+        export_data_file(
+            file_name=full_file_path,
+            format="csv",
+            query=query,
+            schema_class=ExportSchema,
+            pk_name=None,
+            geometry_field=geometry_field_name,
+            srid=local_srid,
+            columns=columns,
+        )
+        db_task.set_succesfull(export_file_name)
+        return TaskSchema().dump(db_task)
+    except Exception as e:
+        db.session.rollback()
+        db_task.status = "error"
+        db.session.commit()
+        raise e
+
+
+def export_taxons(permissions, current_user, params):
+
+    taxon_view = GenericQueryGeo(
+        DB=DB, tableName="v_synthese_taxon_for_export_view", schemaName="gn_synthese"
+    )
+    columns = taxon_view.view.tableDef.columns
+
+    id_list = params.pop("id_list")
+    # Test de conformité de la vue v_synthese_for_export_view
+    try:
+        assert hasattr(columns, "cd_ref")
+    except AssertionError as e:
+        raise Exception("View v_synthese_taxon_for_export_view must have a cd_ref column \n")
+
+    sub_query = (
+        select(
+            VSyntheseForWebApp.cd_ref,
+            func.count(distinct(VSyntheseForWebApp.id_synthese)).label("nb_obs"),
+            func.min(VSyntheseForWebApp.date_min).label("date_min"),
+            func.max(VSyntheseForWebApp.date_max).label("date_max"),
+        )
+        .where(VSyntheseForWebApp.id_synthese.in_(id_list))
+        .group_by(VSyntheseForWebApp.cd_ref)
+    )
+
+    synthese_query_class = SyntheseQuery(
+        VSyntheseForWebApp,
+        sub_query,
+        {},
+    )
+
+    synthese_query_class.filter_query_all_filters(current_user, permissions)
+
+    subq = synthese_query_class.query.alias("subq")
+
+    query = select(*columns, subq.c.nb_obs, subq.c.date_min, subq.c.date_max).join(
+        subq, subq.c.cd_ref == columns.cd_ref
+    )
+
+    # Créate schema
+    extra_fields = {}
+    extra_fields["nb_obs"] = fields.Integer(dump_only=True)
+    extra_fields["date_min"] = fields.Date(dump_only=True)
+    extra_fields["date_max"] = fields.Date(dump_only=True)
+    ExportTaxonViewSchema = type(
+        "ExportTaxonViewSchema", (taxon_view.get_marshmallow_schema(),), extra_fields
+    )
+    return ExportTaxonViewSchema, query, []
+
+
+def export_observations(permissions, current_user, params):
+    export_format = params.get("export_format", "csv")
+    view_name_param = params.get("view_name", "gn_synthese.v_synthese_for_export")
+    id_list = params.pop("id_list")
+    print(id_list)
+    # Test export_format
+    if export_format not in current_app.config["SYNTHESE"]["EXPORT_FORMAT"]:
+        raise BadRequest("Unsupported format")
+    config_view = {
+        "view_name": "gn_synthese.v_synthese_for_web_app",
+        "geojson_4326_field": "geojson_4326",
+        "geojson_local_field": "geojson_local",
+    }
+    # Test export view name is config params for security reason
+    if view_name_param != "gn_synthese.v_synthese_for_export":
+        try:
+            config_view = next(
+                _view
+                for _view in current_app.config["SYNTHESE"]["EXPORT_OBSERVATIONS_CUSTOM_VIEWS"]
+                if _view["view_name"] == view_name_param
+            )
+        except StopIteration:
+            raise Forbidden("This view is not available for export")
+
+    geojson_4326_field = config_view["geojson_4326_field"]
+    geojson_local_field = config_view["geojson_local_field"]
+    try:
+        schema_name, view_name = view_name_param.split(".")
+    except ValueError:
+        raise BadRequest("view_name parameter must be a string with schema dot view_name")
+
+    # Get the SRID for the export
+    local_srid = DB.session.execute(
+        func.Find_SRID("gn_synthese", "synthese", "the_geom_local")
+    ).scalar()
+
+    blurring_permissions, precise_permissions = split_blurring_precise_permissions(permissions)
+
+    # Get the view for export
+    # Useful to have geom column so that they can be replaced by blurred geoms
+    # (only if the user has sensitive permissions)
+    export_view = GenericQueryGeo(DB=DB, tableName=view_name, schemaName=schema_name)
+
+    mandatory_columns = {"id_synthese", geojson_4326_field, geojson_local_field}
+    if not mandatory_columns.issubset(set(map(lambda col: col.name, export_view.view.db_cols))):
+        print(set(map(lambda col: col.name, export_view.view.db_cols)))
+        raise BadRequest(
+            f"The view {view_name} miss one of required columns {str(mandatory_columns)}"
+        )
+
+    # If there is no sensitive permissions => same path as before blurring implementation
+    if not blurring_permissions:
+        # Get the CTE for synthese filtered by user permissions
+        synthese_query_class = SyntheseQuery(
+            Synthese,
+            select(Synthese.id_synthese),
+            {},
+        )
+        synthese_query_class.filter_query_all_filters(current_user, permissions)
+        cte_synthese_filtered = synthese_query_class.build_query().cte("cte_synthese_filtered")
+        selectable_columns = [export_view.view.tableDef]
+    else:
+        # Use slightly the same process as for get_observations_for_web()
+        # Add a where_clause to filter the id_synthese provided to reduce the
+        # UNION queries
+        where_clauses = [Synthese.id_synthese.in_(id_list)]
+        blurred_geom_query, precise_geom_query = build_blurred_precise_geom_queries(
+            filters={}, where_clauses=where_clauses
+        )
+
+        cte_synthese_filtered = build_allowed_geom_cte(
+            blurring_permissions=blurring_permissions,
+            precise_permissions=precise_permissions,
+            blurred_geom_query=blurred_geom_query,
+            precise_geom_query=precise_geom_query,
+            limit=current_app.config["SYNTHESE"]["NB_MAX_OBS_EXPORT"],
+        )
+
+        # Overwrite geometry columns to compute the blurred geometry from the blurring cte
+        columns_with_geom_excluded = [
+            col
+            for col in export_view.view.tableDef.columns
+            if col.name
+            not in [
+                "geometrie_wkt_4326",  # FIXME: hardcoded column names?
+                "x_centroid_4326",
+                "y_centroid_4326",
+                geojson_4326_field,
+                geojson_local_field,
+            ]
+        ]
+        # Recomputed the blurred geometries
+        blurred_geom_columns = [
+            func.st_astext(cte_synthese_filtered.c.geom).label("geometrie_wkt_4326"),
+            func.st_x(func.st_centroid(cte_synthese_filtered.c.geom)).label("x_centroid_4326"),
+            func.st_y(func.st_centroid(cte_synthese_filtered.c.geom)).label("y_centroid_4326"),
+            func.st_asgeojson(cte_synthese_filtered.c.geom).label(geojson_4326_field),
+            func.st_asgeojson(func.st_transform(cte_synthese_filtered.c.geom, local_srid)).label(
+                geojson_local_field
+            ),
+        ]
+
+        # Finally provide all the columns to be selected in the export query
+        selectable_columns = columns_with_geom_excluded + blurred_geom_columns
+
+    # Get the query for export
+    export_query = (
+        select(*selectable_columns)
+        .select_from(
+            export_view.view.tableDef.join(
+                cte_synthese_filtered,
+                cte_synthese_filtered.c.id_synthese
+                == export_view.view.tableDef.columns["id_synthese"],
+            )
+        )
+        .where(export_view.view.tableDef.columns["id_synthese"].in_(id_list))
+        .distinct(export_view.view.tableDef.columns["id_synthese"])
+    )
+
+    # Créate schema
+    ExportObservationViewSchema = export_view.get_marshmallow_schema()
+
+    columns_to_serialize = []
+
+    # loop over synthese config to exclude columns if its default export
+    for db_col in export_view.view.db_cols:
+        if view_name_param == "gn_synthese.v_synthese_for_export":
+            if db_col.key in current_app.config["SYNTHESE"]["EXPORT_COLUMNS"]:
+                columns_to_serialize.append(db_col.key)
+        else:
+            # remove geojson and geometry fields of serialization
+            if (
+                db_col.key not in [geojson_4326_field, geojson_local_field, "geometry"]
+                and not type(db_col.type) is Geometry
+            ):
+                columns_to_serialize.append(db_col.key)
+
+    return (
+        ExportObservationViewSchema,
+        export_query,
+        columns_to_serialize,
+        geojson_local_field,
+        local_srid,
+    )
+
+
+def export_metadata(permissions, current_user, params):
+    metadata_view = GenericQueryGeo(
+        DB=DB, tableName="v_metadata_for_export", schemaName="gn_synthese"
+    )
+    columns = metadata_view.view.tableDef.columns
+    id_dataset_col = current_app.config["SYNTHESE"]["EXPORT_METADATA_ID_DATASET_COL"]
+    try:
+        assert hasattr(metadata_view.view.tableDef.columns, id_dataset_col)
+    except AssertionError as e:
+        raise Exception("View v_metadata_for_export must have a jdd_id column")
+
+    q = select(distinct(VSyntheseForWebApp.id_dataset), metadata_view.view.tableDef)
+
+    synthese_query_class = SyntheseQuery(
+        VSyntheseForWebApp,
+        q,
+        params,
+    )
+    synthese_query_class.add_join(
+        metadata_view.view.tableDef,
+        getattr(
+            metadata_view.view.tableDef.columns,
+            id_dataset_col,
+        ),
+        VSyntheseForWebApp.id_dataset,
+    )
+
+    synthese_query_class.filter_query_all_filters(current_user, permissions)
+
+    query = synthese_query_class.build_query()
+    return metadata_view.get_marshmallow_schema(), query, []
+
+
+def export_status(permissions, current_user, params):
+    filters = params
+    query = select(
+        VSyntheseForWebApp.cd_ref,
+        VSyntheseForWebApp.nom_valide,
+        VSyntheseForWebApp.nom_vern,
+        VBdcStatus.rq_statut,
+        VBdcStatus.regroupement_type,
+        VBdcStatus.lb_type_statut,
+        VBdcStatus.cd_sig,
+        VBdcStatus.full_citation,
+        VBdcStatus.doc_url,
+        VBdcStatus.code_statut,
+        VBdcStatus.label_statut,
+    ).distinct()
+
+    synthese_query_class = SyntheseQuery(
+        VSyntheseForWebApp,
+        query,
+        filters,
+    )
+    synthese_query_class.add_join(
+        VBdcStatus,
+        VBdcStatus.cd_ref,
+        VSyntheseForWebApp.cd_ref,
+    )
+
+    synthese_query_class.filter_query_all_filters(current_user, permissions)
+    query = synthese_query_class.build_query()
+
+    return ExportStatusSchema, query, []
+
+
+def export_data_file(
+    file_name: str,
+    format: str,
+    query: Query,
+    schema_class: Schema,
+    pk_name: Optional[str] = None,
+    geometry_field: Optional[str] = None,
+    srid: Optional[int] = None,
+    columns: Optional[List[str]] = [],
+):
+    """
+    Fonction qui permet de générer un export fichier
+
+    .. :quickref:  Fonction qui permet de générer un export fichier
+
+    :query int id_export: Identifiant de l'export
+    :query str export_format: Format de l'export (csv, json, gpkg)
+    :query {} filters: Filtre à appliquer sur l'export
+    :query
+
+    **Returns:**
+    .. str : nom du fichier
+    """
+    logger.info(f"Generate export {geometry_field} {file_name}...")
+    try:
+        export_as_file(
+            file_format=format,
+            filename=file_name,
+            query=query,
+            schema_class=schema_class,
+            pk_name=pk_name,
+            geometry_field=geometry_field,
+            srid=srid,
+            columns=columns,
+        )
+    except Exception as exp:
+        notify_export_file_generated()
+        raise exp
+    notify_export_file_generated()
+
+
+def notify_export_file_generated():
+    pass
+
+
+def export_as_file(
+    file_format: str,
+    filename: str,
+    query,
+    schema_class,
+    pk_name: Optional[str] = None,
+    geometry_field: Optional[str] = None,
+    srid: Optional[int] = None,
+    columns: Optional[List[str]] = [],
+):
+    # format_list = [k for k in current_app.config["EXPORTS"]["export_format_map"].keys()]
+
+    # if file_format not in format_list:
+    #     raise GeoNatureError("Unsupported format")
+
+    if file_format == "gpkg" and srid is None:
+        srid = get_local_srid(db.session)
+
+    # Generate directory
+    os.makedirs(Path(filename).parent, exist_ok=True)
+    if file_format == "gpkg":
+        export_geopackage(
+            query=query,
+            schema_class=schema_class,
+            filename=filename,
+            geometry_field_name=geometry_field,
+            columns=columns,
+            srid=srid,
+        )
+        return
+
+    func_dict = {
+        "geojson": export_geojson,
+        "json": export_json,
+        "csv": export_csv,
+    }
+
+    with open(filename, "w") as f:
+        func_dict[file_format](
+            query=query,
+            schema_class=schema_class,
+            fp=f,
+            columns=columns,
+            geometry_field_name=geometry_field,
+        )

--- a/backend/geonature/migrations/versions/67b70584ade0_add_tasks_table.py
+++ b/backend/geonature/migrations/versions/67b70584ade0_add_tasks_table.py
@@ -1,0 +1,42 @@
+"""add tasks table
+
+Revision ID: 67b70584ade0
+Revises: 707390c722fe
+Create Date: 2025-06-03 09:44:22.628841
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+# revision identifiers, used by Alembic.
+revision = "67b70584ade0"
+down_revision = "707390c722fe"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "t_tasks",
+        sa.Column("id_task", sa.Integer, primary_key=True),
+        sa.Column("uuid_celery", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "id_role", sa.Integer, sa.ForeignKey("utilisateurs.t_roles.id_role"), nullable=False
+        ),
+        sa.Column(
+            "id_module", sa.Integer, sa.ForeignKey("gn_commons.t_modules.id_module"), nullable=False
+        ),
+        sa.Column("start", sa.DateTime, nullable=False),
+        sa.Column("end", sa.DateTime),
+        sa.Column("status", sa.Unicode(50)),
+        sa.Column("message", sa.Text),
+        sa.Column("file_name", sa.Unicode(500)),
+        schema="gn_commons",
+    )
+
+
+def downgrade():
+    op.drop_table("t_tasks", schema="gn_commons")

--- a/backend/geonature/utils/config.py
+++ b/backend/geonature/utils/config.py
@@ -47,3 +47,5 @@ if "APPLICATION_ROOT" not in config:
     config["APPLICATION_ROOT"] = api_uri.path or "/"
 if "PREFERRED_URL_SCHEME" not in config:
     config["PREFERRED_URL_SCHEME"] = api_uri.scheme
+
+config["SERVER_NAME"] = api_uri.netloc

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -399,7 +399,7 @@ class Synthese(Schema):
     EXPORT_METADATA_ID_DATASET_COL = fields.String(load_default="jdd_id")
     EXPORT_METADATA_ACTOR_COL = fields.String(load_default="acteurs")
     # Formats d'export disponibles ["csv", "geojson", "shapefile", "gpkg"]
-    EXPORT_FORMAT = fields.List(fields.String(), load_default=["csv", "geojson", "shapefile"])
+    EXPORT_FORMAT = fields.List(fields.String(), load_default=["csv", "geojson", "gpkg"])
     # Nombre max d'observation dans les exports
     NB_MAX_OBS_EXPORT = fields.Integer(load_default=50000)
 

--- a/frontend/src/app/syntheseModule/services/store.service.ts
+++ b/frontend/src/app/syntheseModule/services/store.service.ts
@@ -1,4 +1,24 @@
 import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, interval, of } from 'rxjs';
+import { map, switchMap, takeWhile } from 'rxjs/operators';
+import { HttpClient } from '@angular/common/http';
+import { ConfigService } from '@geonature/services/config.service';
+import { DataFormService } from '@geonature_common/form/data-form.service';
+
+export interface SyntheseTask {
+  uuid: string;
+  status: 'PENDING' | 'PROGRESS' | 'SUCCESS' | 'FAILURE' | 'pending' | 'progress' | 'success' | 'failure';
+  progress: number;
+  result: any;
+  message?: {
+    taskType?: 'observations' | 'taxons' | 'statuts' | 'metadata' | string;
+    format?: string;
+    view_name?: string;
+    filename?: string;
+    [key: string]: any;
+  };
+  downloadUrl?: string;
+}
 
 @Injectable({
   providedIn: 'root',
@@ -7,5 +27,278 @@ export class SyntheseStoreService {
   public idSyntheseList: Array<number>;
   public gridData: Array<any>;
   public pointData: Array<any>;
-  constructor() {}
+  public moduleId: string; // ID du module Synthèse
+  
+  // Gestion des tâches asynchrones
+  private tasks = new BehaviorSubject<SyntheseTask[]>([]);
+  // Stockage des métadonnées de tâches pour conserver les informations entre les actualisations
+  private taskMetadata: Map<string, any> = new Map();
+  
+  /**
+   * Sauvegarde explicitement les métadonnées d'une tâche pour les préserver entre les actualisations
+   * @param taskUuid L'UUID de la tâche
+   * @param metadata Les métadonnées à sauvegarder
+   */
+  public saveTaskMetadata(taskUuid: string, metadata: any): void {
+    if (taskUuid && metadata) {
+      console.log(`Sauvegarde des métadonnées pour la tâche ${taskUuid}:`, metadata);
+      this.taskMetadata.set(taskUuid, { ...metadata });
+    }
+  }
+
+  constructor(
+    private http: HttpClient,
+    private config: ConfigService,
+    private dataFormService: DataFormService
+  ) {}
+  
+  /**
+   * Retourne un observable avec toutes les tâches
+   */
+  get tasks$(): Observable<SyntheseTask[]> {
+    return this.tasks.asObservable();
+  }
+  
+  /**
+   * Retourne un observable avec les tâches actives uniquement
+   */
+  get activeTasks$(): Observable<SyntheseTask[]> {
+    return this.tasks$.pipe(
+      map(tasks => tasks.filter(task => 
+        task.status === 'PENDING' || task.status === 'PROGRESS'
+      ))
+    );
+  }
+  
+  /**
+   * Retourne un observable avec le nombre de tâches actives
+   */
+  get activeTasksCount$(): Observable<number> {
+    return this.activeTasks$.pipe(
+      map(tasks => tasks.length)
+    );
+  }
+  
+  /**
+   * Ajoute une tâche à la liste et commence à la suivre
+   * @param task La tâche à ajouter
+   */
+  addTask(task: SyntheseTask): void {
+    const currentTasks = this.tasks.value;
+    if (!currentTasks.find(t => t.uuid === task.uuid)) {
+      // Stocker les métadonnées de la tâche pour les conserver entre les actualisations
+      if (task.message) {
+        this.taskMetadata.set(task.uuid, { ...task.message });
+      }
+      this.tasks.next([...currentTasks, task]);
+    }
+  }
+  
+  /**
+   * Met à jour une tâche existante
+   * @param updatedTask La tâche mise à jour
+   */
+  updateTask(updatedTask: SyntheseTask): void {
+    const taskList = this.tasks.value;
+    const index = taskList.findIndex(t => t.uuid === updatedTask.uuid);
+    
+    if (index !== -1) {
+      taskList[index] = updatedTask;
+      this.tasks.next([...taskList]);
+    }
+  }
+  
+  /**
+   * Supprime une tâche de la liste
+   * @param taskUuid L'identifiant unique de la tâche à supprimer
+   */
+  removeTask(taskUuid: string): void {
+    const currentTasks = this.tasks.value;
+    // Supprimer également les métadonnées stockées pour cette tâche
+    this.taskMetadata.delete(taskUuid);
+    this.tasks.next(currentTasks.filter(task => task.uuid !== taskUuid));
+  }
+  
+  /**
+   * Récupère le statut d'une tâche et met à jour le store
+   * @param taskUuid L'identifiant unique de la tâche
+   */
+  refreshTaskStatus(taskUuid: string): Observable<SyntheseTask> {
+    return this.dataFormService.getTask(taskUuid).pipe(
+      map(response => {
+        return this.processTaskResponse(response, taskUuid);
+      })
+    );
+  }
+  
+  /**
+   * Rafraîchit le statut de toutes les tâches actives en une seule requête
+   * @returns Observable contenant un tableau des tâches mises à jour
+   */
+  refreshActiveTasks(): Observable<SyntheseTask[]> {
+    // Récupérer les UUIDs des tâches actives
+    const activeTasks = this.tasks.value.filter(task => 
+      task.status === 'PENDING' || task.status === 'PROGRESS'
+    );
+    
+    // Si aucune tâche active, retourner un observable vide
+    if (activeTasks.length === 0) {
+      return of([]);
+    }
+    
+    // Extraire les UUIDs
+    const activeTaskUuids = activeTasks.map(task => task.uuid);
+    
+    // Récupérer les statuts de toutes les tâches actives en une seule requête
+    return this.dataFormService.getTasksByUuids(activeTaskUuids).pipe(
+      map(responses => {
+        const updatedTasks: SyntheseTask[] = [];
+        
+        // Pour chaque tâche dans la réponse
+        responses.forEach(response => {
+          // Utiliser l'UUID de la réponse, ou l'UUID stocké dans la réponse
+          const taskUuid = response.uuid || (response.uuid_celery ? response.uuid_celery : null);
+          if (taskUuid) {
+            const updatedTask = this.processTaskResponse(response, taskUuid);
+            updatedTasks.push(updatedTask);
+          } else {
+            console.error("Impossible de déterminer l'UUID de la tâche", response);
+          }
+        });
+        
+        return updatedTasks;
+      })
+    );
+  }
+  
+  /**
+   * Traite la réponse d'une tâche et la met à jour dans le store
+   * @param response La réponse de l'API pour une tâche
+   * @param taskUuid L'UUID de la tâche (utilisé si la réponse est null)
+   * @returns La tâche mise à jour
+   */
+  private processTaskResponse(response: any, taskUuid: string): SyntheseTask {
+    if (!response) {
+      return {
+        uuid: taskUuid,
+        status: 'FAILURE',
+        progress: 0,
+        result: { error: "Tâche non trouvée" },
+        downloadUrl: null
+      };
+    }
+    
+    // Utiliser le service DataFormService pour analyser le message JSON
+    const messageObj = this.dataFormService.parseJsonMessage(response.message);
+
+    // Normaliser le statut (convertir tout en majuscules pour correspondre à notre enum)
+    const normalizedStatus = response.status ? response.status.toUpperCase() : 'FAILURE';
+    
+    // Récupérer les métadonnées stockées pour cette tâche (pour conserver le type d'export)
+    const storedMetadata = this.taskMetadata.get(taskUuid);
+    
+    if (storedMetadata) {
+      console.log(`Restauration des métadonnées pour la tâche ${taskUuid}:`, storedMetadata);
+    }
+    
+    // Construire un objet SyntheseTask à partir de la réponse
+    const updatedTask: SyntheseTask = {
+      uuid: response.uuid_celery || response.uuid,
+      status: normalizedStatus,
+      progress: response.progress || 0,
+      result: messageObj || response.message,
+      downloadUrl: null,
+      // Utiliser prioritairement les métadonnées stockées
+      message: storedMetadata || (messageObj ? { ...messageObj } : undefined)
+    };
+    
+    // Si la tâche est terminée et contient un lien vers un fichier, utiliser ce lien
+    if (normalizedStatus === 'SUCCESS') {
+      if (messageObj && messageObj.file_path) {
+        // Utiliser le service DataFormService pour construire l'URL de téléchargement
+        updatedTask.downloadUrl = this.dataFormService.getFileDownloadUrl(messageObj.file_path);
+      } else if (messageObj && messageObj.url) {
+        updatedTask.downloadUrl = messageObj.url;
+      } else if (response.url) {
+        // Utiliser directement l'URL de la réponse si disponible
+        updatedTask.downloadUrl = response.url;
+      }
+    }
+    
+    // Mettre à jour la tâche dans le store
+    this.updateTask(updatedTask);
+    return updatedTask;
+  }
+  
+  /**
+   * Met en place un polling pour surveiller l'état d'une tâche jusqu'à ce qu'elle soit terminée
+   * @param taskUuid L'identifiant unique de la tâche à surveiller
+   * @param pollInterval Intervalle de temps entre chaque vérification (en ms)
+   */
+  pollTaskStatus(taskUuid: string, pollInterval: number = 3000): Observable<SyntheseTask> {
+    return interval(pollInterval).pipe(
+      switchMap(() => this.refreshTaskStatus(taskUuid)),
+      takeWhile(task => 
+        task.status === 'PENDING' || task.status === 'PROGRESS', 
+        true // Inclut la dernière valeur qui a fait échouer le prédicat
+      )
+    );
+  }
+  
+  /**
+   * Configure un rafraîchissement automatique des tâches actives
+   * @param pollInterval Intervalle de temps entre chaque vérification (en ms)
+   * @returns Un Observable qui émet la liste des tâches actives mises à jour
+   */
+  startAutoRefresh(pollInterval: number = 5000): Observable<SyntheseTask[]> {
+    return interval(pollInterval).pipe(
+      switchMap(() => {
+        const activeTasks = this.tasks.value.filter(task => 
+          task.status === 'PENDING' || task.status === 'PROGRESS'
+        );
+        
+        // Si aucune tâche active, émettre un tableau vide
+        if (activeTasks.length === 0) {
+          return of([]);
+        }
+        
+        // Sinon, rafraîchir les tâches actives
+        return this.refreshActiveTasks();
+      })
+    );
+  }
+  
+  /**
+   * Télécharge le résultat d'une tâche terminée avec succès
+   * @param taskUuid L'identifiant unique de la tâche
+   */
+  downloadTaskResult(taskUuid: string): Observable<any> {
+    // Récupérer la tâche dans le store local si elle existe
+    const task = this.tasks.value.find(t => t.uuid === taskUuid);
+    
+    if (task && task.status?.toUpperCase() === 'SUCCESS' && task.downloadUrl) {
+      // La tâche est déjà dans le store et prête pour le téléchargement
+      this.dataFormService.triggerFileDownload(task.downloadUrl);
+      return of({ success: true, url: task.downloadUrl });
+    } else {
+      // Sinon, rafraîchir le statut et télécharger si prêt
+      return this.refreshTaskStatus(taskUuid).pipe(
+        map(updatedTask => {
+          const isSuccess = updatedTask.status?.toUpperCase() === 'SUCCESS';
+          if (!isSuccess) {
+            throw new Error("La tâche n'est pas terminée avec succès");
+          }
+          
+          if (!updatedTask.downloadUrl) {
+            throw new Error("Aucun lien de téléchargement trouvé pour cette tâche");
+          }
+          
+          // Déclencher le téléchargement via le service DataFormService
+          this.dataFormService.triggerFileDownload(updatedTask.downloadUrl);
+          
+          return { success: true, url: updatedTask.downloadUrl };
+        })
+      );
+    }
+  }
 }

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/modal-download/modal-download.component.html
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/modal-download/modal-download.component.html
@@ -16,16 +16,16 @@
 
   <button
     type="button"
-    class="close"
+    class="btn-close"
     aria-label="Close"
     (click)="activeModal.dismiss('Cross click')"
     data-qa="synthese-download-close-btn"
   >
-    <span aria-hidden="true">&times;</span>
   </button>
 </div>
 
 <div class="modal-body">
+  <!-- Section des options de téléchargement -->
   <div *ngIf="tooManyObs">
     <div
       class="alert alert-danger"
@@ -57,11 +57,10 @@
   </div>
 
   <div *ngIf="!tooManyObs || syntheseConfig.NB_MAX_OBS_EXPORT > syntheseConfig.NB_MAX_OBS_MAP">
-    <div class="my-3 pt-2">
+    <div class="download-section my-3 pt-2">
       <h5 class="second-color">Télécharger les observations</h5>
       <button
         [disabled]="_dataService.isDownloading"
-        style="margin-left: 5px"
         *ngFor="let format of syntheseConfig.EXPORT_FORMAT"
         mat-raised-button
         (click)="downloadObservations(format, 'gn_synthese.v_synthese_for_export')"
@@ -74,12 +73,11 @@
     </div>
     <div
       *ngFor="let export of syntheseConfig.EXPORT_OBSERVATIONS_CUSTOM_VIEWS"
-      class="my-3 pt-2"
+      class="download-section my-3 pt-2"
     >
       <h5 class="second-color">Télécharger les observations - {{ export.label }}</h5>
       <button
         [disabled]="_dataService.isDownloading"
-        style="margin-left: 5px"
         *ngFor="let format of syntheseConfig.EXPORT_FORMAT"
         mat-raised-button
         (click)="downloadObservations(format, export.view_name)"
@@ -90,7 +88,7 @@
       </button>
     </div>
 
-    <div class="my-3 pt-2">
+    <div class="download-section my-3 pt-2">
       <h5 class="second-color">Télécharger les taxons</h5>
       <button
         [disabled]="_dataService.isDownloading"
@@ -103,7 +101,7 @@
       </button>
     </div>
 
-    <div class="my-3 pt-2">
+    <div class="download-section my-3 pt-2">
       <h5 class="second-color">Télécharger les statuts</h5>
       <button
         [disabled]="_dataService.isDownloading"
@@ -116,7 +114,7 @@
       </button>
     </div>
 
-    <div class="my-3 pt-2">
+    <div class="download-section my-3 pt-2">
       <h5 class="my-2 second-color">Télécharger les métadonnées</h5>
       <button
         [disabled]="_dataService.isDownloading"
@@ -132,17 +130,103 @@
 
   <div
     *ngIf="_dataService.isDownloading"
-    class="telechargement card"
-    style="margin-top: 30px"
+    class="download-progress mat-elevation-z1 p-3 my-3"
   >
-    <div class="card-body text-{{ bstype }}">
-      {{ 'Downloading' | translate }}
-      <img
-        src="assets/images/Spinner.gif"
-        alt="Chargement..."
-        height="40"
-        width="40"
-      />
+    <div class="d-flex align-items-center">
+      <span class="me-2">{{ 'Downloading' | translate }}</span>
+      <mat-spinner diameter="24" color="primary"></mat-spinner>
     </div>
   </div>
+
+  <!-- Section des tâches d'export en cours -->
+  <div class="tasks-section mt-4 pt-2 border-top">
+    <h5 class="second-color mb-3">Tâches d'export en cours</h5>
+    
+    <div *ngIf="(tasks$ | async)?.length === 0" class="text-center p-3">
+      <p class="text-muted">Aucune tâche d'export en cours.</p>
+    </div>
+
+    <div *ngIf="(tasks$ | async)?.length > 0" class="task-list mat-elevation-z0">
+      <mat-list class="tasks-list">
+        <div *ngFor="let task of tasks$ | async">
+          <!-- Title of the task type -->
+          <mat-list-item class="task-item">
+            <div matListItemTitle class="d-flex justify-content-between w-100">
+              <h3 class="task-title mb-0">{{ getTaskDescription(task) }}</h3>
+              
+              <div>
+                <button mat-icon-button color="warn" (click)="removeTask(task)" 
+                  matTooltip="Supprimer">
+                  <mat-icon>delete</mat-icon>
+                </button>
+              </div>
+            </div>
+          </mat-list-item>
+          
+          <!-- Status section with spinner -->
+          <div class="mx-4 mb-2 d-flex align-items-center">
+            <span [class]="getStatusClass(task.status)" class="status-label">
+              {{ getStatusLabel(task.status) }}
+            </span>
+            
+            <mat-spinner *ngIf="task.status?.toUpperCase() === 'PROGRESS' || task.status?.toUpperCase() === 'PENDING'" 
+              diameter="16" class="ms-2"></mat-spinner>
+          </div>
+
+          <!-- Progress section -->
+          <div *ngIf="task.status?.toUpperCase() === 'PROGRESS'" class="mx-4 my-2">
+            <mat-progress-bar 
+              mode="determinate" 
+              [value]="task.progress || 0"
+              color="primary">
+            </mat-progress-bar>
+            <div class="text-center mt-1 small">{{ task.progress || 0 }}%</div>
+          </div>
+          
+          <!-- Success section -->
+          <div *ngIf="task.status?.toUpperCase() === 'SUCCESS'" class="mx-4 my-2">
+            <div *ngIf="task.downloadUrl" class="d-grid">
+              <button mat-raised-button class="button-success" (click)="downloadTaskResult(task)">
+                <mat-icon>download</mat-icon> Télécharger
+              </button>
+            </div>
+            
+            <div *ngIf="!task.downloadUrl" class="alert-message py-2 px-3 mt-2 bg-light border rounded">
+              <div class="d-flex align-items-center">
+                <span>
+                  Le téléchargement direct n'est pas disponible pour cette tâche.
+                  <br>
+                  <small>Cherchez le fichier dans le dossier des exports de votre serveur.</small>
+                </span>
+              </div>
+            </div>
+            
+            <div *ngIf="task.result && task.result.file_path" class="mt-2 small text-muted ms-2">
+              <strong>Chemin du fichier:</strong> {{task.result.file_path}}
+            </div>
+          </div>
+          
+          <!-- Failure section -->
+          <div *ngIf="task.status?.toUpperCase() === 'FAILURE'" class="mx-4 my-2">
+            <div class="error-message alert-message py-2 px-3 bg-light border rounded">
+              <div class="d-flex align-items-center">
+                <span>
+                  <strong>Erreur:</strong> 
+                  {{ task.result?.error || 'Une erreur est survenue pendant l\'export.' }}
+                </span>
+              </div>
+            </div>
+          </div>
+          
+          <mat-divider></mat-divider>
+        </div>
+      </mat-list>
+    </div>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <button type="button" class="btn btn-secondary" (click)="activeModal.close()">
+    Fermer
+  </button>
 </div>

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/modal-download/modal-download.component.scss
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/modal-download/modal-download.component.scss
@@ -1,0 +1,115 @@
+// Styles pour le modal de téléchargement
+.tasks-section {
+  margin-top: 24px;
+}
+
+.task-item {
+  margin-bottom: 0;
+}
+
+.task-title {
+  font-size: 16px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.status-label {
+  font-weight: 500;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+// Classes de statut - utilisent les couleurs standards de GeoNature
+.status-pending {
+  color: #ffb53e; // Orange - GeoNature color-orange
+}
+
+.status-progress {
+  color: #30a5ff; // Bleu - GeoNature color-blue
+}
+
+.status-success {
+  color: #389938; // Vert - GeoNature button-success
+}
+
+.status-failure {
+  color: #f9243f; // Rouge - GeoNature color-red
+}
+
+.alert-message {
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.download-section {
+  button {
+    margin-right: 8px;
+    margin-bottom: 8px;
+  }
+}
+
+// Overrides pour les composants Material
+:host ::ng-deep {
+  .mat-mdc-list-item {
+    height: auto !important;
+  }
+
+  .mat-mdc-list-item-title {
+    display: flex !important;
+    justify-content: space-between !important;
+    align-items: center !important;
+  }
+  
+  // Style pour la section de téléchargement
+  .download-section {
+    margin-top: 15px;
+    
+    .mat-mdc-button-base {
+      margin-right: 8px;
+      margin-bottom: 8px;
+    }
+  }
+  
+  // Style pour la liste des tâches
+  .task-list {
+    margin-top: 20px;
+    
+    .mat-divider {
+      margin: 12px 0;
+    }
+  }
+  
+  // Animations spinner
+  .mat-spinner {
+    display: inline-block;
+    margin-left: 8px;
+  }
+  
+  .download-progress {
+    background-color: rgba(0, 0, 0, 0.03);
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    
+    .mat-spinner {
+      margin-left: 12px;
+    }
+  }
+  
+  // Messages d'erreur
+  .error-message {
+    color: var(--error-color, #f9243f); // GeoNature color-red
+    padding: 8px;
+    border-radius: 4px;
+  }
+  
+  // Message de succès
+  .success-message {
+    color: var(--success-color, #389938); // GeoNature button-success
+  }
+  
+  // Barre de progression
+  .mat-progress-bar {
+    margin: 8px 0;
+  }
+}

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/modal-download/modal-download.component.ts
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/modal-download/modal-download.component.ts
@@ -1,16 +1,25 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { SyntheseDataService } from '@geonature_common/form/synthese-form/synthese-data.service';
-import { SyntheseStoreService } from '../../../services/store.service';
+import { SyntheseStoreService, SyntheseTask } from '../../../services/store.service';
 import { SyntheseFormService } from '@geonature_common/form/synthese-form/synthese-form.service';
 import { ConfigService } from '@geonature/services/config.service';
+import { HttpClient } from '@angular/common/http';
+import { DataFormService } from '@geonature_common/form/data-form.service';
+import { Observable, Subscription } from 'rxjs';
+import { ThemePalette } from '@angular/material/core';
 
 @Component({
   selector: 'pnx-synthese-modal-download',
   templateUrl: 'modal-download.component.html',
+  styleUrls: ['modal-download.component.scss']
 })
-export class SyntheseModalDownloadComponent {
+export class SyntheseModalDownloadComponent implements OnInit, OnDestroy {
   public syntheseConfig = null;
+  public moduleCode = 'SYNTHESE'; // Module de synthèse
+  public tasks$: Observable<SyntheseTask[]>;
+  public bstype: string = 'info';
+  private autoRefreshSubscription: Subscription;
 
   @Input() tooManyObs = false;
 
@@ -19,26 +28,246 @@ export class SyntheseModalDownloadComponent {
     public _dataService: SyntheseDataService,
     private _fs: SyntheseFormService,
     private _storeService: SyntheseStoreService,
-    public config: ConfigService
+    public config: ConfigService,
+    private http: HttpClient,
+    private _dataFormService: DataFormService
   ) {
     this.syntheseConfig = this.config.SYNTHESE;
+    
+    // Récupérer l'ID du module Synthèse
+    this._dataFormService.getModuleByCodeName(this.moduleCode).subscribe(module => {
+      if (module && module.id_module) {
+        this._storeService.moduleId = module.id_module.toString();
+      }
+    });
+  }
+
+  ngOnInit() {
+    // Récupérer la liste des tâches
+    this.tasks$ = this._storeService.tasks$;
+    
+    // Rafraîchir immédiatement les tâches actives
+    this._storeService.refreshActiveTasks().subscribe();
+    
+    // Démarrer le rafraîchissement automatique des tâches actives toutes les 5 secondes
+    this.autoRefreshSubscription = this._storeService.startAutoRefresh(5000).subscribe();
+  }
+  
+  ngOnDestroy() {
+    // Annuler le rafraîchissement automatique lorsque le composant est détruit
+    if (this.autoRefreshSubscription) {
+      this.autoRefreshSubscription.unsubscribe();
+    }
   }
 
   downloadObservations(format, view_name) {
-    this._dataService.downloadObservations(this._storeService.idSyntheseList, format, view_name);
+    const params = this._fs.formatParams();
+    this.http.post<any>(`${this.config.API_ENDPOINT}/synthese/export_observations`, {
+      ids: this._storeService.idSyntheseList,
+      format: format,
+      view_name: view_name,
+      params: params
+    }).subscribe(taskResponse => {
+      // Définir explicitement les métadonnées de la tâche
+      const taskInfo = {
+        taskType: 'observations',
+        format: format,
+        view_name: view_name 
+      };
+      
+      // Ajouter la tâche au store du module synthèse
+      this._storeService.addTask({
+        uuid: taskResponse.uuid_task,
+        status: 'PENDING',
+        progress: 0,
+        result: null,
+        downloadUrl: null,
+        message: taskInfo
+      });
+      
+      // Forcer l'enregistrement des métadonnées
+      this._storeService.saveTaskMetadata(taskResponse.uuid_task, taskInfo);
+    });
   }
 
   downloadTaxons(format, filename) {
-    this._dataService.downloadTaxons(this._storeService.idSyntheseList, format, filename);
+    const params = this._fs.formatParams();
+    this.http.post<any>(`${this.config.API_ENDPOINT}/synthese/export_taxons`, {
+      ids: this._storeService.idSyntheseList,
+      format: format,
+      params: params
+    }).subscribe(taskResponse => {
+      // Définir explicitement les métadonnées de la tâche
+      const taskInfo = {
+        taskType: 'taxons',
+        format: format,
+        filename: filename
+      };
+      
+      // Ajouter la tâche au store du module synthèse
+      this._storeService.addTask({
+        uuid: taskResponse.uuid_task,
+        status: 'PENDING',
+        progress: 0,
+        result: null,
+        downloadUrl: null,
+        message: taskInfo
+      });
+      
+      // Forcer l'enregistrement des métadonnées
+      this._storeService.saveTaskMetadata(taskResponse.uuid_task, taskInfo);
+    });
   }
 
   downloadStatusOrMetadata(url, filename) {
     const params = this._fs.formatParams();
-    this._dataService.downloadStatusOrMetadata(
-      `${this.config.API_ENDPOINT}/${url}`,
-      'csv',
-      params,
-      filename
-    );
+    // Ne pas changer le nom de l'endpoint car le backend utilise déjà export_
+    this.http.post<any>(`${this.config.API_ENDPOINT}/${url}`, params).subscribe(taskResponse => {
+      // Définir explicitement les métadonnées de la tâche
+      const taskInfo = {
+        taskType: url.includes('statuts') ? 'statuts' : 'metadata',
+        filename: filename
+      };
+      
+      // Ajouter la tâche au store du module synthèse
+      this._storeService.addTask({
+        uuid: taskResponse.uuid_task,
+        status: 'PENDING',
+        progress: 0,
+        result: null,
+        downloadUrl: null,
+        message: taskInfo
+      });
+      
+      // Forcer l'enregistrement des métadonnées
+      this._storeService.saveTaskMetadata(taskResponse.uuid_task, taskInfo);
+    });
+  }
+
+  /**
+   * Télécharger le résultat d'une tâche
+   */
+  downloadTaskResult(task: SyntheseTask) {
+    const isSuccess = task.status?.toUpperCase() === 'SUCCESS';
+    if (isSuccess) {
+      if (task.downloadUrl) {
+        // Si un lien de téléchargement direct est disponible, l'utiliser
+        this._storeService.downloadTaskResult(task.uuid).subscribe(
+          result => {
+            console.log('Téléchargement démarré:', result);
+          },
+          error => {
+            console.error('Erreur lors du téléchargement:', error);
+            // Afficher un message d'erreur à l'utilisateur
+            alert("Erreur lors du téléchargement: " + error.message);
+          }
+        );
+      } else if (task.result) {
+        // Si la tâche a un résultat mais pas de lien de téléchargement,
+        // afficher un message d'information
+        alert("Le résultat de cette tâche ne peut pas être téléchargé directement.");
+      } else {
+        alert("Aucun résultat disponible pour cette tâche.");
+      }
+    }
+  }
+
+  /**
+   * Rafraîchir manuellement le statut de toutes les tâches actives
+   * (cette méthode est principalement pour avoir un bouton de rafraîchissement manuel en plus du rafraîchissement automatique)
+   */
+  refreshTaskStatus(task: SyntheseTask) {
+    this._storeService.refreshActiveTasks().subscribe();
+  }
+
+  /**
+   * Supprimer une tâche de la liste
+   */
+  removeTask(task: SyntheseTask) {
+    this._storeService.removeTask(task.uuid);
+  }
+
+  /**
+   * Formater le statut d'une tâche pour l'affichage
+   */
+  getStatusLabel(status: string): string {
+    const statusUpper = status ? status.toUpperCase() : '';
+    switch (statusUpper) {
+      case 'PENDING':
+        return 'En attente';
+      case 'PROGRESS':
+        return 'En cours';
+      case 'SUCCESS':
+        return 'Terminée';
+      case 'FAILURE':
+        return 'Échouée';
+      default:
+        return status;
+    }
+  }
+
+  /**
+   * Déterminer la classe CSS à appliquer en fonction du statut
+   */
+  getStatusClass(status: string): string {
+    const statusUpper = status ? status.toUpperCase() : '';
+    switch (statusUpper) {
+      case 'PENDING':
+        return 'status-pending';
+      case 'PROGRESS':
+        return 'status-progress';
+      case 'SUCCESS':
+        return 'status-success';
+      case 'FAILURE':
+        return 'status-failure';
+      default:
+        return '';
+    }
+  }
+  
+  /**
+   * Ces méthodes ont été supprimées car nous n'utilisons plus d'icônes d'état
+   */
+  
+  /**
+   * Récupérer une description de la tâche en fonction du type d'export
+   */
+  getTaskDescription(task: SyntheseTask): string {
+    if (!task || !task.uuid) {
+      return 'Export de données';
+    }
+    
+    // Récupérer les métadonnées du message
+    const message = task.message || {};
+    
+    // Récupérer le type de tâche ou utiliser une valeur par défaut
+    const taskType = message.taskType || '';
+    const format = message.format || 'CSV';
+    
+    console.log(`Génération du titre pour la tâche ${task.uuid}, type: ${taskType}`, message);
+    
+    switch (taskType) {
+      case 'observations':
+        return `Export des observations au format ${format}`;
+      case 'taxons':
+        return `Export des taxons`;
+      case 'statuts':
+        return `Export des statuts de protection`;
+      case 'metadata':
+        return `Export des métadonnées`;
+      default:
+        // En cas d'absence de type de tâche, vérifier s'il y a d'autres indices dans le message
+        if (message.format && message.view_name) {
+          return `Export des observations au format ${message.format}`;
+        } else if (message.filename && message.filename.includes('taxon')) {
+          return `Export des taxons`;
+        } else if (message.filename && message.filename.includes('statut')) {
+          return `Export des statuts de protection`;
+        } else if (message.filename && message.filename.includes('meta')) {
+          return `Export des métadonnées`;
+        }
+        
+        return `Export de données`;
+    }
   }
 }

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.html
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.html
@@ -151,9 +151,14 @@
       color="primary"
       (click)="openDownloadModal()"
       [disabled]="_cruvedStore.cruved?.SYNTHESE?.cruved?.E === 0"
+      [matBadge]="activeTasksCount$ | async"
+      [matBadgeHidden]="(activeTasksCount$ | async) <= 0"
+      matBadgeColor="accent"
+      matBadgePosition="above after"
+      matBadgeOverlap="true"
       data-qa="synthese-download-btn"
     >
-      {{ 'Actions.Download' | translate }}
+      Téléchargement
       <mat-icon>file_download</mat-icon>
     </button>
   </div>

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.scss
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.scss
@@ -43,6 +43,7 @@ ngx-datatable {
   justify-content: end;
 }
 
+
 button[disabled] {
   cursor: not-allowed;
 }

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.ts
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.ts
@@ -24,9 +24,11 @@ import { CruvedStoreService } from '@geonature_common/service/cruved-store.servi
 import { SyntheseInfoObsComponent } from '@geonature/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component';
 import { ConfigService } from '@geonature/services/config.service';
 import { ModuleService } from '@geonature/services/module.service';
+import { SyntheseStoreService } from '@geonature/syntheseModule/services/store.service';
 
 import { FormArray, FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
+import { Observable } from 'rxjs';
 import { fromEvent } from 'rxjs';
 @Component({
   selector: 'pnx-synthese-list',
@@ -51,6 +53,7 @@ export class SyntheseListComponent implements OnInit, OnChanges, AfterContentChe
   @ViewChild('table', { static: true }) table: DatatableComponent;
   private _latestWidth: number;
   public destinationImportCode: string;
+  public activeTasksCount$: Observable<number>;
 
   public userCruved: any;
   public canImport: boolean = false;
@@ -63,11 +66,13 @@ export class SyntheseListComponent implements OnInit, OnChanges, AfterContentChe
     public _cruvedStore: CruvedStoreService,
     public config: ConfigService,
     private _moduleService: ModuleService,
-    private _router: Router
+    private _router: Router,
+    private _syntheseStore: SyntheseStoreService
   ) {
     this.SYNTHESE_CONFIG = this.config.SYNTHESE;
     const currentModule = this._moduleService.currentModule;
     this.destinationImportCode = currentModule.module_code.toLowerCase();
+    this.activeTasksCount$ = this._syntheseStore.activeTasksCount$;
   }
 
   ngOnInit() {
@@ -188,6 +193,9 @@ export class SyntheseListComponent implements OnInit, OnChanges, AfterContentChe
     this.ngbModal.open(modal);
   }
 
+  /**
+   * Ouvre la fenêtre modale de téléchargement et de gestion des tâches asynchrones
+   */
   openDownloadModal() {
     this.ngbModal.open(SyntheseModalDownloadComponent, {
       size: 'lg',


### PR DESCRIPTION
Refonte des exports de la synthèse objectifs : 
-  Export asynchrone via tache celery
-  Création d'un object task qui enregistre les taches celery
-  Modification du frontend
-  Suppression des exports au format shp

cf ticket #3556 
Reste à faire

-    [ ] lint
-    [ ] refaire un tour du front (quelques bout de code à nettoyer et enlever le code mort des anciens exports)
-  [ ] supprimer les tâche quand on clique sur le bouton télécharger
- [ ] en front ne pas filtrer sur les tâches "actives" pour le badge
-    [ ] enlever le filtres par "id_synthese" pour les exports observations et taxons
-    [ ] Voir si le filtre de limite des export est toujours necessaire ? Si oui augmenter ou enlever la valeur par défaut
-    [ ] Faire du ménage dans les tests (beaucoup ont été commenté car il testait le floutage et les données renvoyé. Tout ça est à déporter dans des tests sur la syntheseQuery ou le floutage

