### PR TITLE
Update map.component.ts

### DIFF
--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -163,7 +163,7 @@ export class MapComponent implements OnInit {
           position: 'topright',
           watch: true,
           setView: 'always',
-          flyTo: true,
+          flyTo: false,
           showPopup: false
         }).addTo(this.map);
     }

--- a/frontend/src/app/GN2CommonModule/map/map.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.component.ts
@@ -159,7 +159,13 @@ export class MapComponent implements OnInit {
 
     //  GEOLOCATION
     if (this.geolocation && this.config.MAPCONFIG.GEOLOCATION) {
-      (L.control as any).locate().addTo(this.map);
+       (L.control as any).locate({
+          position: 'topright',
+          watch: true,
+          setView: 'always',
+          flyTo: true,
+          showPopup: false
+        }).addTo(this.map);
     }
 
     // --- LAYERS CONTROL


### PR DESCRIPTION
       (L.control as any).locate({
          position: 'topright',    // place le bouton en haut à droite
          watch: true,             // active le suivi permanent (navigator.watchPosition)
          setView: 'always',       // recentre la carte à chaque mise à jour
          flyTo: true,             // animation fluide pour les transitions
          showPopup: false         // pas de popup "Vous êtes ici"

  

Modif afin d'avoir l'option de géoloc disponible même sans activer l'édition pour monitoring,
 en plaçant le bouton en haut a droite.
 
 Ajout des options watch -> tracking pour suivre le déplacement
 et setview -> utile pour revenir automatiquement a la position gps, même en changeant de fenêtre
 
 exemple concret : 
 Je finis de saisir une observation sur un site, je reviens au niveau module. 
 Je suis recentré automatiquement sur ma nouvelle position GPS proche de mon site suivant, ce qui permet de le sélectionner facilement via la carto (pas besoin de taper le nom dans le filtre).
 
<img width="952" height="487" alt="image" src="https://github.com/user-attachments/assets/2fafb8c9-f3aa-4efd-83b9-5a8da03f62c1" />
