### PR TITLE
feat: Adding screenshot when cypress ci fail

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -129,3 +129,4 @@ jobs:
           name: cypress-screenshots
           path: frontend/cypress/screenshots
           if-no-files-found: ignore
+          retention-days: 1

--- a/frontend/cypress/e2e/occhab-spec.js
+++ b/frontend/cypress/e2e/occhab-spec.js
@@ -54,7 +54,7 @@ describe('Testing occhab', () => {
 
       cy.get('#validateButton').click();
     });
-    
+
     const listHabit = await promisify(
       cy.get(
         '[data-qa="pnx-occhab-map-list-datatable"] > div > datatable-body > datatable-selection > datatable-scroller'


### PR DESCRIPTION
Ici le but est de pouvoir obtenir le screenshot d'erreur quand un test cypress a raté. Il est uploadé sur github et accessible en cliquant dans le lien fourni sur l'action `Upload Cypress screenshots`