### PR TITLE
fix(alembic): add missing depends_on `import-samples` migration

### DIFF
--- a/backend/geonature/migrations/versions/imports/a81f74d0a518_insert_import_sample_data.py
+++ b/backend/geonature/migrations/versions/imports/a81f74d0a518_insert_import_sample_data.py
@@ -16,7 +16,10 @@ import sqlalchemy as sa
 revision = "a81f74d0a518"
 down_revision = None
 branch_labels = ("import-samples",)
-depends_on = "2b0b3bd0248c"
+depends_on = (
+    "2b0b3bd0248c",  # import@2b0b3bd0248c - "multidest"
+    "3d0bf4ee67d1",  # geonature-samples@3d0bf4ee67d1 - "geonature samples"
+)
 
 
 def upgrade():


### PR DESCRIPTION
Alembic migration "geonature-samples@3d0bf4ee67d1 - 'geonature samples'" - with insert of 'hors protocole' in `gn_meta.sinp_datatype_protocols` - is required for "import-samples@a81f74d0a518 'insert_import_sample_data'", because the latter refers to this protocol.