### PR TITLE
Limit pytest GitHub actions execution

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,12 +2,17 @@ name: pytest
 
 on:
   push:
+    paths:
+      - "backend/**"
+      - "contrib/**/backend/**"
     branches:
       - master
       - hotfixes
       - develop
-      - hotfix/geonature2_16_4
   pull_request:
+    paths:
+      - "backend/**"
+      - "contrib/**/backend/**"
     branches:
       - master
       - hotfixes


### PR DESCRIPTION
Pytest github actions is not necessary when only frontend files are modified. To limit the usage of computation time on GitHub server, the github actions should only be launched when at least one file is modified in one of the `backend` directory of the repo.