### PR TITLE
feat: [monitoring] add id_import to sites group model

### DIFF
--- a/backend/geonature/migrations/versions/974hpr70u7hd_add_id_import_column_for_sites_group.py
+++ b/backend/geonature/migrations/versions/974hpr70u7hd_add_id_import_column_for_sites_group.py
@@ -1,0 +1,37 @@
+"""[monitoring] add id_import column for sites group
+
+Revision ID: 974hpr70u7hd
+Revises: c3db57568f88
+Create Date: 2026-02-11 16:00:05.425708
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "974hpr70u7hd"
+down_revision = "c3db57568f88"
+branch_labels = None
+depends_on = None
+
+import_column_name = "id_import"
+schema = "gn_monitoring"
+table = "t_sites_groups"
+
+
+def upgrade():
+    op.add_column(
+        schema=schema,
+        table_name=table,
+        column=sa.Column(import_column_name, sa.Integer, nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column(
+        schema=schema,
+        table_name=table,
+        column_name=import_column_name,
+    )

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -507,9 +507,9 @@
       "Title": "Correspondance des champs avec le modèle",
       "MappingName": "Nom du modèle",
       "Messages": {
-        "SourceFieldsMapped": "{{ mappedFieldsLength }} champs cibles ont été associés à un champs source.",
-        "SourceFieldsAllMapped": "L'ensemble des {{ sourceFieldsLength }} champs du fichier d’import ont été associés à un champs cible.",
-        "SourceFieldsUnmapped": "{{ unmappedFieldsLength }} champs du fichier d’import ne sont actuellement associés à aucun champs cible et seront donc ignorés.",
+        "SourceFieldsMapped": "{{ mappedFieldsLength }} champs cibles ont été associés à un champ source.",
+        "SourceFieldsAllMapped": "L'ensemble des {{ sourceFieldsLength }} champs du fichier d’import ont été associés à un champ cible.",
+        "SourceFieldsUnmapped": "{{ unmappedFieldsLength }} champs du fichier d’import ne sont actuellement associés à aucun champ cible et seront donc ignorés.",
         "MappingNameWarning": "Un nom doit être renseigné pour pouvoir créer un modèle",
         "MappingChangeNameWarning": "Changer de nom pour pouvoir enregistrer le modèle",
         "SinpUUIDWarning": "Attention les identifiants SINP ne seront pas générés",


### PR DESCRIPTION
Edit: erreur de dépôt où mettre la migration

~~[Cf. Ticket 574 de gn_module_monitoring](https://github.com/PnX-SI/gn_module_monitoring/issues/574)~~

~~Migration d'ajout de la colonne `id_import` à `gn_monitoring.t_sites_groups`~~

~~Correction de typos en passant.~~