### PR TITLE
Drop redundant indexes on gn_meta and gn_synthese

### DIFF
--- a/backend/geonature/migrations/versions/d07958b2b7e0_drop_duplicate_indexes.py
+++ b/backend/geonature/migrations/versions/d07958b2b7e0_drop_duplicate_indexes.py
@@ -5,6 +5,7 @@ Revises: 707390c722fe
 Create Date: 2025-06-06 10:00:00.000000
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 


### PR DESCRIPTION
Une simple PR qui supprime trois index redondants, car créés sur des colonnes disposant déjà d'une contrainte d'unicité.

En effet, [la doc postgres](https://www.postgresql.org/docs/12/indexes-unique.html) indique que l'index est le mécanisme sous-jacent de la contrainte d'unicité : 

> PostgreSQL automatically creates a unique index when a unique constraint or primary key is defined for a table. The index covers the columns that make up the primary key or unique constraint (a multicolumn index, if appropriate), and is the mechanism that enforces the constraint.

L'index existe donc déjà sous un autre nom, créer un nouvel index sur les mêmes colonnes ajoute un coût supplémentaire (espace disque, calcul lors de l'insertion...) sans rien apporter de plus.

En l'occurrence, le gain est négligeable car les trois indexes supprimés ici sont sur des tables qui sont en général peu peuplées et évoluent peu (cadres d'acquisition, jeux de données, sources de la synthèse). 

TODO : 
- tests ?
- PR équivalente sur RefGeo (i_unique_bib_areas_types_type_code, i_unique_l_areas_id_type_area_code)