### PR TITLE
Doc https usershub variables change mention

### DIFF
--- a/docs/https.rst
+++ b/docs/https.rst
@@ -94,4 +94,24 @@ Modifier les éléments suivants :
 
 Pour que ces modifications soient prises en compte, exécuter les :ref:`actions à effecture après modification de la configuration <post_config_change>`.
 
+Configuration de l'application UsersHub
+---------------------------------------
+
+Il est aussi nécessaire de mettre à jour les fichiers de configuration de
+UsersHub avec les nouvelles urls en "https" dans ~/usershub/config/config.py :
+
+.. code:: python
+	
+  URL_APPLICATION = 'https://mondomaine.fr/usershub'
+
+
+et dans ~/usershub/config/settings.in :
+
+.. code:: ini
+>
+  url_application=https://mondomaine.fr/usershub
+
+
+Puis de suivre les instructions de l’installation de UsersHub
+
 Les applications sont désormais accessibles sur votre domaine sécurisé en HTTPS !

--- a/docs/https.rst
+++ b/docs/https.rst
@@ -107,8 +107,10 @@ UsersHub avec les nouvelles urls en "https" dans ~/usershub/config/config.py :
 
 et dans ~/usershub/config/settings.ini :
 
-::
+.. code-block::
+
   url_application=https://mondomaine.fr/usershub
+
 
 
 Puis de suivre les instructions de l’installation de UsersHub

--- a/docs/https.rst
+++ b/docs/https.rst
@@ -108,7 +108,6 @@ UsersHub avec les nouvelles urls en "https" dans ~/usershub/config/config.py :
 et dans ~/usershub/config/settings.ini :
 
 ::
->
   url_application=https://mondomaine.fr/usershub
 
 

--- a/docs/https.rst
+++ b/docs/https.rst
@@ -107,7 +107,8 @@ UsersHub avec les nouvelles urls en "https" dans ~/usershub/config/config.py :
 
 et dans ~/usershub/config/settings.ini :
 
-.. code-block:: ini
+::
+>
   url_application=https://mondomaine.fr/usershub
 
 

--- a/docs/https.rst
+++ b/docs/https.rst
@@ -105,10 +105,9 @@ UsersHub avec les nouvelles urls en "https" dans ~/usershub/config/config.py :
   URL_APPLICATION = 'https://mondomaine.fr/usershub'
 
 
-et dans ~/usershub/config/settings.in :
+et dans ~/usershub/config/settings.ini :
 
-.. code:: ini
->
+.. code-block:: ini
   url_application=https://mondomaine.fr/usershub
 
 


### PR DESCRIPTION
I added a few lines in the doc to mention that UsersHub needs to be updated after certbot with https urls