### PR TITLE
Fix: Optimize validation retrieval query

### DIFF
--- a/contrib/gn_module_validation/backend/gn_module_validation/blueprint.py
+++ b/contrib/gn_module_validation/backend/gn_module_validation/blueprint.py
@@ -190,11 +190,11 @@ def get_synthese_data(permissions):
         if score is not None:
             query = query.where(profile.score == score)
         if valid_distribution is not None:
-            query = query.where(profile.valid_distribution.is_(bool(valid_distribution)))
+            query = query.where(profile.valid_distribution == bool(valid_distribution))
         if valid_altitude is not None:
-            query = query.where(profile.valid_altitude.is_(bool(valid_altitude)))
+            query = query.where(profile.valid_altitude == bool(valid_altitude))
         if valid_phenology is not None:
-            query = query.where(profile.valid_phenology.is_(bool(valid_phenology)))
+            query = query.where(profile.valid_phenology == bool(valid_phenology))
 
     if params.pop("modif_since_validation", None):
         query = query.where(Synthese.meta_update_date > last_validation.validation_date)

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.component.html
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.component.html
@@ -85,8 +85,8 @@
           name="score"
         >
           <option [ngValue]="null">{{ 'Synthese.Form.NoFilter' | translate }}</option>
-          <option [ngValue]="true">{{ 'Synthese.Form.Valid' | translate }}</option>
-          <option [ngValue]="false">{{ 'Synthese.Form.Invalid' | translate }}</option>
+          <option [ngValue]="true">{{ 'Valid' | translate }}</option>
+          <option [ngValue]="false">{{ 'Invalid' | translate }}</option>
         </select>
       </div>
       <small


### PR DESCRIPTION
Since the addition of taxonomic and geographic filter on the validation module, a significant increase of the query was found on large volume of observations (1.7M obs -> 4min). It only occurs when both taxonomic and geographic filters are on !

This PR is a work in progress in order to speed up the query.