### PR TITLE
Feat/graph api mailer

### DIFF
--- a/backend/geonature/app.py
+++ b/backend/geonature/app.py
@@ -24,7 +24,8 @@ from werkzeug.wrappers import Response
 
 from geonature.utils.config import config
 
-from geonature.utils.env import MAIL, DB, db, MA, migrate, BACKEND_DIR
+from geonature.utils import utilsmails
+from geonature.utils.env import DB, db, MA, migrate, BACKEND_DIR
 from geonature.utils.logs import config_loggers
 from geonature.utils.module import iter_modules_dist
 from geonature.utils.json import MyJSONProvider
@@ -145,7 +146,7 @@ def create_app(with_external_mods=True):
         conf = app.config.copy()
         conf.update(app.config["MAIL_CONFIG"])
         app.config = conf
-        MAIL.init_app(app)
+        utilsmails.init_mailer(app)
 
     # Pass parameters to the usershub authenfication sub-module, DONT CHANGE THIS
     app.config["DB"] = DB

--- a/backend/geonature/utils/base_mail.py
+++ b/backend/geonature/utils/base_mail.py
@@ -1,0 +1,50 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List, Optional, Tuple, Union
+
+Recipient = Union[str, Tuple[str, str]]
+
+
+@dataclass
+class Message:
+    subject: str = ""
+    recipients: List[Recipient] = None
+    body: Optional[str] = None
+    html: Optional[str] = None
+    sender: Optional[str] = None
+
+    def __post_init__(self):
+        if self.recipients is None:
+            self.recipients = []
+
+
+class BaseMail(ABC):
+
+    def __init__(self, app=None):
+        if app:
+            self.init_app(app)
+
+    @abstractmethod
+    def init_app(self, app) -> None: ...
+
+    def connect(self):
+        return Connection(self)
+
+    @abstractmethod
+    def send(self, message: Message) -> None: ...
+
+
+class Connection:
+    """Context manager compatible avec Flask-Mail."""
+
+    def __init__(self, base: BaseMail):
+        self.base = base
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def send(self, message: Message):
+        return self.base.send(message)

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -71,6 +71,10 @@ class MailConfig(Schema):
     MAIL_SUPPRESS_SEND = fields.Boolean(required=False)
     MAIL_ASCII_ATTACHMENTS = fields.Boolean(required=False)
     ERROR_MAIL_TO = EmailStrOrListOfEmailStrField(load_default=None)
+    GRAPH_API_MAIL_TENANT_ID = fields.String(required=False)
+    GRAPH_API_MAIL_CLIENT_ID = fields.String(required=False)
+    GRAPH_API_MAIL_CLIENT_SECRET = fields.String(required=False)
+    GRAPH_API_MAIL_SCOPE = fields.String(required=False)
 
 
 class CeleryConfig(Schema):

--- a/backend/geonature/utils/env.py
+++ b/backend/geonature/utils/env.py
@@ -11,12 +11,8 @@ else:
 
 from flask_sqlalchemy import SQLAlchemy
 from flask_marshmallow import Marshmallow
-from flask_mail import Mail
 from flask_migrate import Migrate
 
-
-# Must be at top of this file. I don't know why (?)
-MAIL = Mail()
 
 # Define GEONATURE_VERSION before import config_shema module
 # because GEONATURE_VERSION is imported in this module

--- a/backend/geonature/utils/graph_api_mail.py
+++ b/backend/geonature/utils/graph_api_mail.py
@@ -1,0 +1,73 @@
+import requests
+
+from geonature.utils.base_mail import BaseMail, Message
+from typing import Any, Dict
+
+
+class GraphAPIMail(BaseMail):
+
+    def __init__(self, app=None):
+        self.tenant = None
+        self.client_id = None
+        self.client_secret = None
+        super().__init__(app)
+
+    def init_app(self, app) -> None:
+        self.tenant = app.config["GRAPH_API_MAIL_TENANT_ID"]
+        self.client_id = app.config["GRAPH_API_MAIL_CLIENT_ID"]
+        self.client_secret = app.config["GRAPH_API_MAIL_CLIENT_SECRET"]
+
+    def _get_token(self) -> str:
+        url = f"https://login.microsoftonline.com/{self.tenant}/oauth2/v2.0/token"
+        data = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "grant_type": "client_credentials",
+            "scope": "https://graph.microsoft.com/.default",
+        }
+
+        resp = requests.post(
+            url,
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=30,
+        )
+        if not resp.ok:
+            raise RuntimeError(f"Token endpoint error {resp.status_code}: {resp.text}")
+
+        return resp.json()["access_token"]
+
+    def _email_address(self, recipient: Any) -> Dict[str, Dict[str, str]]:
+        if isinstance(recipient, (tuple, list)):
+            return {"emailAddress": {"address": next((x for x in recipient[:2][::-1] if x), None)}}
+
+        return {"emailAddress": {"address": recipient}}
+
+    def send(self, message: Message) -> None:
+        sender = message.sender
+        if not sender:
+            raise ValueError("No sender defined (message.sender or MAIL_DEFAULT_SENDER).")
+
+        token = self._get_token()
+
+        mail = {
+            "message": {
+                "subject": message.subject,
+                "body": {
+                    "contentType": "HTML" if message.html else "Text",
+                    "content": message.html if message.html else (message.body or ""),
+                },
+                "toRecipients": [self._email_address(r) for r in message.recipients],
+            },
+            "saveToSentItems": True,
+        }
+
+        url = f"https://graph.microsoft.com/v1.0/users/{sender}/sendMail"
+        resp = requests.post(
+            url,
+            json=mail,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30,
+        )
+        if not resp.ok:
+            raise RuntimeError(f"Graph API error {resp.status_code}: {resp.text}")

--- a/backend/geonature/utils/utilsmails.py
+++ b/backend/geonature/utils/utilsmails.py
@@ -4,13 +4,25 @@ import logging
 
 from smtplib import SMTPException
 from flask import current_app
-from flask_mail import Message
+from flask_mail import Mail, Message
 
-from geonature.utils.env import MAIL
+from geonature.utils.graph_api_mail import GraphAPIMail
 
 log = logging.getLogger()
 
 name_address_email_regex = re.compile(r"^([^<]+)<([^>]+)>$", re.IGNORECASE)
+
+
+MAIL = None
+
+
+def init_mailer(app):
+    global MAIL
+    if app.config.get("GRAPH_API_MAIL_TENANT_ID"):
+        MAIL = GraphAPIMail()
+    else:
+        MAIL = Mail()
+    MAIL.init_app(app)
 
 
 def send_mail(recipients, subject, msg_html):

--- a/backend/geonature/utils/utilsmails.py
+++ b/backend/geonature/utils/utilsmails.py
@@ -4,9 +4,8 @@ import logging
 
 from smtplib import SMTPException
 from flask import current_app
-from flask_mail import Mail, Message
+from flask_mail import Message
 
-from geonature.utils.graph_api_mail import GraphAPIMail
 
 log = logging.getLogger()
 
@@ -19,8 +18,12 @@ MAIL = None
 def init_mailer(app):
     global MAIL
     if app.config.get("GRAPH_API_MAIL_TENANT_ID"):
+        from geonature.utils.graph_api_mail import GraphAPIMail
+
         MAIL = GraphAPIMail()
     else:
+        from flask_mail import Mail, Message
+
         MAIL = Mail()
     MAIL.init_app(app)
 

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -98,6 +98,11 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
     # Les espaces présents en début et fin de chaine ainsi qu'avant et
     # après les virgules sont ignorés.
     ERROR_MAIL_TO = ["Prénom NOM <email@email.com>", "email2@email.com"]
+    # GRAPH_API_MAIL_TENANT_ID = "<TENANT_ID>"
+    # GRAPH_API_MAIL_CLIENT_ID = "<CLIENT_ID>"
+    # GRAPH_API_MAIL_CLIENT_SECRET = "<CLIENT_SECRET>"
+    # GRAPH_API_MAIL_SCOPE = "https://graph.microsoft.com/.default"
+
 
 [BDD]
     id_area_type_municipality = 25

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -98,6 +98,8 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
     # Les espaces présents en début et fin de chaine ainsi qu'avant et
     # après les virgules sont ignorés.
     ERROR_MAIL_TO = ["Prénom NOM <email@email.com>", "email2@email.com"]
+    
+    # Configuration d'un serveur mail Microsoft GraphAPI
     # GRAPH_API_MAIL_TENANT_ID = "<TENANT_ID>"
     # GRAPH_API_MAIL_CLIENT_ID = "<CLIENT_ID>"
     # GRAPH_API_MAIL_CLIENT_SECRET = "<CLIENT_SECRET>"


### PR DESCRIPTION
Envoi d'e-mails via l’API Microsoft Graph au lieu de SMTP.
Création des classes GraphApiMail et BaseMail. GraphApiMail hérite de BaseMail.
Les futures classes d'envoi de mail pourront/devront aussi hériter de BaseMail afin de s'assurer que toutes les fonctions nécessaires soient implémentées.

cf issue: https://github.com/PnX-SI/GeoNature/issues/3811