### PR TITLE
feat(occhab-occtax): Both uses permission in frontend.

### DIFF
--- a/contrib/gn_module_occhab/frontend/app/components/occhab-map-list/occhab-map-list.component.scss
+++ b/contrib/gn_module_occhab/frontend/app/components/occhab-map-list/occhab-map-list.component.scss
@@ -43,19 +43,3 @@
   // height: 92vh !important;
   height: 100%;
 }
-
-.btn-row {
-  border: none;
-  padding: 0;
-  line-height: 0;
-  color: inherit;
-  cursor: pointer;
-  vertical-align: middle;
-  font-size: 0.7rem;
-  margin-bottom: 0.5vh;
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-    color: #6c757d;
-  }
-}

--- a/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.scss
+++ b/contrib/occtax/frontend/app/occtax-map-list/occtax-map-list.component.scss
@@ -128,19 +128,3 @@ ngx-datatable {
   justify-content: flex-start;
   gap: 0.2rem;
 }
-
-.btn-row {
-  border: none;
-  padding: 0;
-  line-height: 0;
-  color: inherit;
-  cursor: pointer;
-  vertical-align: middle;
-  font-size: 0.7rem;
-  margin-bottom: 0.5vh;
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-    color: #6c757d;
-  }
-}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -270,6 +270,22 @@ li.no-bullet {
   box-shadow: 0 0 0 2px hsla(0, 0%, 80%, 0.5);
 }
 
+.btn-row {
+  border: none;
+  padding: 0;
+  line-height: 0;
+  color: inherit;
+  cursor: pointer;
+  vertical-align: middle;
+  font-size: 0.7rem;
+  margin-bottom: 0.5vh;
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    color: #6c757d;
+  }
+}
+
 .box-shadow {
   box-shadow:
     4px 5px 8px 0 rgba(0, 0, 0, 0.2),


### PR DESCRIPTION
closes https://github.com/PnX-SI/GeoNature/issues/3785

OccHab n'affiche les boutons (ou pour ceux dans la table, permet de cliquer dessus) seulement si l'utilisateur a les bonnes permissions. 

Par ailleurs mise en cohérence de la page de listing pour occhab et occtax : 

# OccHab
## Avant 
<img width="1108" height="352" alt="image" src="https://github.com/user-attachments/assets/66ba1251-da9b-4bf3-af06-c1b60c7b3bfe" />
## Après
<img width="1106" height="330" alt="image" src="https://github.com/user-attachments/assets/16d26910-ca76-4ce4-8297-202ecc023bc4" />

Peu de changement ici (à part le bouton delete qui est grisé car dans mon exemple l'utilisateur n'a pas les droits de supprimer la donnée). C'est OccHab qui a servis de base visuel

# OccTax
## Avant
<img width="1235" height="560" alt="image" src="https://github.com/user-attachments/assets/476ba1b0-9aff-452a-9a8c-fb010a81cc2a" />

## Après
<img width="1233" height="197" alt="image" src="https://github.com/user-attachments/assets/eb96dfa0-020b-4142-81ea-7804925c3307" />

Les icones ne sont plus coupées