### PR TITLE
[FIX][Synthese][Map] Exclure les points hors limites de l'affichage de la carte

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.service.ts
@@ -313,4 +313,8 @@ export class SyntheseFormService {
       })
     );
   }
+
+  getCurrentStoreType() {
+    return this.selectors.get('format') == 'grouped_geom_by_areas' ? 'grid' : 'point';
+  }
 }

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
@@ -322,6 +322,10 @@ export class SyntheseCarteComponent implements OnInit, AfterViewInit, OnChanges,
         : new L.FeatureGroup();
       const geojsonLayer = new L.GeoJSON(change.inputSyntheseData.currentValue, {
         pointToLayer: (feature, latlng) => {
+          const maxBounds = L.latLngBounds(L.latLng(-90, -180), L.latLng(90, 180));
+          if (!maxBounds.contains(latlng)) {
+            return;
+          }
           const circleMarker = L.circleMarker(latlng);
           let countObs = feature.properties.observations.id_synthese.length;
           (circleMarker as any).nb_obs = countObs;
@@ -343,7 +347,13 @@ export class SyntheseCarteComponent implements OnInit, AfterViewInit, OnChanges,
         try {
           // try to fit bound on layer. catch error if no layer in feature group
           if (this.enableFitBounds) {
-            this._ms.map.fitBounds(this.cluserOrSimpleFeatureGroup.getBounds());
+            const maxBounds = L.latLngBounds(L.latLng(-90, -180), L.latLng(90, 180));
+            const computedBounds = this.cluserOrSimpleFeatureGroup.getBounds();
+            if (Object.keys(computedBounds).length && maxBounds.contains(computedBounds)) {
+              this._ms.map.fitBounds(computedBounds);
+            } else {
+              this._ms.map.fitBounds(maxBounds);
+            }
           } else {
             this.enableFitBounds = true;
           }

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
@@ -133,10 +133,11 @@ export class SyntheseCarteComponent implements OnInit, AfterViewInit, OnChanges,
         });
         this._ms.map.fitBounds(tempFeatureGroup.getBounds(), { maxZoom: 18 });
       } else {
-        let warningMessage =
-          "L'observation sélectionnée a une géométrie invalide, possiblement car hors des limites mondiales";
+        let warningMessage = this.translateService.instant('Synthese.Map.Messages.InvalidGeometry');
         if (this.formService.getCurrentStoreType() == 'grid') {
-          warningMessage += ", ou n'est présente dans aucune maille";
+          warningMessage += this.translateService.instant(
+            'Synthese.Map.Messages.InvalidGeometryGrid'
+          );
         }
         this._commonService.regularToaster('warning', warningMessage);
       }

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-carte/synthese-carte.component.ts
@@ -133,10 +133,12 @@ export class SyntheseCarteComponent implements OnInit, AfterViewInit, OnChanges,
         });
         this._ms.map.fitBounds(tempFeatureGroup.getBounds(), { maxZoom: 18 });
       } else {
-        this._commonService.regularToaster(
-          'warning',
-          "L'observation selectionnée n'est présente dans aucune maille - passez en mode 'point' pour la localiser"
-        );
+        let warningMessage =
+          "L'observation sélectionnée a une géométrie invalide, possiblement car hors des limites mondiales";
+        if (this.formService.getCurrentStoreType() == 'grid') {
+          warningMessage += ", ou n'est présente dans aucune maille";
+        }
+        this._commonService.regularToaster('warning', warningMessage);
       }
     });
 

--- a/frontend/src/app/syntheseModule/synthese.component.ts
+++ b/frontend/src/app/syntheseModule/synthese.component.ts
@@ -142,14 +142,10 @@ export class SyntheseComponent implements OnInit {
 
   private initializeStores(rawGeojson) {
     this.syntheseStore.clearData();
-    this.syntheseStore.setData(this.getCurrentStoreType(), rawGeojson);
+    this.syntheseStore.setData(this.formService.getCurrentStoreType(), rawGeojson);
     this.mapListService.idName = 'id_synthese';
     this.mapListService.tableData = [];
     this.noGeomMessage = false;
-  }
-
-  private getCurrentStoreType() {
-    return this.formService.selectors.get('format') == 'grouped_geom_by_areas' ? 'grid' : 'point';
   }
 
   private extractIds(observation) {
@@ -196,7 +192,7 @@ export class SyntheseComponent implements OnInit {
   private displayMessageGeomAbsence() {
     if (this.noGeomMessage) {
       this.toasterService.warning(
-        "Certaine(s) observation(s) n'ont pas pu être affiché(es) sur la carte car leur maille d’aggrégation n'est pas disponible"
+        "Certaine(s) observation(s) n'ont pas pu être affiché(es) sur la carte car leur géométrie est invalide - possiblement car hors des limites mondiales - ou car leur maille d’aggrégation n'est pas disponible"
       );
     }
   }

--- a/frontend/src/app/syntheseModule/synthese.component.ts
+++ b/frontend/src/app/syntheseModule/synthese.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import * as cloneDeep from 'lodash/cloneDeep';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
+import { TranslateService } from '@ngx-translate/core';
 
 import { ConfigService } from '@geonature/services/config.service';
 import { SyntheseDataService } from '@geonature_common/form/synthese-form/synthese-data.service';
@@ -39,7 +40,8 @@ export class SyntheseComponent implements OnInit {
     private route: ActivatedRoute,
     private ngModal: NgbModal,
     private changeDetector: ChangeDetectorRef,
-    private router: Router
+    private router: Router,
+    private translateService: TranslateService
   ) {}
 
   ngOnInit() {
@@ -192,7 +194,7 @@ export class SyntheseComponent implements OnInit {
   private displayMessageGeomAbsence() {
     if (this.noGeomMessage) {
       this.toasterService.warning(
-        "Certaine(s) observation(s) n'ont pas pu être affiché(es) sur la carte car leur géométrie est invalide - possiblement car hors des limites mondiales - ou car leur maille d’aggrégation n'est pas disponible"
+        this.translateService.instant('Synthese.Messages.GeometryAbsence')
       );
     }
   }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -358,7 +358,8 @@
     },
     "Messages": {
       "Copied": "Copied to clipboard!",
-      "DeleteSuccess": "Observation deleted successfully"
+      "DeleteSuccess": "Observation deleted successfully",
+      "GeometryAbsence": "Some observation(s) could not be displayed on the map because their geometry is invalid - possibly because it is outside world boundaries - or because their aggregation grid cell is not available"
     },
     "Errors": {
       "PeriodCompleteness": "The 'start period' and 'end period' fields must be filled if you want to search by period"
@@ -407,7 +408,11 @@
       }
     },
     "Map": {
-      "AreasToggleBtn": "Grid cells"
+      "AreasToggleBtn": "Grid cells",
+      "Messages": {
+        "InvalidGeometry": "The selected observation has an invalid geometry, possibly because it is outside world boundaries",
+        "InvalidGeometryGrid": ", or is not present in any grid cell"
+      }
     }
   },
   "Media": {

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -358,7 +358,8 @@
     },
     "Messages": {
       "Copied": "Copié dans le presse-papier !",
-      "DeleteSuccess": "Observation supprimée avec succès"
+      "DeleteSuccess": "Observation supprimée avec succès",
+      "GeometryAbsence": "Certaine(s) observation(s) n'ont pas pu être affiché(es) sur la carte car leur géométrie est invalide - possiblement car hors des limites mondiales - ou car leur maille d'aggrégation n'est pas disponible"
     },
     "Errors": {
       "PeriodCompleteness": "Le champs 'periode début' ET 'periode fin' doivent être remplis si vous souhaitez faire une recherche par période"
@@ -407,7 +408,11 @@
       }
     },
     "Map": {
-      "AreasToggleBtn": "Mailles"
+      "AreasToggleBtn": "Mailles",
+      "Messages": {
+        "InvalidGeometry": "L'observation sélectionnée a une géométrie invalide, possiblement car hors des limites mondiales",
+        "InvalidGeometryGrid": ", ou n'est présente dans aucune maille"
+      }
     }
   },
   "Media": {


### PR DESCRIPTION
# Description

Limites mondiales :
- Latitudes : -90 à 90
- Longitudes : -180 à 180

Comportement retenu :
- Tout point hors des limites est exclu du GeoJSON rendu, mais reste présent dans la liste 
  - N'entraîne alors qu'une notification d'avertissement au clic et pas de changement de zoom notamment
- Si la couche finale ne contient aucun point, le zoom est fixé sur la bounding box correspondant aux limites mondiales

Reprise de deux messages d'avertissement - toasters :
- N'indiquer "présente dans aucune maille" qu'en mode maille et pas en mode point
- Ajouter "géométrie invalide, possiblement car hors des limites mondiales"

# Comment reproduire ?

Pour avoir un jeu de données intéressantes :
▶️ Passer la migration "d17db834aca5 add sample data for frontend tests"