### PR TITLE
fix(acquisition-frameworks.component): avoid two api calls on comp. init

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.html
+++ b/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.html
@@ -9,7 +9,7 @@
   [clearable]="clearable"
   [virtualScroll]="true"
   [formControl]="parentFormControl"
-  [loading]="(acquisitionFrameworks | async) === null"
+  [loading]="isLoading"
 >
   <ng-template
     ng-option-tmp

--- a/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.ts
+++ b/frontend/src/app/GN2CommonModule/form/acquisition-frameworks/acquisition-frameworks.component.ts
@@ -20,6 +20,8 @@ import { GenericFormComponent } from '@geonature_common/form/genericForm.compone
 })
 export class AcquisitionFrameworksComponent extends GenericFormComponent implements OnInit {
   @Input() acquisitionFrameworks: Observable<Array<any>>;
+  protected isLoading: Boolean = true;
+
   constructor(private _dfs: DataFormService) {
     super();
   }
@@ -36,6 +38,10 @@ export class AcquisitionFrameworksComponent extends GenericFormComponent impleme
         return data.items.sort((a, b) =>
           c.compare(a.acquisition_framework_name, b.acquisition_framework_name)
         );
+      }),
+      map((sortedData) => {
+        this.isLoading = false;
+        return sortedData;
       })
     );
   }


### PR DESCRIPTION
Évite d'effectuer deux appels API vers le endpoint `get_acquisition_frameworks`, c'est-à-dire un appel en double, lors de l'initialisation du composant `pnx-acquisition-frameworks`.

Cet appel en double se produisait notamment lors de l'accès au module Synthese, car le composant était initialisé pour la liste des AF dans le formulaire des filtres.