### PR TITLE
Fix: remove blurred observations outside filtered municipality

### DIFF
--- a/backend/geonature/core/gn_synthese/utils/blurring.py
+++ b/backend/geonature/core/gn_synthese/utils/blurring.py
@@ -107,7 +107,7 @@ def build_blurred_precise_geom_queries(
             CorAreaSyntheseAlias,
             CorAreaSyntheseAlias.id_synthese == Synthese.id_synthese,
         ),
-        geom_column=LAreas.geom_4326,
+        geom_column=LAreasAlias.geom_4326,
     )
     # Joins here are needed to retrieve the blurred geometry
     blurred_geom_query.add_join(LAreasAlias, LAreasAlias.id_area, CorAreaSyntheseAlias.id_area)


### PR DESCRIPTION
See #3566 and #3571.This fix improves the speed of Synthese query when a geographic area filter has been used.