### PR TITLE
[Validation] Utiliser la valeur par défaut de t_validation.validation_date.

### DIFF
--- a/backend/geonature/core/gn_commons/models/base.py
+++ b/backend/geonature/core/gn_commons/models/base.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import relationship, aliased
 from sqlalchemy.sql import select, func
 from sqlalchemy.dialects.postgresql import UUID
 from geoalchemy2 import Geometry
-
+from sqlalchemy.schema import FetchedValue
 from pypnnomenclature.models import TNomenclatures
 from pypnusershub.db.models import User
 from utils_flask_sqla.serializers import serializable
@@ -225,7 +225,7 @@ class TValidations(DB.Model):
     validator_role = DB.relationship(User)
     validation_auto = DB.Column(DB.Boolean)
     validation_comment = DB.Column(DB.Unicode)
-    validation_date = DB.Column(DB.TIMESTAMP)
+    validation_date = DB.Column(DB.TIMESTAMP, server_default=FetchedValue())
     validation_auto = DB.Column(DB.Boolean)
     # FIXME: remove and use nomenclature_valid_status
     validation_label = DB.relationship(

--- a/contrib/gn_module_validation/backend/gn_module_validation/blueprint.py
+++ b/contrib/gn_module_validation/backend/gn_module_validation/blueprint.py
@@ -314,9 +314,6 @@ def post_status(scope, id_synthese):
         # t_validations.id_validator:
         id_validator = g.current_user.id_role
 
-        # t_validations.validation_date
-        val_date = datetime.datetime.now()
-
         # t_validations.validation_auto
         val_auto = False
         val_dict = {
@@ -324,7 +321,6 @@ def post_status(scope, id_synthese):
             "id_nomenclature_valid_status": id_validation_status,
             "id_validator": id_validator,
             "validation_comment": validation_comment,
-            "validation_date": str(val_date),
             "validation_auto": val_auto,
         }
         # insert values in t_validations


### PR DESCRIPTION
Cette PR modifie la route POST utilisée par le module de validation pour actualiser le statut de validité d'une observation. La valeur du champ `validation_date` n'est plus calculée par la route via la fonction `datetime.now()`. 

À la place, on utilise la valeur par défaut de la colonne, ajoutée dans la PR #3387. Cette valeur par défaut a été ajoutée dans le modèle de TValidations pour ne pas que l'application envoie une valeur `null` explicitement à la BDD, enfin de ce que je comprend.

En effet, si le serveur qui exécute l'application GeoNature n'est pas le même que celui qui héberge le cluster Postgres, et que les deux serveurs sont sur un fuseau-horaire différent (typiquement le premier en CEST et le second en GMT), les dates de validation enregistrées ne sont pas toutes sur la même timezone, selon le serveur qui a calculé le "now". Cela peut ensuite engendrer des problèmes pour récupérer la dernière validation d'une observation, par exemple dansla vue `gn_commons.v_latest_validation`  (voir le ticket #3404 ).

Apparemment les tests utilisent bien la date de validation de la base, donc rien à changer de ce côté là ? 

https://github.com/PnX-SI/GeoNature/blob/master/backend/geonature/tests/test_validation.py#L88

:heavy_check_mark: Testé sur mon instance GN (2.14.2), tout est OK

closes #3404 