### PR TITLE
Update data-form.service.ts

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -52,14 +52,14 @@ export class DataFormService {
     group3_inpn
       ? (params = params.set('group3_inpn', group3_inpn))
       : (params = params.set('group3_inpn', ''));
-    if (filters['orderby']) {
-      params = params.set('orderby', filters['orderby']);
+    if (filters?.orderby) {
+      params = params.set('orderby', filters.orderby);
     }
-    if (filters['order']) {
-      params = params.set('order', filters['order']);
+    if (filters?.order) {
+      params = params.set('order', filters.order);
     }
-    if (filters['cd_nomenclature'] && filters['cd_nomenclature'].length > 0) {
-      filters['cd_nomenclature'].forEach((cd) => {
+    if (filters?.cd_nomenclature && filters.cd_nomenclature.length > 0) {
+      filters.cd_nomenclature.forEach((cd) => {
         params = params.append('cd_nomenclature', cd);
       });
     }


### PR DESCRIPTION
En l'état si le paramètre optionnel filters n'est pas défini, une erreur JS est levée.
La modif permet d'intégrer le test si filter est undefined ou pas avant de tester la clé.