### PR TITLE
fix(import): ensure errors get displayed in import pdf report

### DIFF
--- a/backend/geonature/core/imports/models.py
+++ b/backend/geonature/core/imports/models.py
@@ -346,6 +346,8 @@ cor_role_import = db.Table(
         "destination.label",
         "destination.statistics_labels",
         "destination.module",
+        "errors.type",
+        "errors.entity",
     ]
 )
 class TImports(InstancePermissionMixin, db.Model):


### PR DESCRIPTION
The attribute `errors` would not be output by SQLAlchemy query serialization because two relationship attributes were missing in the corresponding @seriailize decorator.

Fix #4045