### PR TITLE
Update synthese-list.component.html

### DIFF
--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.html
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.html
@@ -92,7 +92,7 @@
         [title]="row[col.prop]"
         [ngSwitch]="col.prop"
       >
-        <div *ngSwitchCase="'date_min' || 'date_max'">
+        <div *ngSwitchCase="['date_min', 'date_max'].includes(col.prop) ? col.prop : false">
           {{ getDate(row[col.prop]) }}
         </div>
         <div *ngSwitchCase="'nom_vern_or_lb_nom'">


### PR DESCRIPTION
Un OR ( || ) dans un *ngSwitchCase ne fonctionne pas, donc l'affichage de la date_max était considéré comme un champ quelconque et donc sans mise en forme. La modif prposée permet de formater le champ date_max correctement.

cf : https://stackoverflow.com/questions/43775796/angular-2-ngswitchcase-or-operator-not-working

Peut-être qu'utiliser la forme suivante serait aussi plus propre ? :
```
    <ng-container [ngSwitch]="true">
        <ng-container *ngSwitchCase="options === 'a'">Code A</ng-container>
        <ng-container *ngSwitchCase="options === 'b'">Code B</ng-container>
        <ng-container *ngSwitchCase="options === 'c'">Code C</ng-container>
        <ng-container *ngSwitchCase="options === 'd' || options === 'e' || options === 'f'">Common Code</ng-container>
        <ng-container *ngSwitchDefault>Code Default</ng-container>
    </ng-container
```
