### PR TITLE
Feat: hiérarchiser les fournisseurs d'identité sur la page de connexion

### DIFF
--- a/backend/geonature/tests/test_users.py
+++ b/backend/geonature/tests/test_users.py
@@ -190,7 +190,7 @@ class TestUsers:
         data["password_confirmation"] = "invalid_password"
         response = self.client.post(url_for("users.inscription"), json=data)
         assert response.status_code == 400
-        assert response.json["description"] == "Le mot de passe ne respècte pas les critères"
+        assert response.json["description"] == "Le mot de passe ne respecte pas les critères"
 
     def test_login_recovery_enabled_and_disabled(self, users):
         """
@@ -281,7 +281,7 @@ class TestUsers:
             },
         )
         assert resp.status_code == 400
-        assert resp.json["description"] == "Le mot de passe ne respècte pas les critères"
+        assert resp.json["description"] == "Le mot de passe ne respecte pas les critères"
 
         resp = self.client.put(
             url,
@@ -310,7 +310,7 @@ class TestUsers:
             },
         )
         assert resp.status_code == 400
-        assert resp.json["description"] == "Le mot de passe ne respècte pas les critères"
+        assert resp.json["description"] == "Le mot de passe ne respecte pas les critères"
         resp = self.client.put(
             url,
             json={

--- a/docs/admin/authentication-custom.rst
+++ b/docs/admin/authentication-custom.rst
@@ -1,7 +1,7 @@
 
-Se connecter à d'autres fournisseurs d'identités
+Se connecter à d'autres fournisseurs d'identité
 """"""""""""""""""""""""""""""""""""""""""""""""
-Depuis la version 2.15, il est maintenant possible de se connecter à GeoNature à l'aide de fournisseurs d'identités externes (comme Google, GitHub ou INPN).
+Depuis la version 2.15, il est maintenant possible de se connecter à GeoNature à l'aide de fournisseurs d'identité externes (comme Google, GitHub ou INPN).
 Pour cela, il est nécessaire d'implémenter le protocole de connexion pour permettre à GeoNature de communiquer avec ces fournisseurs.
 Actuellement, GeoNature vient avec plusieurs protocoles de connexion implémentés, tels que :
 
@@ -12,11 +12,11 @@ Actuellement, GeoNature vient avec plusieurs protocoles de connexion implément�
 Ajouter un nouveau fournisseur d'identité
 ````````````````````````````````````````````
 
-Pour ajouter un nouveau fournisseur d'identités à votre instance de GeoNature, vous devez ajouter une section ``[[AUTHENTICATION.PROVIDERS]]`` dans la partie ``AUTHENTICATION`` de votre fichier de configuration.
+Pour ajouter un nouveau fournisseur d'identité à votre instance de GeoNature, vous devez ajouter une section ``[[AUTHENTICATION.PROVIDERS]]`` dans la partie ``AUTHENTICATION`` de votre fichier de configuration.
 Chaque section doit comporter deux variables obligatoires: ``module`` et ``id_provider``. La variable ``module`` indique le chemin vers la classe Python qui implémente le protocole de connexion, tandis que ``id_provider`` indique l'identifiant unique du fournisseur d'identité.
 Vous devez également ajouter les variables de configuration spécifiques au protocole de connexion correspondant.
 
-Dans l'exemple ci-dessous, on déclare deux fournisseurs d'identités : le premier est le fournisseur d'identité par défaut (local) et le deuxième permet de se connecter à l'INPN.
+Dans l'exemple ci-dessous, on déclare deux fournisseurs d'identité : le premier est le fournisseur d'identité par défaut (local) et le deuxième permet de se connecter à l'INPN.
 
 .. code:: toml
 
@@ -80,7 +80,7 @@ Si les protocoles de connexion que nous avons implémentés ne vous suffisent pa
         is_external = True # si redirection vers un portail de connexion externe
 
         def authenticate(self, *args, **kwargs) -> Union[Response, models.User]:
-            pass # doit retourner un utilisateur (User) ou rediriger (flask.Redirect) vers le portail de connexion du fournisseur d'identités
+            pass # doit retourner un utilisateur (User) ou rediriger (flask.Redirect) vers le portail de connexion du fournisseur d'identité
 
         def authorize(self):
             # appeler par /auth/authorize si redirection d'un portail de connexion externe
@@ -93,7 +93,7 @@ Si les protocoles de connexion que nous avons implémentés ne vous suffisent pa
             class SchemaConf(ProviderConfigurationSchema):
                 VAR = fields.String(required=True)
             configuration = SchemaConf().load(configuration) # Si besoin d'un processus de validation
-            ...# Configuration du fournisseur d'identités
+            ...# Configuration du fournisseur d'identité
 
 
 .. note::
@@ -103,7 +103,13 @@ Si les protocoles de connexion que nous avons implémentés ne vous suffisent pa
 Désactiver l'authentification par défaut
 ````````````````````````````````````````
 
-Si vous souhaitez désactiver l'authentification par défaut au profit d'un ou plusieurs autres fournisseurs d'identités, il suffit de ne pas déclarer celui-ci dans la section `[[AUTHENTICATION.PROVIDERS]]` dans la partie `AUTHENTICATION` de la configuration.
+Si vous souhaitez désactiver l'authentification par défaut au profit d'un ou plusieurs autres fournisseurs d'identité, il suffit de ne pas déclarer celui-ci dans la section ``[[AUTHENTICATION.PROVIDERS]]`` dans la partie `AUTHENTICATION` de la configuration.
 
 .. note:: 
-    Si un seul fournisseur d'identités (différent de l'authentification par défaut) est déclaré dans la section `[[AUTHENTICATION.PROVIDERS]]` de la configuration, l'utilisateur sera redirigé automatiquement vers le portail de connexion de ce dernier.
+    Si un seul fournisseur d'identité (différent de l'authentification par défaut) est déclaré dans la section ``[[AUTHENTICATION.PROVIDERS]]`` de la configuration, l'utilisateur sera redirigé automatiquement vers le portail de connexion de ce dernier.
+
+Hiérarchiser différents fournisseurs d'identité
+```````````````````````````````````````````````
+
+L'attribut ``is_secondary`` permet de hiérarchiser l'affichage des fournisseurs d'identité lorsque plusieurs sont activés. Il suffit d'ajouter la ligne ``is_secondary = true`` à la configuration ``[[AUTHENTICATION.PROVIDERS]]`` d'un fournisseur d'identité pour qu'il s'affiche derrière un composant `details`.
+Les autres fournisseurs d'identité ont par défaut le paramètre ``is_secondary = false`` et restent visibles. L'ordre d'affichage au sein de chaque section (fournisseurs principaux et fournisseurs secondaires) dépend de leur ordre dans le fichier de configuration.

--- a/docs/admin/authentication-custom.rst
+++ b/docs/admin/authentication-custom.rst
@@ -1,6 +1,6 @@
 
 Se connecter à d'autres fournisseurs d'identité
-""""""""""""""""""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""""""""""""""""
 Depuis la version 2.15, il est maintenant possible de se connecter à GeoNature à l'aide de fournisseurs d'identité externes (comme Google, GitHub ou INPN).
 Pour cela, il est nécessaire d'implémenter le protocole de connexion pour permettre à GeoNature de communiquer avec ces fournisseurs.
 Actuellement, GeoNature vient avec plusieurs protocoles de connexion implémentés, tels que :

--- a/frontend/src/app/modules/login/login/login.component.html
+++ b/frontend/src/app/modules/login/login/login.component.html
@@ -28,118 +28,61 @@
             </div>
             <div class="panel-body">
               <ng-container *ngIf="!login_or_pass_recovery; else logPwdRecoBlock">
-                <ng-container *ngIf="localProviderEnabled">
-                  <form
-                    (ngSubmit)="register(userForm.value)"
-                    #userForm="ngForm"
-                  >
-                    <div class="form-group">
-                      <i class="addon fa fa-user"></i>
-                      <input
-                        type="text"
-                        id="login"
-                        class="form-control"
-                        name="login"
-                        ngModel
-                        placeholder="Identifiant"
-                        autofocus
-                        data-qa="gn-connection-id"
+                <div>
+                  <ng-container *ngFor="let provider of primaryProviders">
+                    <div class="text-center">
+                      <ng-container
+                        *ngTemplateOutlet="providerTemplate; context: { provider: provider }"
                       />
                     </div>
-                    <div class="form-group password-field">
-                      <i class="addon fa fa-lock"></i>
-                      <input
-                        #password
-                        [type]="showPassword ? 'text' : 'password'"
-                        name="password"
-                        class="form-control"
-                        placeholder="Mot de passe"
-                        ngModel
-                        data-qa="gn-connection-pwd"
-                      />
-                      <button
-                        type="button"
-                        class="password-toggle-btn"
-                        (click)="togglePasswordVisibility()"
-                        [attr.aria-label]="
-                          showPassword
-                            ? ('Authentication.Messages.HidePassword' | translate)
-                            : ('Authentication.Messages.ShowPassword' | translate)
-                        "
-                        [matTooltip]="
-                          showPassword
-                            ? ('Authentication.Messages.HidePassword' | translate)
-                            : ('Authentication.Messages.ShowPassword' | translate)
-                        "
-                        matTooltipPosition="right"
-                        tabindex="-1"
-                      >
-                        <mat-icon>{{ showPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
-                      </button>
-                    </div>
-                    <div
-                      *ngIf="enable_user_management"
-                      class="forgot"
-                      (click)="login_or_pass_recovery = true; _authService.loginError = false"
-                    >
-                      {{ 'Authentication.Messages.ForgotPasswordOrLogin' | translate }}
-                    </div>
+                    <br
+                      *ngIf="primaryProviders.length > 1 && primaryProviders.indexOf(provider) == 0"
+                    />
+                  </ng-container>
 
-                    <button
-                      class="btn btn-lg btn-success btn-block text-uppercase"
-                      type="submit"
-                      data-qa="gn-connection-button"
-                    >
-                      Se connecter
-                    </button>
-                  </form>
+                  <ng-container *ngIf="hasSecondaryProviders">
+                    <br />
+                    <details>
+                      <summary>{{ 'Authentication.OtherAuthProviders' | translate }}</summary>
+                      <br />
+                      <ng-container *ngFor="let provider of secondaryProviders">
+                        <div class="text-center">
+                          <ng-container
+                            *ngTemplateOutlet="providerTemplate; context: { provider: provider }"
+                          />
+                        </div>
+                        <br
+                          *ngIf="
+                            secondaryProviders.length > 1 &&
+                            secondaryProviders.indexOf(provider) != secondaryProviders.length - 1
+                          "
+                        />
+                      </ng-container>
+                    </details>
+                  </ng-container>
+                </div>
+
+                <div>
                   <hr />
-                </ng-container>
-
-                <ng-container *ngIf="isOtherProviders">
-                  <p>Se connecter avec :</p>
-                  <div class="row center">
-                    <div *ngFor="let provider of authProviders">
-                      <button
-                        *ngIf="!provider.is_external; else externalAuthBlock"
-                        (click)="openDialog(provider)"
-                        class="btn btn-primary rounded mr-2 mt-2"
-                      >
-                        <span [innerHTML]="provider.logo | safeHTML"></span>
-                        {{ provider.label }}
-                      </button>
-                      <ng-template #externalAuthBlock>
-                        <a
-                          [href]="getProviderLoginUrl(provider.id_provider)"
-                          class="btn btn-primary rounded mr-2 mt-2"
-                        >
-                          <span [innerHTML]="provider.logo | safeHTML"></span>
-                          {{ provider.label }}
-                        </a>
-                      </ng-template>
-                    </div>
-                  </div>
-                </ng-container>
-
-                <br />
-
-                <div *ngIf="enable_sign_up">
-                  <div class="inscription">
+                  <div
+                    *ngIf="enable_sign_up"
+                    class="inscription"
+                  >
                     <a routerLink="/login/inscription">
                       {{ 'Authentication.Actions.CreateAccount' | translate }}
                     </a>
                   </div>
-                </div>
-                <div
-                  *ngFor="let link of external_links"
-                  class="external_link"
-                >
-                  <a
-                    href="{{ link.url }}"
-                    target="_blank"
+                  <div
+                    *ngFor="let link of external_links"
+                    class="external_link"
                   >
-                    {{ link.label }}
-                  </a>
+                    <a
+                      href="{{ link.url }}"
+                      target="_blank"
+                    >
+                      {{ link.label }}
+                    </a>
+                  </div>
                 </div>
                 <!-- <input type="submit" class="btn btn-success" value="Connexion"> -->
               </ng-container>
@@ -148,12 +91,11 @@
                 <ng-container *ngIf="login_or_pass_recovery">
                   <div>
                     <small style="color: white !important">
-                      Veuillez renseigner votre adresse email utilisée lors de votre inscription.
+                      {{ 'Authentication.Messages.Recovery.MailAsked' | translate }}
                     </small>
                     <br />
                     <small style="color: white !important">
-                      Un message y sera envoyé avec votre identifiant et la possibilité de
-                      renouveler votre votre mot de passe.
+                      {{ 'Authentication.Messages.Recovery.Process' | translate }}
                     </small>
                   </div>
 
@@ -169,7 +111,7 @@
                         class="form-control"
                         name="email"
                         ngModel
-                        placeholder="Adresse mail"
+                        placeholder="{{ 'Authentication.Email' | translate }}"
                         autofocus
                         required
                         email
@@ -192,7 +134,7 @@
                       class="btn btn-lg btn-success btn-block text-uppercase"
                       type="submit"
                     >
-                      Envoyer
+                      {{ 'Authentication.Actions.Send' | translate }}
                     </button>
                   </form>
                 </ng-container>
@@ -240,16 +182,107 @@
   </ng-container>
 </div>
 
-<ng-template #noProvider>
-  <div class="container">
-    <div id="no-provider">
-      <div
-        class="alert alert-warning text-center p-3 mx-auto"
-        role="alert"
-        style="width: 50%"
-      >
-        <h1>Aucun fournisseur d'identités n'est configuré.</h1>
-      </div>
+<ng-template
+  #providerTemplate
+  let-provider="provider"
+>
+  <ng-container
+    *ngTemplateOutlet="
+      provider.id_provider === 'local_provider' ? localProviderForm : otherProvider;
+      context: { provider: provider }
+    "
+  />
+</ng-template>
+
+<ng-template #localProviderForm>
+  <ng-container *ngIf="!isLocalProviderOnlyPrimaryProvider">
+    {{ 'Authentication.Authentication' | translate }} GeoNature
+  </ng-container>
+  <form
+    (ngSubmit)="register(userForm.value)"
+    #userForm="ngForm"
+  >
+    <div class="form-group">
+      <i class="addon fa fa-user"></i>
+      <input
+        type="text"
+        id="login"
+        class="form-control"
+        name="login"
+        ngModel
+        placeholder="{{ 'Authentication.Username' | translate }}"
+        autofocus
+        data-qa="gn-connection-id"
+      />
     </div>
-  </div>
+    <div class="form-group password-field">
+      <i class="addon fa fa-lock"></i>
+      <input
+        #password
+        [type]="showPassword ? 'text' : 'password'"
+        name="password"
+        class="form-control"
+        placeholder="Mot de passe"
+        ngModel
+        data-qa="gn-connection-pwd"
+      />
+      <button
+        type="button"
+        class="password-toggle-btn"
+        (click)="togglePasswordVisibility()"
+        [attr.aria-label]="
+          showPassword
+            ? ('Authentication.Messages.HidePassword' | translate)
+            : ('Authentication.Messages.ShowPassword' | translate)
+        "
+        [matTooltip]="
+          showPassword
+            ? ('Authentication.Messages.HidePassword' | translate)
+            : ('Authentication.Messages.ShowPassword' | translate)
+        "
+        matTooltipPosition="right"
+        tabindex="-1"
+      >
+        <mat-icon>{{ showPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+      </button>
+    </div>
+    <div
+      *ngIf="enable_user_management"
+      class="forgot"
+      (click)="login_or_pass_recovery = true; _authService.loginError = false"
+    >
+      {{ 'Authentication.Messages.Recovery.ForgotPasswordOrLogin' | translate }}
+    </div>
+
+    <button
+      class="btn btn-lg btn-success btn-block text-uppercase"
+      type="submit"
+      data-qa="gn-connection-button"
+    >
+      {{ 'Authentication.Actions.LogIn' | translate }}
+    </button>
+  </form>
+</ng-template>
+
+<ng-template
+  #otherProvider
+  let-provider="provider"
+>
+  <button
+    *ngIf="!provider.is_external; else externalAuthBlock"
+    (click)="openDialog(provider)"
+    class="btn btn-primary rounded mr-2 mt-2"
+  >
+    <span [innerHTML]="provider.logo | safeHTML"></span>
+    {{ provider.label }}
+  </button>
+  <ng-template #externalAuthBlock>
+    <a
+      [href]="getProviderLoginUrl(provider.id_provider)"
+      class="btn btn-primary rounded mr-2 mt-2"
+    >
+      <span [innerHTML]="provider.logo | safeHTML"></span>
+      {{ provider.label }}
+    </a>
+  </ng-template>
 </ng-template>

--- a/frontend/src/app/modules/login/login/login.component.scss
+++ b/frontend/src/app/modules/login/login/login.component.scss
@@ -77,7 +77,7 @@ mat-dialog-content {
 }
 
 #login-body {
-  height: 100vh;
+  min-height: 100svh;
   background-size: cover;
 }
 

--- a/frontend/src/app/modules/login/login/login.component.ts
+++ b/frontend/src/app/modules/login/login/login.component.ts
@@ -31,8 +31,8 @@ export class LoginComponent implements OnInit {
   login_or_pass_recovery: boolean = false;
   public APP_NAME = null;
   public authProviders: Array<Provider>;
-  public localProviderEnabled: boolean = true;
-  public isOtherProviders: boolean = false;
+  public primaryProviders: Array<Provider>;
+  public secondaryProviders: Array<Provider>;
   public errorMsg = '';
   public showPassword: boolean = false;
 
@@ -63,20 +63,31 @@ export class LoginComponent implements OnInit {
     }
     this._authService.getAuthProviders().subscribe((providers) => {
       this.authProviders = providers;
-      this.isOtherProviders = this.authProviders.length > 1;
-      // If local provider is not available in the configuration, disable it
-      if (!this.authProviders.find((p) => p.id_provider === 'local_provider')) {
-        this.localProviderEnabled = false;
-      }
-      // Local provider should not be display in the other providers buttons
-      this.authProviders = this.authProviders.filter((p) => p.id_provider !== 'local_provider');
 
-      // If one provider is declared (except the local one)
-      if (this.authProviders.length === 1 && !this.localProviderEnabled) {
+      // Redirect if the only provider declared isn't the local provider
+      if (
+        this.authProviders.length === 1 &&
+        this.authProviders[0].id_provider !== 'local_provider'
+      ) {
         const provider = this.authProviders[0];
         window.location.href = this.getProviderLoginUrl(provider.id_provider);
+      } else {
+        // Separate primary provider(s) and other provider(s)
+        this.primaryProviders = this.authProviders.filter((p) => p.is_secondary !== true);
+        this.secondaryProviders = this.authProviders.filter((p) => p.is_secondary === true);
       }
     });
+  }
+
+  get hasSecondaryProviders(): boolean {
+    return this.secondaryProviders?.length > 0 ? true : false;
+  }
+
+  get isLocalProviderOnlyPrimaryProvider(): boolean {
+    return this.primaryProviders?.length == 1 &&
+      this.primaryProviders[0].id_provider == 'local_provider'
+      ? true
+      : false;
   }
 
   async register(form) {

--- a/frontend/src/app/modules/login/providers.ts
+++ b/frontend/src/app/modules/login/providers.ts
@@ -5,4 +5,5 @@ export interface Provider {
   login_url: string;
   logout_url: string;
   logo: string;
+  is_secondary: boolean;
 }

--- a/frontend/src/app/modules/login/sign-up/sign-up.component.scss
+++ b/frontend/src/app/modules/login/sign-up/sign-up.component.scss
@@ -70,7 +70,7 @@
 
 #login-body {
   background-size: cover;
-  height: 100%;
+  min-height: 100svh;
 }
 
 form.ng-invalid {

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -39,15 +39,19 @@
   },
 
   "Authentication": {
+    "Authentication": "Authentication",
     "Email": "Email",
     "Username": "Username",
     "Password": "Password",
     "LogIn": "Login",
     "LogOut": "Logout",
     "Actions": {
+      "LogIn": "Log in",
+      "LogOut": "Log out",
       "CreateAccount": "Create an account",
       "ActivateAccount": "Activate my account",
-      "ActivateAccountValidator": "Activate this account"
+      "ActivateAccountValidator": "Activate this account",
+      "Send": "Send"
     },
     "Errors": {
       "WrongLoginOrPassword": "Incorrect username or password.",
@@ -63,13 +67,20 @@
       }
     },
     "Messages": {
-      "ForgotPasswordOrLogin": "Forgot username or password?",
+      "Recovery": {
+        "ForgotPasswordOrLogin": "Forgot username or password?",
+        "MailAsked": "Please enter the email address you used when registering.",
+        "Process": "A message will be sent to this address with your username and the option to reset your password."
+      },
       "ActivateAccountConfirmation": "To activate your account, click on the button below",
       "ActivateAccountConfirmationValidator": "To activate this account, click on the button below",
       "PasswordChanged": "Your password has been changed",
       "ShowPassword": "Show password",
-      "HidePassword": "Hide password"
-    }
+      "HidePassword": "Hide password",
+      "MailMandatory": "Email is mandatory.",
+      "InvalidMail": "Please enter a valid email address."
+    },
+    "OtherAuthProviders": "Other login methods"
   },
   "MyAccount": {
     "MyAccount": "My account",

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -38,15 +38,17 @@
   },
 
   "Authentication": {
-    "Email": "Email",
+    "Authentication": "Authentification",
+    "Email": "Adresse mail",
     "Username": "Nom d'utilisateur",
     "Password": "Mot de passe",
     "Actions": {
-      "LogIn": "Connexion",
+      "LogIn": "Se connecter",
       "LogOut": "Déconnexion",
       "CreateAccount": "Créer un compte",
       "ActivateAccount": "Activer mon compte",
-      "ActivateAccountValidator": "Activer le compte"
+      "ActivateAccountValidator": "Activer le compte",
+      "Send": "Envoyer"
     },
     "Errors": {
       "WrongLoginOrPassword": "Identifiant ou mot de passe incorrect",
@@ -62,15 +64,21 @@
       }
     },
     "Messages": {
-      "ForgotPasswordOrLogin": "Identifiant ou mot de passe oublié ?",
+      "Recovery": {
+        "ForgotPasswordOrLogin": "Identifiant ou mot de passe oublié ?",
+        "MailAsked": "Veuillez renseigner l'adresse email utilisée lors de votre inscription.",
+        "Process": "Un message y sera envoyé avec votre identifiant et la possibilité de renouveler votre mot de passe."
+      },
       "ActivateAccountConfirmation": "Pour activer votre compte, cliquez sur le bouton ci-dessous",
       "ActivateAccountConfirmationValidator": "Pour activer ce compte, cliquez sur le bouton ci-dessous",
       "PasswordChanged": "Votre mot de passe a bien été changé",
       "MailMandatory": "L'adresse email est obligatoire.",
       "InvalidMail": "Veuillez saisir une adresse email valide.",
       "ShowPassword": "Afficher le mot de passe",
-      "HidePassword": "Masquer le mot de passe"
-    }
+      "HidePassword": "Masquer le mot de passe",
+      "InvalidMail": "Veuillez saisir une adresse email valide."
+    },
+    "OtherAuthProviders": "Autres moyens de connexion"
   },
   "MyAccount": {
     "MyAccount": "Mon compte",


### PR DESCRIPTION
Fixes #3912

En lien avec [la PR 144 de UsersHub-authentification-module](https://github.com/PnX-SI/UsersHub-authentification-module/pull/144)

- transformation des blocs de connexion `local-provider` et des autres fournisseurs en templates
- refonte de la logique d'affichage des fournisseurs avec une séparation en `primaryProviders` et `secondaryProviders`
- création d'un composant `details` pour masquer les `secondaryProviders`
- traduction de tous les éléments de la page en français et anglais