### PR TITLE
Chore/delete view v_releve_list

### DIFF
--- a/contrib/occtax/backend/occtax/migrations/4d4e4b7350fe_delete_v_releve_list.py
+++ b/contrib/occtax/backend/occtax/migrations/4d4e4b7350fe_delete_v_releve_list.py
@@ -1,0 +1,27 @@
+"""delete v_releve_list
+
+Revision ID: 4d4e4b7350fe
+Revises: b66d30f4e3d1
+Create Date: 2026-03-11 11:10:12.342311
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "4d4e4b7350fe"
+down_revision = "b66d30f4e3d1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DROP VIEW IF EXISTS pr_occtax.v_releve_list;")
+
+
+def downgrade():
+    print(
+        "If you had the view 'v_releve_list', it cannot be restored automatically and is not used anywhere. "
+        "This downgrade do nothing."
+    )

--- a/contrib/occtax/occtax_config.toml.example
+++ b/contrib/occtax/occtax_config.toml.example
@@ -35,23 +35,26 @@ releve_map_zoom_level = 6
 # Columns which are default display in the list
 default_maplist_columns = [
     { prop = "taxons", name = "Taxon(s)" },
-    { prop = "date_min", name = "Date début", max_width = "100" },
-    { prop = "observateurs", name = "Observateur(s)" },
-    { prop = "dataset_name", name = "Jeu de données" }
+    { prop = "observateurs", name = "Observateurs" },
+    { prop = "date", name = "Date" },
+    { prop = "dataset", name = "Jeu de données" },
 ]
+
 
 # Available columns which can be add manualy by user
 available_maplist_column = [
-    { prop = "altitude_max", name = "altitude_max" },
-    { prop = "altitude_min", name = "altitude_min" },
+    { prop = "altitude_min", name = "Altitude min" },
+    { prop = "altitude_max", name = "Altitude max" },
     { prop = "comment", name = "Commentaire" },
-    { prop = "date_max", name = "Date fin" },
+    { prop = "date", name = "Date" },
     { prop = "date_min", name = "Date début" },
-    { prop = "id_dataset", name = "ID dataset" },
+    { prop = "date_max", name = "Date fin" },
+    { prop = "id_dataset", name = "ID jeu de données" },
+    { prop = "dataset", name = "Jeu de données" },
     { prop = "id_digitiser", name = "ID rédacteur" },
     { prop = "id_releve_occtax", name = "ID relevé" },
-    { prop = "observateurs", name = "observateurs" },
-    { prop = "taxons", name = "taxons" }
+    { prop = "observateurs", name = "Observateurs" },
+    { prop = "nb_taxons", name = "Nb. taxon" }
 ]
 
 # Message of the list of releve

--- a/docs/admin-manual.rst
+++ b/docs/admin-manual.rst
@@ -1841,13 +1841,17 @@ Par défaut :
 .. code:: toml
 
     default_maplist_columns = [
-        { prop = "taxons", name = "Taxon" },
-        { prop = "date_min", name = "Date début" },
+        { prop = "taxons", name = "Taxon(s)" },
         { prop = "observateurs", name = "Observateurs" },
-        { prop = "dataset_name", name = "Jeu de données" }
+        { prop = "date", name = "Date" },
+        { prop = "dataset", name = "Jeu de données" },
     ]
 
-Voir la vue ``occtax.v_releve_list`` pour voir les champs disponibles.
+La clé prop de ces dictionnaire peut prendre les valeurs ``date``, ``nb_taxons``, ``taxons``, ``observateurs`` et ``dataset``.
+Elle peut également prendre le nom de n'importe quelle nom de colonne de la table ``t_releves_occtax``
+
+Le paramètre ``available_maplist_column`` contient quant à lui la liste totale des champs pouvant être affichés ou masqués dans ce tableau.
+Si un élément est présent dans ``default_maplist_columns`` mais pas dans ``available_maplist_column``, il sera toujours affiché et ne pourra pas être masqué.
 
 Ajouter une contrainte d'échelle de saisie sur la carte
 ```````````````````````````````````````````````````````


### PR DESCRIPTION
Cette PR supprime (pour les instances qui la possède) la table v_releve_list qui n'est plus utilisée depuis longtemps. On en profite pour màj la documentation sur les paramètres `default_maplist_columns` et `available_maplist_column` qui n'avait pas suivis les évolution d'occtax. 

Voir commentaire: https://github.com/PnX-SI/GeoNature/issues/690#issuecomment-4037849765 