### PR TITLE
fix: enhance zonage display: sort by name, including numeric order

### DIFF
--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.ts
@@ -199,6 +199,7 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
         for (const key in areaDict) {
           this.formatedAreas.push({ area_type: key, areas: areaDict[key] });
         }
+        this.formatedAreas.sort((a, b) => a.area_type.localeCompare(b.area_type, undefined, { numeric: true }));
 
         if (this.selectedObs['unique_id_sinp']) {
           this.loadValidationHistory(this.selectedObs['unique_id_sinp']);

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.ts
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.ts
@@ -199,7 +199,9 @@ export class SyntheseInfoObsComponent implements OnInit, OnChanges {
         for (const key in areaDict) {
           this.formatedAreas.push({ area_type: key, areas: areaDict[key] });
         }
-        this.formatedAreas.sort((a, b) => a.area_type.localeCompare(b.area_type, undefined, { numeric: true }));
+        this.formatedAreas.sort((a, b) =>
+          a.area_type.localeCompare(b.area_type, undefined, { numeric: true })
+        );
 
         if (this.selectedObs['unique_id_sinp']) {
           this.loadValidationHistory(this.selectedObs['unique_id_sinp']);


### PR DESCRIPTION
Closes #4041

Rajouter un tri à l'affichage, qui prennent en compte les valeurs numériques.

<img width="1011" height="375" alt="image" src="https://github.com/user-attachments/assets/02516820-a5c0-4389-a070-2d9cc6397531" />
