### PR TITLE
Fix/sheets config

### DIFF
--- a/backend/geonature/core/gn_synthese/blueprints/taxon_info.py
+++ b/backend/geonature/core/gn_synthese/blueprints/taxon_info.py
@@ -245,7 +245,8 @@ if app.config["SYNTHESE"]["ENABLE_TAXON_SHEETS"]:
         """Return stats for a specific taxon"""
         area_type = request.args.get("area_type")
         field_separators = request.args.get(
-            "field_separators", app.config["SYNTHESE"]["FIELD_OBSERVERS_SEPARATORS"]
+            "field_separators",
+            app.config["SYNTHESE"]["FIELD_OBSERVERS_SEPARATORS"],
         )
         if not sheet.has_instance_permission(permissions=permissions):
             raise Forbidden
@@ -337,7 +338,8 @@ if app.config["SYNTHESE"]["TAXON_SHEET"]["ENABLE_TAB_OBSERVERS"]:
             "sort_order", PaginationSortingUtils.SortOrder.ASC, PaginationSortingUtils.SortOrder
         )
         field_separators = request.args.get(
-            "field_separators", app.config["SYNTHESE"]["FIELD_OBSERVERS_SEPARATORS"]
+            "field_separators",
+            app.config["SYNTHESE"]["FIELD_OBSERVERS_SEPARATORS"],
         )
         # Handle sorting
         if sort_by not in ["observer", "date_min", "date_max", "observation_count", "media_count"]:

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -309,6 +309,7 @@ class TaxonSheet(Schema):
 class ObserverSheet(Schema):
     # --------------------------------------------------------------------
     # SYNTHESE - OBSERVER_SHEET
+    ENABLE_TAB_OBSERVATIONS = fields.Boolean(load_default=True)
     ENABLE_TAB_TAXA = fields.Boolean(load_default=True)
     ENABLE_TAB_MEDIA = fields.Boolean(load_default=True)
 

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -299,6 +299,7 @@ class ExportObservationSchema(Schema):
 class TaxonSheet(Schema):
     # --------------------------------------------------------------------
     # SYNTHESE - TAXON_SHEET
+    ENABLE_TAB_OBSERVATIONS = fields.Boolean(load_default=True)
     ENABLE_TAB_OBSERVERS = fields.Boolean(load_default=True)
     ENABLE_TAB_PROFILE = fields.Boolean(load_default=True)
     ENABLE_TAB_TAXONOMY = fields.Boolean(load_default=True)

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -466,6 +466,8 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
     ENABLE_OBSERVER_SHEETS = true
     [SYNTHESE.OBSERVER_SHEET]
         # Options dédiées à la fiche observateur
+        # Permet d'activer ou non la section "Observations"
+        ENABLE_TAB_OBSERVATIONS = true
         # Permet d'activer ou non la section "Medias"
         ENABLE_TAB_MEDIA = true
         # Affiche la section overview

--- a/frontend/cypress/e2e/observer-sheet-tabs-config-spec.js
+++ b/frontend/cypress/e2e/observer-sheet-tabs-config-spec.js
@@ -1,0 +1,68 @@
+const OBSERVER_TABS = ['observations', 'taxa', 'medias'];
+
+describe('Observer sheet tabs configuration', () => {
+  beforeEach(() => {
+    cy.geonatureLogin();
+  });
+
+  it('should allow observer sheet access when ENABLE_OBSERVER_SHEETS is true', () => {
+    cy.interceptGlobalConfig({
+      SYNTHESE: {
+        ENABLE_OBSERVER_SHEETS: true,
+      },
+    });
+
+    cy.openObserverSheet();
+    cy.get('[data-qa="tabs-layout-nav"]').should('exist');
+  });
+
+  it('should redirect observer sheet access to 404 when ENABLE_OBSERVER_SHEETS is false', () => {
+    cy.interceptGlobalConfig({
+      SYNTHESE: {
+        ENABLE_OBSERVER_SHEETS: false,
+      },
+    });
+
+    cy.visit('/#/');
+    cy.wait('@globalConfig');
+
+    cy.window().then((win) => {
+      const currentUser = JSON.parse(win.localStorage.getItem('gn_current_user'));
+      cy.visit(`/#/synthese/observer/${currentUser.id_role}`);
+    });
+
+    cy.get('[data-qa="page-not-found-title"]').should('exist');
+  });
+
+  it('should display all observer sheet tabs when all flags are true', () => {
+    cy.interceptGlobalConfig({
+      SYNTHESE: {
+        ENABLE_OBSERVER_SHEETS: true,
+        OBSERVER_SHEET: {
+          ENABLE_TAB_OBSERVATIONS: true,
+          ENABLE_TAB_TAXA: true,
+          ENABLE_TAB_MEDIA: true,
+        },
+      },
+    });
+
+    cy.openObserverSheet();
+    cy.assertTabsVisible(OBSERVER_TABS);
+  });
+
+  it('should hide all observer sheet tabs when all flags are false', () => {
+    cy.interceptGlobalConfig({
+      SYNTHESE: {
+        ENABLE_OBSERVER_SHEETS: true,
+        OBSERVER_SHEET: {
+          ENABLE_TAB_OBSERVATIONS: false,
+          ENABLE_TAB_TAXA: false,
+          ENABLE_TAB_MEDIA: false,
+        },
+      },
+    });
+
+    cy.openObserverSheet();
+    cy.assertTabsHidden(OBSERVER_TABS);
+  });
+});

--- a/frontend/cypress/e2e/taxon-sheet-tabs-config-spec.js
+++ b/frontend/cypress/e2e/taxon-sheet-tabs-config-spec.js
@@ -1,0 +1,65 @@
+const TAXON_TABS = ['observations', 'taxonomy', 'observers', 'media', 'profile'];
+
+describe('Taxon sheet tabs configuration', () => {
+  beforeEach(() => {
+    cy.geonatureLogin();
+  });
+
+  it('should expose taxon sheet links when ENABLE_TAXON_SHEETS is true', () => {
+    cy.interceptGlobalConfig({
+      SYNTHESE: {
+        ENABLE_TAXON_SHEETS: true,
+      },
+    });
+
+    cy.openSyntheseList();
+    cy.get('[data-qa="synthese-list-taxon-sheet-link"]').should('exist');
+  });
+
+  it('should hide taxon sheet links when ENABLE_TAXON_SHEETS is false', () => {
+    cy.interceptGlobalConfig({
+      SYNTHESE: {
+        ENABLE_TAXON_SHEETS: false,
+      },
+    });
+
+    cy.openSyntheseList();
+    cy.get('[data-qa="synthese-list-taxon-sheet-link"]').should('not.exist');
+  });
+
+  it('should display all taxon sheet tabs when all flags are true', () => {
+    cy.interceptGlobalConfig({
+      SYNTHESE: {
+        ENABLE_TAXON_SHEETS: true,
+        TAXON_SHEET: {
+          ENABLE_TAB_OBSERVATIONS: true,
+          ENABLE_TAB_TAXONOMY: true,
+          ENABLE_TAB_OBSERVERS: true,
+          ENABLE_TAB_MEDIA: true,
+          ENABLE_TAB_PROFILE: true,
+        },
+      },
+    });
+
+    cy.openTaxonSheet();
+    cy.assertTabsVisible(TAXON_TABS);
+  });
+
+  it('should hide all taxon sheet tabs when all flags are false', () => {
+    cy.interceptGlobalConfig({
+      SYNTHESE: {
+        ENABLE_TAXON_SHEETS: true,
+        TAXON_SHEET: {
+          ENABLE_TAB_OBSERVATIONS: false,
+          ENABLE_TAB_TAXONOMY: false,
+          ENABLE_TAB_OBSERVERS: false,
+          ENABLE_TAB_MEDIA: false,
+          ENABLE_TAB_PROFILE: false,
+        },
+      },
+    });
+
+    cy.openTaxonSheet();
+    cy.assertTabsHidden(TAXON_TABS);
+  });
+});

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -1,3 +1,4 @@
 import './users';
 
 import './import';
+import './synthese';

--- a/frontend/cypress/support/synthese/assertTabsHidden.js
+++ b/frontend/cypress/support/synthese/assertTabsHidden.js
@@ -1,0 +1,7 @@
+Cypress.Commands.add('assertTabsHidden', (paths) => {
+  cy.get('[data-qa="tabs-layout-nav"]').within(() => {
+    paths.forEach((path) => {
+      cy.get(`[data-qa="tabs-layout-tab-${path}"]`).should('not.exist');
+    });
+  });
+});

--- a/frontend/cypress/support/synthese/assertTabsVisible.js
+++ b/frontend/cypress/support/synthese/assertTabsVisible.js
@@ -1,0 +1,7 @@
+Cypress.Commands.add('assertTabsVisible', (paths) => {
+  cy.get('[data-qa="tabs-layout-nav"]').within(() => {
+    paths.forEach((path) => {
+      cy.get(`[data-qa="tabs-layout-tab-${path}"]`).should('exist');
+    });
+  });
+});

--- a/frontend/cypress/support/synthese/index.js
+++ b/frontend/cypress/support/synthese/index.js
@@ -1,0 +1,6 @@
+import './interceptGlobalConfig';
+import './assertTabsVisible';
+import './assertTabsHidden';
+import './openSyntheseList';
+import './openTaxonSheet';
+import './openObserverSheet';

--- a/frontend/cypress/support/synthese/interceptGlobalConfig.js
+++ b/frontend/cypress/support/synthese/interceptGlobalConfig.js
@@ -1,0 +1,25 @@
+Cypress.Commands.add('interceptGlobalConfig', (overrides) => {
+  cy.request('GET', `${Cypress.env('apiEndpoint')}gn_commons/config`).then((response) => {
+    const config = response.body;
+    const syntheseOverrides = overrides.SYNTHESE || {};
+    const mockedConfig = {
+      ...config,
+      SYNTHESE: {
+        ...config.SYNTHESE,
+        ...syntheseOverrides,
+        TAXON_SHEET: {
+          ...config.SYNTHESE.TAXON_SHEET,
+          ...(syntheseOverrides.TAXON_SHEET || {}),
+        },
+        OBSERVER_SHEET: {
+          ...config.SYNTHESE.OBSERVER_SHEET,
+          ...(syntheseOverrides.OBSERVER_SHEET || {}),
+        },
+      },
+    };
+
+    cy.intercept('GET', `${Cypress.env('apiEndpoint')}gn_commons/config`, mockedConfig).as(
+      'globalConfig'
+    );
+  });
+});

--- a/frontend/cypress/support/synthese/interceptGlobalConfig.js
+++ b/frontend/cypress/support/synthese/interceptGlobalConfig.js
@@ -18,8 +18,6 @@ Cypress.Commands.add('interceptGlobalConfig', (overrides) => {
       },
     };
 
-    cy.intercept('GET', `${Cypress.env('apiEndpoint')}gn_commons/config`, mockedConfig).as(
-      'globalConfig'
-    );
+    cy.intercept('GET', '**/gn_commons/config*', mockedConfig).as('globalConfig');
   });
 });

--- a/frontend/cypress/support/synthese/openObserverSheet.js
+++ b/frontend/cypress/support/synthese/openObserverSheet.js
@@ -1,0 +1,11 @@
+Cypress.Commands.add('openObserverSheet', () => {
+  cy.visit('/#/');
+  cy.wait('@globalConfig');
+
+  cy.window().then((win) => {
+    const currentUser = JSON.parse(win.localStorage.getItem('gn_current_user'));
+    cy.visit(`/#/synthese/observer/${currentUser.id_role}`);
+  });
+
+  cy.location('hash').should('match', /#\/synthese\/observer\/.+/);
+});

--- a/frontend/cypress/support/synthese/openSyntheseList.js
+++ b/frontend/cypress/support/synthese/openSyntheseList.js
@@ -1,0 +1,4 @@
+Cypress.Commands.add('openSyntheseList', () => {
+  cy.visit('/#/synthese');
+  cy.wait('@globalConfig');
+});

--- a/frontend/cypress/support/synthese/openTaxonSheet.js
+++ b/frontend/cypress/support/synthese/openTaxonSheet.js
@@ -1,0 +1,12 @@
+Cypress.Commands.add('openTaxonSheet', () => {
+  cy.openSyntheseList();
+
+  cy.get('[data-qa="synthese-list-taxon-sheet-link"]')
+    .first()
+    .should('have.attr', 'href')
+    .then((href) => {
+      cy.visit(href);
+    });
+
+  cy.location('hash').should('match', /#\/synthese\/taxon\/.+/);
+});

--- a/frontend/src/app/GN2CommonModule/layouts/tabs-layout/tabs-layout.component.html
+++ b/frontend/src/app/GN2CommonModule/layouts/tabs-layout/tabs-layout.component.html
@@ -3,6 +3,7 @@
     mat-tab-nav-bar
     class="Tabs__navBar"
     [tabPanel]="tabPanel"
+    data-qa="tabs-layout-nav"
   >
     <a
       *ngFor="let tab of tabs"
@@ -11,6 +12,7 @@
       routerLinkActive
       #rla="routerLinkActive"
       [active]="rla.isActive"
+      [attr.data-qa]="'tabs-layout-tab-' + tab.path"
     >
       {{ tab.label }}
     </a>

--- a/frontend/src/app/components/page-not-found/page-not-found.component.html
+++ b/frontend/src/app/components/page-not-found/page-not-found.component.html
@@ -1,1 +1,1 @@
-<h1>Page Not Found 404!</h1>
+<h1 data-qa="page-not-found-title">Page Not Found 404!</h1>

--- a/frontend/src/app/syntheseModule/observer-sheet/observer-sheet.component.ts
+++ b/frontend/src/app/syntheseModule/observer-sheet/observer-sheet.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { GN2CommonModule } from '@geonature_common/GN2Common.module';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -61,6 +62,8 @@ export class ObserverSheetComponent extends Loadable implements OnInit {
   private readonly _destroy$ = new Subject<void>();
 
   constructor(
+    private _route: ActivatedRoute,
+    private _router: Router,
     public routes: ObserverSheetRouteService,
     private _oss: ObserverSheetService
   ) {
@@ -73,6 +76,13 @@ export class ObserverSheetComponent extends Loadable implements OnInit {
       if (observer) {
         this.startLoading();
         this.setIndicators(null);
+
+        if (!this._route.firstChild) {
+          const defaultTab = this.routes.TAB_LINKS[0]?.path;
+          if (defaultTab) {
+            this._router.navigate(['./', defaultTab], { relativeTo: this._route });
+          }
+        }
       }
     });
 

--- a/frontend/src/app/syntheseModule/observer-sheet/observer-sheet.component.ts
+++ b/frontend/src/app/syntheseModule/observer-sheet/observer-sheet.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { GN2CommonModule } from '@geonature_common/GN2Common.module';
 import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { CommonModule } from '@angular/common';
 import { InfosComponent } from './infos/infos.component';
@@ -76,13 +76,7 @@ export class ObserverSheetComponent extends Loadable implements OnInit {
       if (observer) {
         this.startLoading();
         this.setIndicators(null);
-
-        if (!this._route.firstChild) {
-          const defaultTab = this.routes.TAB_LINKS[0]?.path;
-          if (defaultTab) {
-            this._router.navigate(['./', defaultTab], { relativeTo: this._route });
-          }
-        }
+        this.redirectToDefaultTabIfNeeded();
       }
     });
 
@@ -94,6 +88,13 @@ export class ObserverSheetComponent extends Loadable implements OnInit {
         }
         this.setIndicators(stats);
       });
+
+    this._router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntil(this._destroy$)
+      )
+      .subscribe(() => this.redirectToDefaultTabIfNeeded());
   }
 
   ngOnDestroy(): void {
@@ -105,5 +106,16 @@ export class ObserverSheetComponent extends Loadable implements OnInit {
     this.indicators = INDICATORS.map((indicatorConfig: IndicatorDescription) =>
       computeIndicatorFromStats(indicatorConfig, stats)
     );
+  }
+
+  private redirectToDefaultTabIfNeeded() {
+    if (!this.observer || this._route.firstChild) {
+      return;
+    }
+
+    const defaultTab = this.routes.TAB_LINKS[0]?.path;
+    if (defaultTab) {
+      this._router.navigate(['./', defaultTab], { relativeTo: this._route });
+    }
   }
 }

--- a/frontend/src/app/syntheseModule/observer-sheet/observer-sheet.route.service.ts
+++ b/frontend/src/app/syntheseModule/observer-sheet/observer-sheet.route.service.ts
@@ -65,6 +65,11 @@ export class ObserverSheetRouteService implements CanActivate, CanActivateChild 
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+    if (!this._config['SYNTHESE']?.['ENABLE_OBSERVER_SHEETS']) {
+      this._router.navigate(['/404'], { skipLocationChange: true });
+      return of(false);
+    }
+
     return this._loadObserver(route).pipe(
       tap((observer) => this._oss.setObserver(observer)),
       map(() => true),

--- a/frontend/src/app/syntheseModule/observer-sheet/observer-sheet.route.service.ts
+++ b/frontend/src/app/syntheseModule/observer-sheet/observer-sheet.route.service.ts
@@ -26,7 +26,7 @@ export const ALL_OBSERVERS_ADVANCED_INFOS_ROUTES: Array<ChildRouteDescription> =
     label: 'Observations',
     path: 'observations',
     component: ObservationsComponent,
-    configEnabledField: null, // make it always available !
+    configEnabledField: 'ENABLE_TAB_OBSERVATIONS',
   },
   {
     label: 'Taxons',

--- a/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.html
+++ b/frontend/src/app/syntheseModule/synthese-results/synthese-list/synthese-list.component.html
@@ -99,6 +99,7 @@
           <a
             class="Link"
             [routerLink]="getTaxonSheetUrl(row.cd_nom)"
+            data-qa="synthese-list-taxon-sheet-link"
             *ngIf="
               config.SYNTHESE.ENABLE_TAXON_SHEETS && row.hasOwnProperty('cd_nom');
               else cellDefault

--- a/frontend/src/app/syntheseModule/synthese.module.ts
+++ b/frontend/src/app/syntheseModule/synthese.module.ts
@@ -66,16 +66,6 @@ const routes: Routes = [
     canActivate: [ObserverSheetRouteService],
     canActivateChild: [ObserverSheetRouteService],
     children: [
-      // auto redirect to the first mandatory tab
-      {
-        path: '',
-        redirectTo: ALL_OBSERVERS_ADVANCED_INFOS_ROUTES.find(
-          (path) => path.configEnabledField === null
-        ).path,
-        pathMatch: 'full',
-      },
-      // The tabs are all optional. therefore, we can't apply redireciotn here.
-      // A redirection from parent to child is apply in canActivate
       ...ALL_OBSERVERS_ADVANCED_INFOS_ROUTES.map((tab) => {
         return {
           path: tab.path,

--- a/frontend/src/app/syntheseModule/synthese.module.ts
+++ b/frontend/src/app/syntheseModule/synthese.module.ts
@@ -52,14 +52,6 @@ const routes: Routes = [
     canActivate: [TaxonSheetRouteService],
     canActivateChild: [TaxonSheetRouteService],
     children: [
-      // auto redirect to the first mandatory tab
-      {
-        path: '',
-        redirectTo: ALL_TAXON_SHEET_ADVANCED_INFOS_ROUTES.find(
-          (path) => path.configEnabledField === null
-        ).path,
-        pathMatch: 'full',
-      },
       ...ALL_TAXON_SHEET_ADVANCED_INFOS_ROUTES.map((tab) => {
         return {
           path: tab.path,

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { GN2CommonModule } from '@geonature_common/GN2Common.module';
 import { InfosComponent } from './infos/infos.component';
 import {
@@ -15,6 +15,8 @@ import { CD_REF_PARAM_NAME, TaxonSheetRouteService } from './taxon-sheet.route.s
 import { Taxon } from '@geonature_common/form/taxonomy/taxonomy.component';
 import { Loadable } from '../sheets/loadable';
 import { ObservationsFiltersService } from '../sheets/observations/observations-filters.service';
+import { Subject } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 const INDICATORS: Array<IndicatorDescription> = [
   {
@@ -59,6 +61,7 @@ const INDICATORS: Array<IndicatorDescription> = [
 })
 export class TaxonSheetComponent extends Loadable implements OnInit {
   taxon: Taxon | null = null;
+  private readonly _destroy$ = new Subject<void>();
 
   get isLoadingIndicators() {
     return this.isLoading;
@@ -76,35 +79,52 @@ export class TaxonSheetComponent extends Loadable implements OnInit {
   }
 
   ngOnInit() {
-    this._tss.taxon.subscribe((taxon: Taxon | null) => {
+    this._tss.taxon.pipe(takeUntil(this._destroy$)).subscribe((taxon: Taxon | null) => {
       this.taxon = taxon;
     });
 
-    this._tss.taxonStats.subscribe((stats: TaxonStats | null) => {
+    this._tss.taxonStats.pipe(takeUntil(this._destroy$)).subscribe((stats: TaxonStats | null) => {
       this.stopLoading();
       this.setIndicators(stats);
     });
 
-    this._route.params.subscribe((params) => {
+    this._route.params.pipe(takeUntil(this._destroy$)).subscribe((params) => {
       const cd_ref = params[CD_REF_PARAM_NAME];
       if (cd_ref) {
         this.startLoading();
         this.setIndicators(null);
         this._tss.fetchTaxonByCdRef(cd_ref);
-
-        if (!this._route.firstChild) {
-          const defaultTab = this.routes.TAB_LINKS[0]?.path;
-          if (defaultTab) {
-            this._router.navigate(['./', defaultTab], { relativeTo: this._route });
-          }
-        }
+        this.redirectToDefaultTabIfNeeded();
       }
     });
+
+    this._router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntil(this._destroy$)
+      )
+      .subscribe(() => this.redirectToDefaultTabIfNeeded());
+  }
+
+  ngOnDestroy(): void {
+    this._destroy$.next();
+    this._destroy$.complete();
   }
 
   setIndicators(stats: any) {
     this.indicators = INDICATORS.map((indicatorConfig: IndicatorDescription) =>
       computeIndicatorFromStats(indicatorConfig, stats)
     );
+  }
+
+  private redirectToDefaultTabIfNeeded() {
+    if (!this._route.snapshot.params[CD_REF_PARAM_NAME] || this._route.firstChild) {
+      return;
+    }
+
+    const defaultTab = this.routes.TAB_LINKS[0]?.path;
+    if (defaultTab) {
+      this._router.navigate(['./', defaultTab], { relativeTo: this._route });
+    }
   }
 }

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { GN2CommonModule } from '@geonature_common/GN2Common.module';
 import { InfosComponent } from './infos/infos.component';
 import {
@@ -68,6 +68,7 @@ export class TaxonSheetComponent extends Loadable implements OnInit {
 
   constructor(
     private _route: ActivatedRoute,
+    private _router: Router,
     private _tss: TaxonSheetService,
     public routes: TaxonSheetRouteService
   ) {
@@ -90,6 +91,13 @@ export class TaxonSheetComponent extends Loadable implements OnInit {
         this.startLoading();
         this.setIndicators(null);
         this._tss.fetchTaxonByCdRef(cd_ref);
+
+        if (!this._route.firstChild) {
+          const defaultTab = this.routes.TAB_LINKS[0]?.path;
+          if (defaultTab) {
+            this._router.navigate(['./', defaultTab], { relativeTo: this._route });
+          }
+        }
       }
     });
   }

--- a/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.route.service.ts
+++ b/frontend/src/app/syntheseModule/taxon-sheet/taxon-sheet.route.service.ts
@@ -26,7 +26,7 @@ export const ALL_TAXON_SHEET_ADVANCED_INFOS_ROUTES: Array<ChildRouteDescription>
   {
     label: 'Observations',
     path: 'observations',
-    configEnabledField: null, // make it always available !
+    configEnabledField: 'ENABLE_TAB_OBSERVATIONS',
     component: ObservationsComponent,
   },
   {


### PR DESCRIPTION
Closes #3997

Il y avait effectivement un réglage étrange au niveau de TAXON_SHEET, et une dissonance avec le fichier example. 

Au passage, j'ai fait une petite évolution de la gestion des configs. Il y avait une mécanique de redirection automatique vers le premier onglet enable qui était faite manuellement.
Depuis, j'ai découvert l'attribut "firstChild",  qui fluidifie tout. Appliqué sur fiche espèce et fiche observateur. 

Pour être sur, j'ai rajouté les test frontend qui permettent de valider la prise en compte de la config. Il y a notamment un intercept de config global pour l'éditer à la volée qui est intéressante. 
