### PR TITLE
feat: handle login_errors in query_params

### DIFF
--- a/frontend/src/app/modules/login/login/login.component.ts
+++ b/frontend/src/app/modules/login/login/login.component.ts
@@ -55,6 +55,11 @@ export class LoginComponent implements OnInit {
   }
 
   ngOnInit() {
+    // Error message passed via redirect query params after external auth failure.
+    const loginError = this.route.snapshot.queryParams['login_error'];
+    if (loginError) {
+      this.errorMsg = loginError;
+    }
     this._authService.getAuthProviders().subscribe((providers) => {
       this.authProviders = providers;
       this.isOtherProviders = this.authProviders.length > 1;


### PR DESCRIPTION
L'objet de cette PR est de permettre d'injecter dans la page de connection des erreurs de login en tant que query_params.

Cette PR est liée à cette fonctionnalité: https://github.com/PnX-SI/UsersHub-authentification-module/pull/143

Cette approche a été choisie car elle est minimaliste, et n'implique que très peu de modification sur la page. 