### PR TITLE
fix(taxon-sheet): add Ctrl modifier to media keyboard navigation to prevent weird behavior with left-right keys

### DIFF
--- a/frontend/src/app/syntheseModule/taxon-sheet/tab-media/tab-media.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/tab-media/tab-media.component.ts
@@ -92,12 +92,15 @@ export class TabMediaComponent extends Loadable implements OnInit {
 
   @HostListener('window:keydown', ['$event'])
   onKeydown(event: KeyboardEvent) {
-    if (event.key === 'ArrowLeft') {
-      event.preventDefault();
-      this.selectFollowingMedia(Direction.BACKWARD);
-    } else if (event.key === 'ArrowRight') {
-      event.preventDefault();
-      this.selectFollowingMedia(Direction.FORWARD);
+    // add Ctrl modifier to prevent triggering other left arrow actions
+    if (event.ctrlKey) {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        this.selectFollowingMedia(Direction.BACKWARD);
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        this.selectFollowingMedia(Direction.FORWARD);
+      }
     }
   }
 


### PR DESCRIPTION
[Bugfix]
Dans l'onglet media de la fiche espèce, on peut actuellement naviguer entre les media à l'aide des touches gauche et droite.
MAIS Les touches gauche et droites servent également à naviguer entre les onglets. 

On peut se retrouver dans le cas où on change le media courant ET on place le selecteur d'onglet sur un autre onglet. 

<img width="1859" height="973" alt="image" src="https://github.com/user-attachments/assets/e38b4b7d-f720-4a7b-b213-7136faeeabb0" />

En ajoutant le modifieur Ctrl à la navigation des medias dans la fiche espèce, on contourne le problème de manière assez pragmatique.




