### PR TITLE
[Synthèse] Ajout de target _blank pour les liens fiche taxon et dataset

### DIFF
--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.html
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.html
@@ -99,6 +99,7 @@
           <a
             class="Link"
             [routerLink]="['taxon/' + row.cd_nom]"
+            target="_blank"
             *ngIf="
               config.SYNTHESE.ENABLE_TAXON_SHEETS && row.hasOwnProperty('cd_nom');
               else cellDefault
@@ -112,6 +113,7 @@
           <a
             class="Link"
             [routerLink]="['/metadata/dataset_detail/' + row.id_dataset]"
+            target="_blank"
             *ngIf="row.hasOwnProperty('id_dataset'); else cellDefault"
             matTooltip="Afficher la fiche du jeu de données"
           >


### PR DESCRIPTION
Permet d'ouvrir la fiche espèce et la fiche JDD dans un nouvel onglet et non à la place de la synthèse pour éviter de perdre la recherche réalisée.