### PR TITLE
Fix: Add missing permissions areatype entry in documentation

### DIFF
--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -155,7 +155,7 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
 
 # Configuration des paramètres des permissions
 [PERMISSIONS]
-    # Types d'area disponibles pour le filtrage géographique
+    # Types de zonages accessibles pour les filtres géographiques
     GEOGRAPHIC_FILTER_AREA_TYPES = ["COM", "DEP", "REG"]
 
 # Configuration de l'affichage des cartes dans GeoNature

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -153,6 +153,11 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
     # Activer l'affichage des informations liées aux profils de taxons (dans les modules Validation, Synthèse et Occtax)
     ENABLE_PROFILES = true
 
+# Configuration des paramètres des permissions
+[PERMISSIONS]
+    # Types d'area disponibles pour le filtrage géographique
+    GEOGRAPHIC_FILTER_AREA_TYPES = ["COM", "DEP", "REG"]
+
 # Configuration de l'affichage des cartes dans GeoNature
 [MAPCONFIG]
 


### PR DESCRIPTION
Ajout de l'entrée manquante dans la config PERMISSIONS > GEOGRAPHIC_FILTER_AREA_TYPES
(https://matrix.to/#/!gJfHSUgjLUSdSyZfkn:matrix.org/$dokVOh0FSSVYIeUQSzI9t1qZ7f7eXn4tH2b0UJwf5ww?via=matrix.org&via=matrix.makina-corpus.net&via=moon.org.nz)