### PR TITLE
fix: added clean local storage stat to logout

### DIFF
--- a/frontend/src/app/components/auth/auth.service.ts
+++ b/frontend/src/app/components/auth/auth.service.ts
@@ -155,6 +155,7 @@ export class AuthService {
     localStorage.removeItem(this.prefix + 'id_token');
     localStorage.removeItem(this.prefix + 'expires_at');
     localStorage.removeItem('modules');
+    localStorage.removeItem('homePage.stats');
   }
 
   isAuthenticated(): boolean {


### PR DESCRIPTION
Lors de tests, nous avons cru qu'une régression s'était produite, les stats affichant les informations à l'échelle de l'instance et pas à celle de l'utilisateur connecté. Après recherche, le problème constaté venait simplement d'un oubli de vider le local storage au moment de la déconnexion. 

À priori, avec cet ajout, le local storage lié au core sera totalement vide à la déconnexion, à l'exception de l'élément permettant de sélectionner le fond de carte (`MapLayer`). Il semble pertinent de conserver ce dernier même en cas de déconnexion pour que les préférences de l'utilisateur soient persistantes. 

Si les module gn remplissent le local storage, le fait de le vider reste à leur charge.