### PR TITLE
[2.16-dev] Fix application of new taxonomic/geographic filters on TaxonSheet and Synthese

### DIFF
--- a/backend/geonature/core/gn_permissions/models.py
+++ b/backend/geonature/core/gn_permissions/models.py
@@ -287,13 +287,14 @@ class Permission(db.Model):
 
     def __repr__(self):
         return f"""Permission {self.id_permission} 
-        - Role: {self.role.nom_complet} 
+        - Role: {self.role.nom_complet or self.role.identifiant} 
         - Module: {self.module.module_label} 
         - Action : {self.action.code_action}
         - Scope : {self.scope_value}
         - Taxons Filter : {self.taxons_filter}
         - Areas Filter : {self.areas_filter}
         - Object: {self.object}
+        - Floutage : {"Oui" if self.sensitivity_filter else "Non"}
         - Expire le : {self.expire_on}\n"""
 
     @staticmethod

--- a/backend/geonature/core/gn_permissions/models.py
+++ b/backend/geonature/core/gn_permissions/models.py
@@ -285,6 +285,17 @@ class Permission(db.Model):
         "TAXONOMIC": "taxons_filter",
     }
 
+    def __repr__(self):
+        return f"""Permission {self.id_permission} 
+        - Role: {self.role.nom_complet} 
+        - Module: {self.module.module_label} 
+        - Action : {self.action.code_action}
+        - Scope : {self.scope_value}
+        - TaxonsFilter : {self.taxons_filter}
+        - Areas Filter : {self.areas_filter}
+        - Object: {self.object}
+        - Expire le : {self.expire_on}\n"""
+
     @staticmethod
     def __SCOPE_le__(a, b):
         return b is None or (a is not None and a <= b)

--- a/backend/geonature/core/gn_permissions/models.py
+++ b/backend/geonature/core/gn_permissions/models.py
@@ -291,7 +291,7 @@ class Permission(db.Model):
         - Module: {self.module.module_label} 
         - Action : {self.action.code_action}
         - Scope : {self.scope_value}
-        - TaxonsFilter : {self.taxons_filter}
+        - Taxons Filter : {self.taxons_filter}
         - Areas Filter : {self.areas_filter}
         - Object: {self.object}
         - Expire le : {self.expire_on}\n"""

--- a/backend/geonature/core/gn_synthese/blueprints/synthese.py
+++ b/backend/geonature/core/gn_synthese/blueprints/synthese.py
@@ -145,20 +145,7 @@ def get_observations_for_web(permissions):
 
     # Need to check if there are blurring permissions so that the blurring process
     # does not affect the performance if there is no blurring permissions
-    print("permissions returned by permissions_required")
-    print(permissions)
-    print("permissions returned by _get_user_permissions")
-    permissions = [
-        perm
-        for perm in _get_user_permissions(g.current_user.id_role)
-        if perm.id_permission == 15131
-        and perm.module.module_code == "SYNTHESE"
-        and perm.action.code_action == "R"
-    ]
-    print(permissions)
-    # print(permissions2)
     blurring_permissions, precise_permissions = split_blurring_precise_permissions(permissions)
-
     if not blurring_permissions:
         # No need to apply blurring => same path as before blurring feature
         obs_query = (
@@ -246,6 +233,9 @@ def get_observations_for_web(permissions):
         )
         query = select(obs_query.c.geojson, grouped_properties).group_by(obs_query.c.geojson)
 
+    from utils_flask_sqla.utils import get_query_SQL
+
+    print(get_query_SQL(query))
     results = DB.session.execute(query)
 
     # Build final GeoJson

--- a/backend/geonature/core/gn_synthese/blueprints/synthese.py
+++ b/backend/geonature/core/gn_synthese/blueprints/synthese.py
@@ -7,6 +7,8 @@ from flask import (
     jsonify,
     g,
 )
+from geonature.core.gn_permissions.tools import _get_user_permissions
+
 from werkzeug.exceptions import Forbidden, NotFound, BadRequest
 from sqlalchemy import func, select, case, join, and_
 from sqlalchemy.orm import joinedload, lazyload, selectinload, contains_eager
@@ -143,7 +145,20 @@ def get_observations_for_web(permissions):
 
     # Need to check if there are blurring permissions so that the blurring process
     # does not affect the performance if there is no blurring permissions
+    print("permissions returned by permissions_required")
+    print(permissions)
+    print("permissions returned by _get_user_permissions")
+    permissions = [
+        perm
+        for perm in _get_user_permissions(g.current_user.id_role)
+        if perm.id_permission == 15131
+        and perm.module.module_code == "SYNTHESE"
+        and perm.action.code_action == "R"
+    ]
+    print(permissions)
+    # print(permissions2)
     blurring_permissions, precise_permissions = split_blurring_precise_permissions(permissions)
+
     if not blurring_permissions:
         # No need to apply blurring => same path as before blurring feature
         obs_query = (

--- a/backend/geonature/core/gn_synthese/blueprints/synthese.py
+++ b/backend/geonature/core/gn_synthese/blueprints/synthese.py
@@ -7,7 +7,6 @@ from flask import (
     jsonify,
     g,
 )
-from geonature.core.gn_permissions.tools import _get_user_permissions
 
 from werkzeug.exceptions import Forbidden, NotFound, BadRequest
 from sqlalchemy import func, select, case, join, and_

--- a/backend/geonature/core/gn_synthese/blueprints/taxon_info.py
+++ b/backend/geonature/core/gn_synthese/blueprints/taxon_info.py
@@ -33,7 +33,7 @@ taxon_info_routes = Blueprint("synthese_taxon_info", __name__)
 
 
 @taxon_info_routes.url_value_preprocessor
-def resolve_import(endpoint, values):
+def resolve_taxon_sheet(endpoint, values):
     if current_app.url_map.is_endpoint_expecting(endpoint, "cd_ref"):
         sheet = TaxonSheet(values.get("cd_ref"))
         values["sheet"] = sheet
@@ -196,7 +196,7 @@ def get_taxon_tree():
 ## ############################################################################
 
 
-@taxon_info_routes.route("/taxon/<int:cd_ref>/medias", methods=["GET"])
+@taxon_info_routes.route("/taxon/<int(signed=True):cd_ref>/medias", methods=["GET"])
 @login_required
 @permissions.permissions_required("R", module_code="SYNTHESE")
 @json_resp
@@ -228,7 +228,7 @@ def taxon_medias(permissions, cd_ref, sheet):
 
 if app.config["SYNTHESE"]["ENABLE_TAXON_SHEETS"]:
 
-    @taxon_info_routes.route("/taxon/<int:cd_ref>/access")
+    @taxon_info_routes.route("/taxon/<int(signed=True):cd_ref>/access")
     @permissions.permissions_required("R", module_code="SYNTHESE")
     @json_resp
     def is_authorized(permissions, cd_ref, sheet):
@@ -237,7 +237,7 @@ if app.config["SYNTHESE"]["ENABLE_TAXON_SHEETS"]:
             raise Forbidden
         return "Authorized", 200
 
-    @taxon_info_routes.route("/taxon/<int:cd_ref>", methods=["GET"])
+    @taxon_info_routes.route("/taxon/<int(signed=True):cd_ref>", methods=["GET"])
     @permissions.permissions_required("R", module_code="SYNTHESE")
     @json_resp
     def taxon_stats(permissions, cd_ref, sheet):
@@ -300,7 +300,7 @@ if app.config["SYNTHESE"]["ENABLE_TAXON_SHEETS"]:
 
 if app.config["SYNTHESE"]["TAXON_SHEET"]["ENABLE_TAB_OBSERVERS"]:
 
-    @taxon_info_routes.route("/taxon/<int:cd_ref>/observers", methods=["GET"])
+    @taxon_info_routes.route("/taxon/<int(signed=True):cd_ref>/observers", methods=["GET"])
     @permissions.permissions_required("R", module_code="SYNTHESE")
     def taxon_observers(permissions, cd_ref, sheet):
 

--- a/backend/geonature/core/gn_synthese/blueprints/taxon_info.py
+++ b/backend/geonature/core/gn_synthese/blueprints/taxon_info.py
@@ -189,7 +189,7 @@ def get_taxon_tree():
 ## ############################################################################
 
 
-@taxon_info_routes.route("/taxon_medias/<int:cd_ref>", methods=["GET"])
+@taxon_info_routes.route("/taxon/<int:cd_ref>/medias", methods=["GET"])
 @login_required
 @permissions.check_cruved_scope("R", module_code="SYNTHESE")
 @json_resp
@@ -221,7 +221,7 @@ def taxon_medias(cd_ref):
 
 if app.config["SYNTHESE"]["ENABLE_TAXON_SHEETS"]:
 
-    @taxon_info_routes.route("/taxon_sheet/is_authorized/<int:cd_ref>")
+    @taxon_info_routes.route("/taxon/<int:cd_ref>/access")
     @permissions.check_cruved_scope("R", module_code="SYNTHESE")
     @json_resp
     def is_authorized(cd_ref):
@@ -230,7 +230,7 @@ if app.config["SYNTHESE"]["ENABLE_TAXON_SHEETS"]:
             raise Forbidden
         return "Authorized", 200
 
-    @taxon_info_routes.route("/taxon_stats/<int:cd_ref>", methods=["GET"])
+    @taxon_info_routes.route("/taxon/<int:cd_ref>", methods=["GET"])
     @permissions.permissions_required("R", module_code="SYNTHESE")
     @json_resp
     def taxon_stats(permissions, cd_ref):
@@ -293,7 +293,7 @@ if app.config["SYNTHESE"]["ENABLE_TAXON_SHEETS"]:
 
 if app.config["SYNTHESE"]["TAXON_SHEET"]["ENABLE_TAB_OBSERVERS"]:
 
-    @taxon_info_routes.route("/taxon_observers/<int:cd_ref>", methods=["GET"])
+    @taxon_info_routes.route("/taxon/<int:cd_ref>/observers", methods=["GET"])
     @permissions.permissions_required("R", module_code="SYNTHESE")
     def taxon_observers(permissions, cd_ref):
 

--- a/backend/geonature/core/gn_synthese/blueprints/taxon_info.py
+++ b/backend/geonature/core/gn_synthese/blueprints/taxon_info.py
@@ -198,10 +198,10 @@ def get_taxon_tree():
 
 @taxon_info_routes.route("/taxon/<int:cd_ref>/medias", methods=["GET"])
 @login_required
-@permissions.check_cruved_scope("R", module_code="SYNTHESE")
+@permissions.permissions_required("R", module_code="SYNTHESE")
 @json_resp
-def taxon_medias(cd_ref, sheet):
-    if not sheet.has_instance_permission():
+def taxon_medias(permissions, cd_ref, sheet):
+    if not sheet.has_instance_permission(permissions=permissions):
         raise Forbidden
 
     per_page = request.args.get("per_page", 10, int)
@@ -229,10 +229,10 @@ def taxon_medias(cd_ref, sheet):
 if app.config["SYNTHESE"]["ENABLE_TAXON_SHEETS"]:
 
     @taxon_info_routes.route("/taxon/<int:cd_ref>/access")
-    @permissions.check_cruved_scope("R", module_code="SYNTHESE")
+    @permissions.permissions_required("R", module_code="SYNTHESE")
     @json_resp
-    def is_authorized(cd_ref, sheet):
-        is_authorized_status = sheet.has_instance_permission()
+    def is_authorized(permissions, cd_ref, sheet):
+        is_authorized_status = sheet.has_instance_permission(permissions)
         if not is_authorized_status:
             raise Forbidden
         return "Authorized", 200
@@ -244,7 +244,7 @@ if app.config["SYNTHESE"]["ENABLE_TAXON_SHEETS"]:
         """Return stats for a specific taxon"""
         area_type = request.args.get("area_type")
 
-        if not sheet.has_instance_permission():
+        if not sheet.has_instance_permission(permissions=permissions):
             raise Forbidden
         if not area_type:
             raise BadRequest("Missing area_type parameter")
@@ -304,7 +304,7 @@ if app.config["SYNTHESE"]["TAXON_SHEET"]["ENABLE_TAB_OBSERVERS"]:
     @permissions.permissions_required("R", module_code="SYNTHESE")
     def taxon_observers(permissions, cd_ref, sheet):
 
-        if not sheet.has_instance_permission():
+        if not sheet.has_instance_permission(permissions):
             raise Forbidden
 
         per_page = request.args.get("per_page", 10, int)

--- a/backend/geonature/core/gn_synthese/blueprints/taxon_info.py
+++ b/backend/geonature/core/gn_synthese/blueprints/taxon_info.py
@@ -221,6 +221,15 @@ def taxon_medias(cd_ref):
 
 if app.config["SYNTHESE"]["ENABLE_TAXON_SHEETS"]:
 
+    @taxon_info_routes.route("/taxon_sheet/is_authorized/<int:cd_ref>")
+    @permissions.check_cruved_scope("R", module_code="SYNTHESE")
+    @json_resp
+    def is_authorized(cd_ref):
+        is_authorized_status = TaxonSheetUtils.has_instance_permission(cd_ref)
+        if not is_authorized_status:
+            raise Forbidden
+        return "Authorized", 200
+
     @taxon_info_routes.route("/taxon_stats/<int:cd_ref>", methods=["GET"])
     @permissions.permissions_required("R", module_code="SYNTHESE")
     @json_resp

--- a/backend/geonature/core/gn_synthese/utils/blurring.py
+++ b/backend/geonature/core/gn_synthese/utils/blurring.py
@@ -1,32 +1,63 @@
 from functools import lru_cache
+from typing import Dict, List, Tuple
 
 from apptax.taxonomie.models import TaxrefTree
 from flask import g
 import sqlalchemy as sa
 from sqlalchemy.orm import aliased
+from sqlalchemy.sql.expression import CTE
 from pypnnomenclature.models import BibNomenclaturesTypes, TNomenclatures
 from ref_geo.models import BibAreasTypes, LAreas
 
 from geonature.core.gn_synthese.models import CorAreaSynthese, Synthese, VSyntheseForWebApp
 from geonature.core.sensitivity.models import cor_sensitivity_area_type
 from geonature.core.gn_synthese.utils.query_select_sqla import SyntheseQuery
+from geonature.core.gn_permissions.models import Permission
 
 from geonature.utils.env import db
 
 
-def split_blurring_precise_permissions(permissions):
+def split_blurring_precise_permissions(
+    permissions: List[Permission],
+) -> Tuple[List[Permission], List[Permission]]:
     """
-    Return permissions respectively with and without sensitivity filter.
+    Split permissions into two lists based on sensitivity filters.
+
+    Parameters
+    ----------
+    permissions : List[Permission]
+        List of permissions to be split.
+
+    Returns
+    -------
+    Tuple[List[Permission], List[Permission]]
+        A tuple containing two lists:
+            - The first list contains permissions with sensitivity filters.
+            - The second list contains permissions without sensitivity filters.
     """
-    return [p for p in permissions if p.sensitivity_filter], [
-        p for p in permissions if not p.sensitivity_filter
+    return [
+        blurred_permission
+        for blurred_permission in permissions
+        if blurred_permission.sensitivity_filter
+    ], [
+        precise_permission
+        for precise_permission in permissions
+        if not precise_permission.sensitivity_filter
     ]
 
 
 @lru_cache()  # to retrive non sensitive nomenclature only on first call
-def build_sensitive_unsensitive_filters():
+def build_sensitive_unsensitive_filters() -> Tuple:
     """
     Return where clauses for sensitive and non-sensitive observations.
+
+    Returns
+    -------
+    Tuple[sa.Column, sa.Column]
+        A tuple containing two SQLAlchemy where clauses:
+            - The first clause is for sensitive observations.
+            - The second clause is for non-sensitive observations.
+
     """
     non_sensitive_nomenc = db.session.scalar(
         sa.select(TNomenclatures.id_nomenclature).where(
@@ -42,11 +73,38 @@ def build_sensitive_unsensitive_filters():
 
 
 def build_blurred_precise_geom_queries(
-    filters, where_clauses: list = [], select_size_hierarchy=False
-):
+    filters: Dict[str, any],
+    where_clauses: list = [],  # Optional. A list of additional WHERE  clause conditions for the base query.
+    select_size_hierarchy: bool = False,  # Optional. Include size hierarchy in the result set.
+) -> Tuple[SyntheseQuery, SyntheseQuery]:
+    """
+    Builds two SQLAlchemy queries that will be UNIONed. These queries are used for
+    the export of geometries in a sensitive or non-sensitive context.
+
+    The provided `where_clauses` list enables adding additional conditions
+    to the base query.
+
+    Parameters
+    ----------
+    filters: (Dict[str, any])
+        A dictionary containing filteringriteria retrieved from the HTTP query.
+    where_clauses: (list, optional)
+        Additional WHERE clause conditions for the base query. Defaults to [].
+    select_size_hierarchy: (bool, optional)
+        Include the size hierarchy column in the generated queries (used in the grid mode). Defaults to False.
+
+    Returns
+    -------
+        Tuple[SyntheseQuery, SyntheseQuery]
+            A tuple containing two `SyntheseQuery` objects representing the blurred and precise geometries queries.
+
+    """
+
     # Build 2 queries that will be UNIONed
     # The where_clauses list enables to add more conditions to the base query
     # Used in export query
+    if not where_clauses:
+        where_clauses = []
     where_clauses.append(Synthese.the_geom_4326.isnot(None))
 
     # Query precise geom, for use with unsensitive observations
@@ -57,7 +115,7 @@ def build_blurred_precise_geom_queries(
         Synthese.the_geom_4326.label("geom"),
     ]
     # Size hierarchy can be used here to filter on it in
-    # a mesh mode scenario.
+    # a grid mode scenario.
     if select_size_hierarchy:
         # 0 since no blurring geometry is associated here and a point have a 0 size
         columns.append(sa.literal(0).label("size_hierarchy"))
@@ -127,18 +185,47 @@ def build_blurred_precise_geom_queries(
 
 
 def build_allowed_geom_cte(
-    blurring_permissions,
-    precise_permissions,
-    blurred_geom_query,
-    precise_geom_query,
-    limit,
-):
-    """ """
-    # The goal is to separate the blurring and precise permissions.
-    # But in sensitive permissions there can be unsensitive observations so we need
-    # to split them.
-    # sensitive_where_clause and unsensitive_where_clause represents this split
-    # See https://github.com/PnX-SI/GeoNature/issues/2558
+    blurring_permissions: List[Permission],
+    precise_permissions: List[Permission],
+    blurred_geom_query: SyntheseQuery,
+    precise_geom_query: SyntheseQuery,
+    limit: int,
+) -> sa.Select:
+    """
+    Apply permissions filters and sensitivity filters to separate blurring and precise permissions.
+
+    This method ensures that sensitive and non-sensitive observations are correctly filtered based on the provided permissions.
+
+    The goal is to separate the blurring and precise permissions.
+    But in sensitive permissions there can be unsensitive observations so we need
+    to split them.
+    sensitive_where_clause and unsensitive_where_clause represents this split
+
+
+    Parameters
+    ----------
+    blurring_permissions : List[Permission]
+        list contains permissions with a sensitivity scope filter
+    precise_permissions : List[Permission]
+        list that contains permissions without sensitivity scope
+    blurred_geom_query : SyntheseQuery
+        SyntheseQuery object used to fetch sensitive observations
+    precise_geom_query : SyntheseQuery
+        SyntheseQuery object used to fetch unsensitive observations
+    limit : int
+        limit of observations returned
+
+    Returns
+    -------
+    Select
+        Union between blurred obs and non-blurred obs
+
+    Notes
+    -----
+    See https://github.com/PnX-SI/GeoNature/issues/2558 for more informations
+    """
+
+    #
 
     sensitive_obs_filter, unsensitive_obs_filter = build_sensitive_unsensitive_filters()
 
@@ -147,10 +234,16 @@ def build_allowed_geom_cte(
         g.current_user,
         precise_permissions,
     )
+
     blurring_perms_filter = blurred_geom_query.build_permissions_filter(
         g.current_user,
         blurring_permissions,
     )
+
+    # Apply missing join for taxonomic/geo permission filters
+    precise_geom_query.build_permissions_filter(g.current_user, blurring_permissions)
+    precise_geom_query.build_query()
+    blurred_geom_query.build_query()
 
     # Access precise geom for obs with precise perm and for unsensitive obs with blurring perm
     precise_geom_query = precise_geom_query.query.where(
@@ -170,22 +263,33 @@ def build_allowed_geom_cte(
         )
     ).limit(limit)
 
-    if any([len(perm.taxons_filter) > 0 for perm in blurring_permissions]):
-        precise_geom_query = precise_geom_query.outerjoin(
-            TaxrefTree.cd_nom, Synthese.cd_nom == TaxrefTree.cd_nom
-        )
-        blurred_geom_query = blurred_geom_query.outerjoin(
-            TaxrefTree.cd_nom, Synthese.cd_nom == TaxrefTree.cd_nom
-        )
-
     return precise_geom_query.union(blurred_geom_query).cte("allowed_geom")
 
 
-def build_synthese_obs_query(observations, allowed_geom_cte, limit):
+def build_synthese_obs_query(
+    observations_columns: List[sa.Column], allowed_geom_cte: CTE, limit: int
+):
+    """
+    Generate the final query used to fetch observations when a user has a sensitivity filter in one of their permissions.
+
+    Parameters
+    ----------
+    observations : List[sa.Column]
+        list of fields of the Synthese returned by the query
+    allowed_geom_cte : CTE
+        CTE that contains all available observations
+    limit : int
+        number of observations limit
+
+    Returns
+    -------
+    Select
+        Final query
+    """
     # Final observation query
     # orderby priority as explained in build_allowed_geom_cte()
     obs_query = (
-        sa.select(observations)
+        sa.select(observations_columns)
         .select_from(
             VSyntheseForWebApp.__table__.join(
                 allowed_geom_cte, allowed_geom_cte.c.id_synthese == VSyntheseForWebApp.id_synthese

--- a/backend/geonature/core/gn_synthese/utils/blurring.py
+++ b/backend/geonature/core/gn_synthese/utils/blurring.py
@@ -5,7 +5,7 @@ from apptax.taxonomie.models import TaxrefTree
 from flask import g
 import sqlalchemy as sa
 from sqlalchemy.orm import aliased
-from sqlalchemy.sql.expression import CTE
+from sqlalchemy.sql.expression import CTE, Select
 from pypnnomenclature.models import BibNomenclaturesTypes, TNomenclatures
 from ref_geo.models import BibAreasTypes, LAreas
 
@@ -190,7 +190,7 @@ def build_allowed_geom_cte(
     blurred_geom_query: SyntheseQuery,
     precise_geom_query: SyntheseQuery,
     limit: int,
-) -> sa.Select:
+) -> Select:
     """
     Apply permissions filters and sensitivity filters to separate blurring and precise permissions.
 
@@ -268,9 +268,9 @@ def build_allowed_geom_cte(
 
 def build_synthese_obs_query(
     observations_columns: List[sa.Column], allowed_geom_cte: CTE, limit: int
-):
+) -> Select:
     """
-    Generate the final query used to fetch observations when a user has a sensitivity filter in one of their permissions.
+    $Generate the final query used to fetch observations when a user has a sensitivity filter in one of their permissions.
 
     Parameters
     ----------
@@ -288,7 +288,7 @@ def build_synthese_obs_query(
     """
     # Final observation query
     # orderby priority as explained in build_allowed_geom_cte()
-    obs_query = (
+    query = (
         sa.select(observations_columns)
         .select_from(
             VSyntheseForWebApp.__table__.join(
@@ -303,4 +303,4 @@ def build_synthese_obs_query(
         .distinct(VSyntheseForWebApp.date_min, VSyntheseForWebApp.id_synthese)
         .limit(limit)
     )
-    return obs_query
+    return query

--- a/backend/geonature/core/gn_synthese/utils/blurring.py
+++ b/backend/geonature/core/gn_synthese/utils/blurring.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 
+from apptax.taxonomie.models import TaxrefTree
 from flask import g
 import sqlalchemy as sa
 from sqlalchemy.orm import aliased
@@ -169,7 +170,11 @@ def build_allowed_geom_cte(
         )
     ).limit(limit)
 
-    return precise_geom_query.union(blurred_geom_query).cte("allowed_geom")
+    return (
+        precise_geom_query.join(TaxrefTree.cd_nom, Synthese.cd_nom == TaxrefTree.cd_nom)
+        .union(blurred_geom_query.join(TaxrefTree.cd_nom, Synthese.cd_nom == TaxrefTree.cd_nom))
+        .cte("allowed_geom")
+    )
 
 
 def build_synthese_obs_query(observations, allowed_geom_cte, limit):

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -216,7 +216,7 @@ class SyntheseQuery:
                 where_clause = TaxrefTree.path.op("<@")(
                     sa.select(sa.func.array_agg(TaxrefTree.path))
                     .where(TaxrefTree.cd_nom.in_([t.cd_nom for t in perm.taxons_filter]))
-                    .subquery()
+                    .scalar_subquery()
                 )
                 perm_filters.append(where_clause)
             if perm_filters:

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -211,7 +211,7 @@ class SyntheseQuery:
                 perm_filters.append(where_clause)
             if perm.taxons_filter:
                 # Does obs taxon path is an descendant of any path of taxons_filter?
-                self.add_join(TaxrefTree, TaxrefTree.cd_nom, self.model.cd_nom)
+                self.add_join(TaxrefTree, TaxrefTree.cd_nom, self.model.cd_nom, join_type="left")
                 where_clause = TaxrefTree.path.op("<@")(
                     sa.select(sa.func.array_agg(TaxrefTree.path)).where(
                         TaxrefTree.cd_nom.in_([t.cd_nom for t in perm.taxons_filter])

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -128,7 +128,6 @@ class SyntheseQuery:
             self.first = False
             self._already_joined_table.append(right_table)
         else:
-            print(self._already_joined_table)
             # check if the table not already joined
             if right_table not in self._already_joined_table:
                 self.query_joins = self.query_joins.join(right_table, left_column == right_column)
@@ -211,13 +210,8 @@ class SyntheseQuery:
 
                 perm_filters.append(where_clause)
             if perm.taxons_filter:
-                print("JE SUIS LA !!!!")
                 # Does obs taxon path is an descendant of any path of taxons_filter?
-                self.add_join(
-                    TaxrefTree,
-                    TaxrefTree.cd_nom,
-                    self.model.cd_nom,
-                )
+                self.add_join(TaxrefTree, self.model.cd_nom, TaxrefTree.cd_nom, join_type="right")
 
                 where_clause = TaxrefTree.path.op("<@")(
                     sa.select(sa.func.array_agg(TaxrefTree.path))

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -128,6 +128,7 @@ class SyntheseQuery:
             self.first = False
             self._already_joined_table.append(right_table)
         else:
+            print(self._already_joined_table)
             # check if the table not already joined
             if right_table not in self._already_joined_table:
                 self.query_joins = self.query_joins.join(right_table, left_column == right_column)

--- a/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
+++ b/backend/geonature/core/gn_synthese/utils/query_select_sqla.py
@@ -211,12 +211,18 @@ class SyntheseQuery:
 
                 perm_filters.append(where_clause)
             if perm.taxons_filter:
+                print("JE SUIS LA !!!!")
                 # Does obs taxon path is an descendant of any path of taxons_filter?
-                self.add_join(TaxrefTree, TaxrefTree.cd_nom, self.model.cd_nom, join_type="left")
+                self.add_join(
+                    TaxrefTree,
+                    TaxrefTree.cd_nom,
+                    self.model.cd_nom,
+                )
+
                 where_clause = TaxrefTree.path.op("<@")(
-                    sa.select(sa.func.array_agg(TaxrefTree.path)).where(
-                        TaxrefTree.cd_nom.in_([t.cd_nom for t in perm.taxons_filter])
-                    )
+                    sa.select(sa.func.array_agg(TaxrefTree.path))
+                    .where(TaxrefTree.cd_nom.in_([t.cd_nom for t in perm.taxons_filter]))
+                    .subquery()
                 )
                 perm_filters.append(where_clause)
             if perm_filters:

--- a/backend/geonature/core/gn_synthese/utils/taxon_sheet.py
+++ b/backend/geonature/core/gn_synthese/utils/taxon_sheet.py
@@ -25,10 +25,7 @@ class TaxonSheet:
     def __init__(self, cd_ref):
         self.cd_ref = cd_ref
 
-    def has_instance_permission(self, user=None):
-        if not user:
-            user = g.current_user
-        permissions = get_permissions("R", user.id_role, "SYNTHESE")
+    def has_instance_permission(self, permissions=[]):
 
         for perm in permissions:
             if perm.taxons_filter:

--- a/backend/geonature/core/gn_synthese/utils/taxon_sheet.py
+++ b/backend/geonature/core/gn_synthese/utils/taxon_sheet.py
@@ -29,19 +29,7 @@ class TaxonSheetUtils:
         permissions = get_permissions("R", user.id_role, "SYNTHESE")
 
         for perm in permissions:
-            current = aliased(TaxrefTree)
-            child_taxon_cte = (
-                select(Taxref.cd_nom)
-                .join(TaxrefTree, TaxrefTree.cd_nom == Taxref.cd_nom)
-                .join(
-                    current,
-                    or_(
-                        current.cd_nom == cd_ref,
-                        TaxrefTree.path.op("<@")(current.path),
-                    ),
-                )
-                .alias("taxons")
-            )
+            child_taxon_cte = TaxonSheetUtils.get_taxon_selectquery(cd_ref)
 
             is_authorized = db.session.scalar(
                 exists(child_taxon_cte)

--- a/backend/geonature/core/gn_synthese/utils/taxon_sheet.py
+++ b/backend/geonature/core/gn_synthese/utils/taxon_sheet.py
@@ -105,7 +105,7 @@ class TaxonSheetUtils:
             select(TaxrefTree.cd_nom)
             .where(
                 TaxrefTree.path.op("<@")(
-                    select(TaxrefTree.path).where(TaxrefTree.cd_nom == cd_ref).subquery()
+                    select(TaxrefTree.path).where(TaxrefTree.cd_nom == cd_ref).scalar_subquery()
                 )
             )
             .alias("taxons")

--- a/backend/geonature/core/gn_synthese/utils/taxon_sheet.py
+++ b/backend/geonature/core/gn_synthese/utils/taxon_sheet.py
@@ -20,10 +20,12 @@ class SortOrder(Enum):
     DESC = "desc"
 
 
-class TaxonSheetUtils:
+class TaxonSheet:
 
-    @staticmethod
-    def has_instance_permission(cd_ref, user=None):
+    def __init__(self, cd_ref):
+        self.cd_ref = cd_ref
+
+    def has_instance_permission(self, user=None):
         if not user:
             user = g.current_user
         permissions = get_permissions("R", user.id_role, "SYNTHESE")
@@ -43,12 +45,15 @@ class TaxonSheetUtils:
                 )
 
                 is_authorized = db.session.scalar(
-                    exists(TaxrefTree).where(child_taxon_cte.c.cd_nom.in_([cd_ref])).select()
+                    exists(TaxrefTree).where(child_taxon_cte.c.cd_nom.in_([self.cd_ref])).select()
                 )
                 if not is_authorized:
                     return False
 
         return True
+
+
+class TaxonSheetUtils:
 
     @staticmethod
     def update_query_with_sorting(query: Query, sort_by: str, sort_order: SortOrder) -> Query:

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -1995,7 +1995,10 @@ class TestMediaTaxon:
 
 @pytest.mark.usefixtures("client_class", "temporary_transaction")
 class TestSyntheseGeographicFilter:
-    def test_geographic_filter_get_obs(self, synthese_data, synthese_read_permissions):
+    @pytest.mark.parametrize("sensitivity_activated", (True, False))
+    def test_geographic_filter_get_obs(
+        self, synthese_data, synthese_read_permissions, sensitivity_activated
+    ):
         with db.session.begin_nested():
             user = User()
             db.session.add(user)
@@ -2005,7 +2008,12 @@ class TestSyntheseGeographicFilter:
         guirec = db.session.execute(
             sa.select(LAreas).where(LAreas.area_name == "Perros-Guirec")
         ).scalar_one()
-        synthese_read_permissions(user, scope_value=None, areas_filter=[chambery, guirec])
+        synthese_read_permissions(
+            user,
+            scope_value=None,
+            areas_filter=[chambery, guirec],
+            sensitivity_filter=sensitivity_activated,
+        )
         set_logged_user(self.client, user)
         response = self.client.get(
             url_for(
@@ -2029,7 +2037,10 @@ class TestSyntheseGeographicFilter:
         )
         assert response.status_code == 200, response.data
 
-    def test_geographic_filter_list_obs(self, synthese_data, synthese_read_permissions):
+    @pytest.mark.parametrize("sensitivity_activated", (True, False))
+    def test_geographic_filter_list_obs(
+        self, synthese_data, synthese_read_permissions, sensitivity_activated
+    ):
         with db.session.begin_nested():
             user = User()
             db.session.add(user)
@@ -2039,7 +2050,12 @@ class TestSyntheseGeographicFilter:
         guirec = db.session.execute(
             sa.select(LAreas).where(LAreas.area_name == "Perros-Guirec")
         ).scalar_one()
-        synthese_read_permissions(user, scope_value=None, areas_filter=[chambery, guirec])
+        synthese_read_permissions(
+            user,
+            scope_value=None,
+            areas_filter=[chambery, guirec],
+            sensitivity_filter=sensitivity_activated,
+        )
         set_logged_user(self.client, user)
         response = self.client.get(
             url_for(
@@ -2055,13 +2071,21 @@ class TestSyntheseGeographicFilter:
 
 @pytest.mark.usefixtures("client_class", "temporary_transaction")
 class TestSyntheseTaxonomicFilter:
-    def test_taxonomic_filter_get_obs(self, synthese_data, synthese_read_permissions):
+    @pytest.mark.parametrize("sensitivity_activated", (True, False))
+    def test_taxonomic_filter_get_obs(
+        self, synthese_data, synthese_read_permissions, sensitivity_activated
+    ):
         with db.session.begin_nested():
             user = User()
             db.session.add(user)
         taxon1 = synthese_data["obs1"].taxref
         taxon2 = synthese_data["obs2"].taxref.parent
-        synthese_read_permissions(user, scope_value=None, taxons_filter=[taxon1, taxon2])
+        synthese_read_permissions(
+            user,
+            scope_value=None,
+            taxons_filter=[taxon1, taxon2],
+            sensitivity_filter=sensitivity_activated,
+        )
         set_logged_user(self.client, user)
         response = self.client.get(
             url_for(
@@ -2085,13 +2109,21 @@ class TestSyntheseTaxonomicFilter:
         )
         assert response.status_code == Forbidden.code, response.data
 
-    def test_taxonomic_filter_list_obs(self, synthese_data, synthese_read_permissions):
+    @pytest.mark.parametrize("sensitivity_activated", (True, False))
+    def test_taxonomic_filter_list_obs(
+        self, synthese_data, synthese_read_permissions, sensitivity_activated
+    ):
         with db.session.begin_nested():
             user = User()
             db.session.add(user)
         taxon1 = synthese_data["obs1"].taxref
         taxon2 = synthese_data["obs2"].taxref.parent
-        synthese_read_permissions(user, scope_value=None, taxons_filter=[taxon1, taxon2])
+        synthese_read_permissions(
+            user,
+            scope_value=None,
+            taxons_filter=[taxon1, taxon2],
+            sensitivity_filter=sensitivity_activated,
+        )
         set_logged_user(self.client, user)
         response = self.client.get(
             url_for(

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -5,7 +5,6 @@ import datetime
 import itertools
 from collections import Counter
 
-from geonature.core.gn_synthese.utils.taxon_sheet import TaxonSheetUtils
 import pytest
 from flask import url_for, current_app
 import sqlalchemy as sa

--- a/docs/sensitivity.rst
+++ b/docs/sensitivity.rst
@@ -256,6 +256,14 @@ Ce floutage des données a été implémenté sur 3 routes de la synthèse :
 
 Des tests unitaires ont également été écrits.
 
+.. warning::
+   Si ``BLUR_SENSITIVE_OBSERVATIONS=true`` et qu'un utilisateur se voit appliquer un filtre de floutage, 
+   les observations avec une nomenclature de sensibilité nulle seront absentes des résultats ! 
+
+   Pour assigner une valeur de nomenclature sur ces observations, deux solutions s'offrent à vous : 
+
+   - Relancer l'attribution de la nomenclature de sensibilité en s'appuyant sur le référentiel : ``geonature sensitivity update-synthese``
+   - **OU** Modifier la valeur du champs `gn_synthese.synthese.id_nomenclature_sensitivity` pour les observations concernées 
 
 Traitement des problématiques liés aux zonages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/sensitivity.rst
+++ b/docs/sensitivity.rst
@@ -260,10 +260,8 @@ Des tests unitaires ont également été écrits.
    Si ``BLUR_SENSITIVE_OBSERVATIONS=true`` et qu'un utilisateur se voit appliquer un filtre de floutage, 
    les observations avec une nomenclature de sensibilité nulle seront absentes des résultats ! 
 
-   Pour assigner une valeur de nomenclature sur ces observations, deux solutions s'offrent à vous : 
+   Pour assigner une valeur de nomenclature sur ces observations, relancer l'attribution de la nomenclature de sensibilité en s'appuyant sur le référentiel avec la commande : ``geonature sensitivity update-synthese``
 
-   - Relancer l'attribution de la nomenclature de sensibilité en s'appuyant sur le référentiel : ``geonature sensitivity update-synthese``
-   - **OU** Modifier la valeur du champs `gn_synthese.synthese.id_nomenclature_sensitivity` pour les observations concernées 
 
 Traitement des problématiques liés aux zonages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
@@ -79,6 +79,10 @@ export class SyntheseDataService {
     });
   }
 
+  getIsAuthorizedCdRefForUser(cd_ref: number){
+    return this._api.get(`${this.config.API_ENDPOINT}/synthese/taxon_sheet/is_authorized/${cd_ref}`);
+  }
+
 
   getSyntheseTaxonSheetObservers(
     cd_ref: number,

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-data.service.ts
@@ -68,19 +68,19 @@ export class SyntheseDataService {
   }
 
   getSyntheseTaxonSheetStat(cd_ref: number, areaType: string = 'COM'): Observable<TaxonStats> {
-    return this._api.get<TaxonStats>(`${this.config.API_ENDPOINT}/synthese/taxon_stats/${cd_ref}`, {
+    return this._api.get<TaxonStats>(`${this.config.API_ENDPOINT}/synthese/taxon/${cd_ref}`, {
       params: new HttpParams().append('area_type', areaType),
     });
   }
 
   getTaxonMedias(cdRef: number, params?: {}): Observable<any> {
-    return this._api.get(`${this.config.API_ENDPOINT}/synthese/taxon_medias/${cdRef}`, {
+    return this._api.get(`${this.config.API_ENDPOINT}/synthese/taxon/${cdRef}/medias`, {
       params,
     });
   }
 
   getIsAuthorizedCdRefForUser(cd_ref: number){
-    return this._api.get(`${this.config.API_ENDPOINT}/synthese/taxon_sheet/is_authorized/${cd_ref}`);
+    return this._api.get(`${this.config.API_ENDPOINT}/synthese/taxon/${cd_ref}/access`);
   }
 
 
@@ -89,7 +89,7 @@ export class SyntheseDataService {
     pagination: SyntheseDataPaginationItem = DEFAULT_PAGINATION,
     sort: SyntheseDataSortItem = DEFAULT_SORT
   ) {
-    return this._api.get<any>(`${this.config.API_ENDPOINT}/synthese/taxon_observers/${cd_ref}`, {
+    return this._api.get<any>(`${this.config.API_ENDPOINT}/synthese/taxon/${cd_ref}/observers`, {
       params: {
         per_page: pagination.perPage,
         page: pagination.currentPage,


### PR DESCRIPTION
This PR resolves issues raised during the pre-release test of GeoNature 2.16.0

This PR add the following:
- apply new filters on the taxon sheet
- change taxon sheet route naming
- add warning entry in the documentation regarding blurring with id_nomenclature_sensitivity empty  
- Add new test to verify if the taxonsheets routes raise Forbidden when a user try to fetch info on a taxon which is not authorized for him
- Complete test of Geo/Taxo filters when recovering observations in the Synthese with and without a sensitivity filter
- change the `__repr__` method of `Permission` to ease the debug related to permissions