### PR TITLE
Feat/enhance synthese per taxa search

### DIFF
--- a/.github/workflows/gn-module-pytest.yml
+++ b/.github/workflows/gn-module-pytest.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           psql -h localhost -U geonatadmin -d geonature2db -f install/assets/db/add_pg_extensions.sql
         env:
-          PGPASSWORD: geonatpasswd
+          PGPASSWORD: 'geonatadmin'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -43,12 +43,12 @@ amqp==5.3.1
     # via kombu
 async-timeout==5.0.1
     # via redis
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   fiona
     #   jsonschema
     #   referencing
-authlib==1.6.4
+authlib==1.6.5
     # via pypnusershub
 babel==2.17.0
     # via flask-babel
@@ -73,7 +73,7 @@ brotli==1.1.0
     # via fonttools
 celery[redis]==5.5.3
     # via -r requirements-common.in
-certifi==2025.8.3
+certifi==2025.10.5
     # via
     #   fiona
     #   pyproj
@@ -191,7 +191,7 @@ flask-wtf==1.2.2
     # via
     #   -r requirements-common.in
     #   usershub
-fonttools[woff]==4.60.0
+fonttools[woff]==4.60.1
     # via
     #   fonttools
     #   weasyprint
@@ -208,7 +208,7 @@ gunicorn==23.0.0
     #   -r requirements-common.in
     #   taxhub
     #   usershub
-idna==3.10
+idna==3.11
     # via
     #   email-validator
     #   requests
@@ -240,7 +240,7 @@ lxml==6.0.2
     # via -r requirements-common.in
 mako==1.3.10
     # via alembic
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   flask
     #   jinja2
@@ -284,7 +284,7 @@ packaging==25.0
     #   gunicorn
     #   kombu
     #   marshmallow
-pandas==2.3.2
+pandas==2.3.3
     # via
     #   -r requirements-common.in
     #   bokeh
@@ -300,7 +300,7 @@ platformdirs==4.4.0
     # via black
 prompt-toolkit==3.0.52
     # via click-repl
-psycopg2==2.9.10
+psycopg2==2.9.11
     # via
     #   -r requirements-common.in
     #   pypn-habref-api
@@ -382,7 +382,7 @@ toml==0.10.2
     # via
     #   -r requirements-common.in
     #   taxhub
-tomli==2.2.1
+tomli==2.3.0
     # via
     #   alembic
     #   black

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,12 +13,12 @@ amqp==5.3.1
     # via kombu
 async-timeout==5.0.1
     # via redis
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   fiona
     #   jsonschema
     #   referencing
-authlib==1.6.4
+authlib==1.6.5
     # via pypnusershub
 babel==2.17.0
     # via flask-babel
@@ -41,7 +41,7 @@ brotli==1.1.0
     # via fonttools
 celery[redis]==5.5.3
     # via -r requirements-common.in
-certifi==2025.8.3
+certifi==2025.10.5
     # via
     #   fiona
     #   pyproj
@@ -149,7 +149,7 @@ flask-weasyprint==1.1.0
     # via -r requirements-common.in
 flask-wtf==1.2.2
     # via -r requirements-common.in
-fonttools[woff]==4.60.0
+fonttools[woff]==4.60.1
     # via
     #   fonttools
     #   weasyprint
@@ -165,7 +165,7 @@ gunicorn==23.0.0
     # via
     #   -r requirements-common.in
     #   taxhub
-idna==3.10
+idna==3.11
     # via requests
 importlib-metadata==4.13.0 ; python_version < "3.10"
     # via
@@ -191,7 +191,7 @@ lxml==6.0.2
     # via -r requirements-common.in
 mako==1.3.10
     # via alembic
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   flask
     #   jinja2
@@ -230,7 +230,7 @@ packaging==25.0
     #   gunicorn
     #   kombu
     #   marshmallow
-pandas==2.3.2
+pandas==2.3.3
     # via
     #   -r requirements-common.in
     #   bokeh
@@ -242,7 +242,7 @@ pillow==11.3.0
     #   weasyprint
 prompt-toolkit==3.0.52
     # via click-repl
-psycopg2==2.9.10
+psycopg2==2.9.11
     # via
     #   -r requirements-common.in
     #   pypn-habref-api
@@ -335,7 +335,7 @@ toml==0.10.2
     # via
     #   -r requirements-common.in
     #   taxhub
-tomli==2.2.1
+tomli==2.3.0
     # via alembic
 tornado==6.5.2
     # via bokeh

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [TaxHub] Mise à jour de TaxHub en version [2.2.3](https://github.com/PnX-SI/TaxHub/releases) incluant diverses évolutions et corrections
 - [Général] Affichage des versions des modules et des référentiels dans le bas du menu latéral (#3664 par @Christophe-Ramet)
 - [Général] La version [18](https://inpn.mnhn.fr/telechargement/referentielEspece/taxref/18.0/menu) de Taxref et du référentiel de sensibilité est désormais installée par défaut lors des nouvelles installations (#3680 par @Pierre-Narcisi)
-- [Métadonnées] Ajout d'un champ de saisie d'UUID dans le formulaire de création de cadre d'acquisition (#3664 par @andriacap, @edelclaux et @jacquesfize)
+- [Métadonnées] Ajout d'un champ de saisie d'UUID dans le formulaire de création de cadre d'acquisition, activable avec le paramètre `ENABLE_UUID_EDITION_FIELD`, mais non activé par défaut car il n'est pas toujours souhaité de pouvoir saisir ou modifier les UUID des métadonnées (#3583 par @andriacap, @edelclaux et @jacquesfize)
 - [TaxHub] Ajout de la fonctionnalité d'export dans la liste de taxons (#3712 par @amandine-sahl)
 - [TaxHub] Ajout d'une fiche d'info sur TaxHub et Taxref dans un nouvel onglet "Informations" (#3717 par @amandine-sahl)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,7 @@
   - Utilisation des `cd_ref` plutôt que les `cd_nom` pour compter le nombre d'espèces observées (#3677)
 - [Développement] Correction de la valeur retournée par la propriété `total_filtered` dans Utils-Flask-SQLAlchemy, corrigeant une régression de GeoNature 2.16.0 avec GN2PG (https://github.com/PnX-SI/Utils-Flask-SQLAlchemy/issues/62, par @jacquesfize)
 - [Occhab] Suppression du champ `id_habitat` dans l'import Occhab (#3716 par @jacquesfize)
-- [Métadonnées] Les dates de début et de fin ne sont plus limités (#3675 par @jacquesfize)
+- [Métadonnées] Les dates de début et de fin ne sont plus limitées (#3675 par @jacquesfize)
 - [Développement] Correction de la fonction `getNomenclature` (#3661 par @jbrieuclp)
 - [Développement] Mise à jour du fichier `.editorconfig` (#3683 par @jpm-cbna)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,8 +21,11 @@
   - Utilisation des `cd_ref` plutôt que les `cd_nom` pour compter le nombre d'espèces observées (#3677)
 - [Développement] Correction de la valeur retournée par la propriété `total_filtered` dans Utils-Flask-SQLAlchemy, corrigeant une régression de GeoNature 2.16.0 avec GN2PG (https://github.com/PnX-SI/Utils-Flask-SQLAlchemy/issues/62, par @jacquesfize)
 - [Occhab] Suppression du champ `id_habitat` dans l'import Occhab (#3716 par @jacquesfize)
+- [Métadonnées] Les dates de début et de fin ne sont plus limités (#3675 par @jacquesfize)
+- [Développement] Correction de la fonction `getNomenclature` (#3661 par @jbrieuclp)
+- [Développement] Mise à jour du fichier `.editorconfig` (#3683 par @jpm-cbna)
 
-- ### ⚠️ Notes de version
+### ⚠️ Notes de version
 
 - La version 2.2.3 de TaxHub inclut des corrections de commandes qu'il peut être nécessaire que vous appliquiez depuis le venv de GeoNature (https://github.com/PnX-SI/TaxHub/releases)
 

--- a/frontend/src/app/GN2CommonModule/form/datalist/datalist.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/datalist/datalist.component.ts
@@ -26,6 +26,7 @@ export class DatalistComponent extends GenericFormComponent implements OnInit {
   @Input() definition: boolean; // help
 
   @Input() filters = {}; // help
+  @Input() orderBy: 'asc' | 'desc';
 
   @Input() default;
   @Input() nullDefault;
@@ -87,6 +88,13 @@ export class DatalistComponent extends GenericFormComponent implements OnInit {
       if (filter_.length) {
         values = filter_.map((f) => values.find((v) => v[key] === f)).filter((v) => !!v);
       }
+    }
+    if (this.orderBy) {
+      values = values.sort((value1, value2) =>
+        this.orderBy === 'desc'
+          ? value2[this.keyLabel].localeCompare(value1[this.keyLabel])
+          : value1[this.keyLabel].localeCompare(value2[this.keyLabel])
+      );
     }
 
     return values;

--- a/frontend/src/app/GN2CommonModule/form/dynamic-form/dynamic-form.component.html
+++ b/frontend/src/app/GN2CommonModule/form/dynamic-form/dynamic-form.component.html
@@ -377,6 +377,7 @@
       [filters]="formDefComp['filters']"
       [default]="formDefComp['default']"
       [nullDefault]="formDefComp['nullDefault']"
+      [orderBy]="formDefComp['orderBy']"
     ></pnx-datalist>
     <pnx-individuals
       *ngSwitchCase="'individuals'"

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/dynamicFormConfig.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/dynamicFormConfig.ts
@@ -294,6 +294,7 @@ export const DYNAMIC_FORM_DEF = [
     required: false,
     designStyle: 'bootstrap',
     multiple: true,
+    orderBy: 'asc',
   },
   {
     type_widget: 'datalist',

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.component.html
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.component.html
@@ -149,7 +149,24 @@
       [apiEndPoint]="taxonApiEndPoint"
       (onChange)="formService.getCurrentTaxon($event)"
     ></pnx-taxonomy>
-
+    <div
+      id="modif"
+      class="form-check"
+    >
+      <input
+        id="modif_checkbox"
+        class="form-check-input"
+        value="true"
+        [formControl]="formService.searchForm.get('fetchChildrenTaxon')"
+        type="checkbox"
+      />
+      <label
+        for="modif_checkbox"
+        class="form-check-label"
+      >
+        <small>Récupérer les taxons enfants</small>
+      </label>
+    </div>
     <div
       *ngIf="formService.selectedtaxonFromComponent.length > 0"
       class="alert alert-warning search-alert mt-2"

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.service.ts
@@ -91,6 +91,7 @@ export class SyntheseFormService {
       taxonomy_group2_inpn: null,
       taxonomy_group3_inpn: null,
       taxon_rank: null,
+      fetchChildrenTaxon: null,
     });
 
     this.searchForm.setValidators([this.periodValidator()]);
@@ -186,7 +187,8 @@ export class SyntheseFormService {
     }
 
     if (this.selectedtaxonFromComponent.length > 0) {
-      updatedParams['cd_ref'] = this.selectedtaxonFromComponent.map((taxon) => taxon.cd_ref);
+      const key = this.searchForm.controls['fetchChildrenTaxon'].value ? 'cd_ref_parent' : 'cd_ref';
+      updatedParams[key] = this.selectedtaxonFromComponent.map((taxon) => taxon.cd_ref);
     }
     if (this.selectedCdRefFromTree.length > 0 || this.selectedTaxonFromRankInput.length > 0) {
       updatedParams['cd_ref_parent'] = [

--- a/frontend/src/app/GN2CommonModule/map/gps/gps.component.html
+++ b/frontend/src/app/GN2CommonModule/map/gps/gps.component.html
@@ -17,18 +17,31 @@
   <div class="modal-body">
     <p>Degrés décimaux (WGS84)</p>
     <div class="form-inline">
-      <div class="form-group">
+      <div class="form-group d-flex w-100">
         <input
-          class="form-control col-sm-4 col-md-4"
+          class="form-control w-50"
           placeholder="X"
           [(ngModel)]="x"
           type="number"
         />
         <input
-          class="form-control col-sm-4 col-md-4"
+          class="form-control w-50"
           placeholder="Y"
           [(ngModel)]="y"
           type="number"
+        />
+      </div>
+      <div class="form-group w-100 mt-2">
+        <p class="mb-1">OU Format texte (WGS84)</p>
+        <input
+          type="text"
+          class="form-control w-100"
+          placeholder="Latitude, Longitude (Y,X)"
+          [(ngModel)]="coordsInput"
+          (ngModelChange)="onCoordsInputChange($event)"
+          ngbTooltip="Exemple : 47.619, -3.425"
+          triggers="hover focus"
+          container="body"
         />
       </div>
     </div>

--- a/frontend/src/app/GN2CommonModule/map/gps/gps.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/gps/gps.component.ts
@@ -36,6 +36,10 @@ export class GPSComponent extends MarkerComponent implements OnInit {
     this.enableGps();
   }
   enableGps() {
+    const currentGpsElement: HTMLElement = document.getElementById('GPSLegend');
+    if (currentGpsElement) {
+      currentGpsElement.remove();
+    }
     // Add leaflet button
     const GPSLegend = this.mapService.addCustomLegend('topleft', 'GPSLegend');
     this.map.addControl(new GPSLegend());

--- a/frontend/src/app/GN2CommonModule/map/gps/gps.component.ts
+++ b/frontend/src/app/GN2CommonModule/map/gps/gps.component.ts
@@ -18,6 +18,9 @@ import { ConfigService } from '@geonature/services/config.service';
 })
 export class GPSComponent extends MarkerComponent implements OnInit {
   @ViewChild('modalContent', { static: false }) public modalContent: any;
+  public x: number;
+  public y: number;
+  public coordsInput: string = '';
   constructor(
     public mapService: MapService,
     public modalService: NgbModal,
@@ -33,18 +36,45 @@ export class GPSComponent extends MarkerComponent implements OnInit {
     this.enableGps();
   }
   enableGps() {
+    // Add leaflet button
     const GPSLegend = this.mapService.addCustomLegend('topleft', 'GPSLegend');
     this.map.addControl(new GPSLegend());
+
+    // Fetch control and customize its appearance
     const gpsElement: HTMLElement = document.getElementById('GPSLegend');
     L.DomEvent.disableClickPropagation(gpsElement);
     gpsElement.innerHTML = '<span> <b> GPS </span> <b>';
     gpsElement.style.paddingLeft = '3px';
+
+    // Bind the open modal functionality
     gpsElement.onclick = () => {
       this.modalService.open(this.modalContent);
     };
   }
 
+  onCoordsInputChange(value: string) {
+    if (!value) {
+      return;
+    }
+    const tokens = value
+      .split(',')
+      .map((token) => token.trim())
+      .filter((token) => token.length > 0 && !Number.isNaN(token));
+
+    if (tokens.length < 2) return;
+
+    this.x = parseFloat(tokens[1]);
+    this.y = parseFloat(tokens[0]);
+    this.coordsInput = this.formatCoordsInput(this.x, this.y);
+  }
+
+  private formatCoordsInput(x: number, y: number): string {
+    return `${x}, ${y}`;
+  }
+
   setMarkerFromGps(x, y) {
+    this.coordsInput = this.formatCoordsInput(this.x, this.y);
+
     super.generateMarkerAndEvent(x, y);
     // remove others layers
     this.mapService.removeAllLayers(this.mapService.map, this.mapService.leafletDrawFeatureGroup);


### PR DESCRIPTION
This PR propose to : 

-  use the Taxref tree to filter Synthese results when one or multiple `cd_ref_parent` are given 
-  add the possibility as discussed in #3707 to filter by taxa and their children (if the user want it) directly using the taxon seach form. A checkbox under the taxon search formular was proposed 

This is not definitive, this PR is still a **work in progress** 

TODO

- [ ] Search field in the Synthese still only search through taxons observed in GN
- [ ] A checkbox below the form indicate if the user wishes to fetch also children taxon