### PR TITLE
fix(frontend) : observations tab first loading

### DIFF
--- a/frontend/src/app/syntheseModule/sheets/observations/observations-filters.service.ts
+++ b/frontend/src/app/syntheseModule/sheets/observations/observations-filters.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@geonature/services/config.service';
 import { SheetStats } from '@geonature_common/form/synthese-form/synthese-data.service';
 import { BehaviorSubject } from 'rxjs';
 
-export type Filters = Record<string, string | number | number[]>;
+export type Filters = Record<string, string | number | number[]> | null;
 
 export interface YearInterval {
   min: number;
@@ -13,7 +13,7 @@ export interface YearInterval {
 @Injectable()
 export class ObservationsFiltersService {
   // Filter - can hold  filter by observer, taxon, etc.
-  filters: BehaviorSubject<Filters> = new BehaviorSubject<Filters>({});
+  filters: BehaviorSubject<Filters> = new BehaviorSubject<Filters>(null);
 
   // Filter - yearInterval management - reference, and user setup
   yearIntervalBoundaries: BehaviorSubject<YearInterval | null> =

--- a/frontend/src/app/syntheseModule/sheets/observations/observations.component.ts
+++ b/frontend/src/app/syntheseModule/sheets/observations/observations.component.ts
@@ -34,8 +34,8 @@ interface MapAreasStyle {
 export class ObservationsComponent extends Loadable implements OnInit {
   areasEnable: boolean;
   areasLegend: any;
-  private _areasLabelSwitchBtn;
-  styleTabGeoJson: {};
+  private _areasLabelSwitchBtn: any;
+  styleTabGeoJson: any = {};
 
   yearInterval: YearInterval | null = null;
   yearIntervalBoundaries: YearInterval | null = null;
@@ -74,12 +74,11 @@ export class ObservationsComponent extends Loadable implements OnInit {
 
   ngOnInit() {
     this._os.filters.subscribe((filters: Filters | null) => {
-      if (!filters) {
+      if (filters == null) {
         this.styleTabGeoJson = undefined;
         this.clearObservationLayers();
         return;
-      }
-      if (filters.cd_ref || filters.cd_ref_parent) {
+      } else {
         this.updateObservations();
       }
     });
@@ -93,6 +92,7 @@ export class ObservationsComponent extends Loadable implements OnInit {
   }
 
   updateObservations() {
+    console.log('updateObservations');
     this.startLoading();
 
     const format = this.areasEnable ? 'grouped_geom_by_areas' : 'grouped_geom';
@@ -285,6 +285,7 @@ export class ObservationsComponent extends Loadable implements OnInit {
 
   private clearObservationLayers() {
     const map = this._ms.map;
+    if (!map) return;
     map.eachLayer((layer) => {
       if (!(layer instanceof L.TileLayer)) {
         map.removeLayer(layer);

--- a/frontend/src/app/syntheseModule/sheets/observations/observations.component.ts
+++ b/frontend/src/app/syntheseModule/sheets/observations/observations.component.ts
@@ -92,7 +92,6 @@ export class ObservationsComponent extends Loadable implements OnInit {
   }
 
   updateObservations() {
-    console.log('updateObservations');
     this.startLoading();
 
     const format = this.areasEnable ? 'grouped_geom_by_areas' : 'grouped_geom';


### PR DESCRIPTION
This PR fix the map initialization of the "Observations" tab in both the taxon sheet and the observer sheet