### PR TITLE
feat(metadata): add config for pre-fill of modules to new dataset

### DIFF
--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -157,6 +157,7 @@ class MetadataConfig(Schema):
     )
     ENABLE_UUID_EDITION_FIELD = fields.Boolean(load_default=False)
     ROUTE_ADD_AF = fields.String(load_default="/metadata/af")
+    DATASETS_DEFAULT_ASSOCIATED_MODULES = fields.List(fields.Str(), load_default=[])
 
 
 class AuthenticationConfig(Schema):

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -608,6 +608,10 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
     ]
     # Activer le champs pour permettre l'édition des uuids des cadres d'acquisition et des jeux de données
     ENABLE_UUID_EDITION_FIELD = false
+    # Spécifier une liste de modules à pré-remplir pour le champs de sélection des modules à associer dans le formulaire de saisie de JDD
+    #   C'est le code du module qui est utilisé, i.e. les valeurs du champs `gn_commons.t_modules.module_code`
+    #   Exemple : DATASETS_DEFAULT_ASSOCIATED_MODULES = ["IMPORT", "SYNTHESE", "OCCHAB", "OCCTAX"]
+    DATASETS_DEFAULT_ASSOCIATED_MODULES = []
 
 # Page d’accueil
 [HOME]

--- a/frontend/src/app/metadataModule/services/dataset-form.service.ts
+++ b/frontend/src/app/metadataModule/services/dataset-form.service.ts
@@ -6,6 +6,9 @@ import { tap, filter, switchMap, map } from 'rxjs/operators';
 
 import { ActorFormService } from './actor-form.service';
 import { FormService } from '@geonature_common/form/form.service';
+import { ConfigService } from '@geonature/services/config.service';
+import { ActivatedRoute } from '@librairies/@angular/router';
+import { ModuleService } from '@geonature/services/module.service';
 
 @Injectable()
 export class DatasetFormService {
@@ -19,7 +22,10 @@ export class DatasetFormService {
     private fb: UntypedFormBuilder,
     private _toaster: ToastrService,
     private actorFormS: ActorFormService,
-    private formS: FormService
+    private formS: FormService,
+    private _config: ConfigService,
+    private _route: ActivatedRoute,
+    public moduleService: ModuleService
   ) {
     this.initForm();
     this.setObservables();
@@ -106,6 +112,18 @@ export class DatasetFormService {
             this.addActor(actor);
           });
           delete value.cor_dataset_actor;
+          // Pre-fill associated modules from config
+          //  but only for the creation a new DS and not for the update of an existing one
+          this._route.params.subscribe((params) => {
+            const isCreateAndNotUpdate = !params.hasOwnProperty('id');
+            if (isCreateAndNotUpdate) {
+              value.modules = this.moduleService.modules.filter((module) => {
+                return this._config.METADATA.DATASETS_DEFAULT_ASSOCIATED_MODULES.includes(
+                  module.module_code
+                );
+              });
+            }
+          });
           return value;
         })
       )


### PR DESCRIPTION
Ajout d'un nouveau paramètre de configuration `DATASETS_DEFAULT_ASSOCIATED_MODULES` dans la section `[METADATA]`. 

Ce paramètre est utilisé pour préremplir les modules à associer à un nouveau JDD.

Ce paramètre est une liste de codes de modules - par exemple : ["IMPORT", "SYNTHESE"].

Ref https://github.com/PnX-SI/GeoNature/issues/3806