### PR TITLE
Feat/add organism to nav display 

### DIFF
--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -288,6 +288,8 @@ class GnFrontEndConf(Schema):
     DISPLAY_EMAIL_INFO_OBS = fields.Boolean(load_default=True)
     DISPLAY_EMAIL_DISPLAY_INFO = fields.List(fields.String(), load_default=["NOM_VERN"])
 
+    DISPLAY_USER_ORGANISM = fields.Boolean(load_default=True)
+
 
 class ExportObservationSchema(Schema):
     label = fields.String(required=True)

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -146,6 +146,9 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
     # Activer l'affichage des informations liées aux profils de taxons (dans les modules Validation, Synthèse et Occtax)
     ENABLE_PROFILES = true
 
+    # Afficher l'organisme de l'utilisateur dans la barre de navigation (true / false)
+    DISPLAY_USER_ORGANISM = true
+
 # Configuration des paramètres des permissions
 [PERMISSIONS]
     # Types de zonages accessibles pour les filtres géographiques

--- a/frontend/src/app/components/auth/auth.service.ts
+++ b/frontend/src/app/components/auth/auth.service.ts
@@ -16,6 +16,7 @@ export interface User {
   user_login: string;
   id_role: string;
   id_organisme: number;
+  nom_organisme?: string;
   prenom_role?: string;
   nom_role?: string;
   nom_complet?: string;
@@ -99,6 +100,7 @@ export class AuthService {
       nom_role: data.user.nom_role,
       nom_complet: data.user.nom_role + ' ' + data.user.prenom_role,
       id_organisme: data.user.id_organisme,
+      nom_organisme: data.user.organisme?.nom_organisme,
       providers: data.user.providers.map((provider) => provider.name),
     };
     this.setCurrentUser(userForFront);

--- a/frontend/src/app/components/nav-home/nav-home.component.html
+++ b/frontend/src/app/components/nav-home/nav-home.component.html
@@ -66,7 +66,12 @@
             <mat-icon>person</mat-icon>
             <div class="user-info">
               <div class="user-info__name">{{ displayName }}</div>
-              <div *ngIf="displayOrganism" class="user-info__organism">{{ displayOrganism }}</div>
+              <div
+                *ngIf="displayOrganism"
+                class="user-info__organism"
+              >
+                {{ displayOrganism }}
+              </div>
             </div>
           </button>
 
@@ -108,7 +113,12 @@
             <mat-icon>person</mat-icon>
             <div class="user-info">
               <div class="user-info__name">{{ displayName }}</div>
-              <div *ngIf="displayOrganism" class="user-info__organism">{{ displayOrganism }}</div>
+              <div
+                *ngIf="displayOrganism"
+                class="user-info__organism"
+              >
+                {{ displayOrganism }}
+              </div>
             </div>
           </div>
         </ng-template>

--- a/frontend/src/app/components/nav-home/nav-home.component.html
+++ b/frontend/src/app/components/nav-home/nav-home.component.html
@@ -58,13 +58,16 @@
           "
         >
           <button
-            class="mx-1"
+            class="user-button mx-1"
             mat-raised-button
             matTooltip="Ouvrir le menu de mon profil"
             [matMenuTriggerFor]="userMenu"
           >
             <mat-icon>person</mat-icon>
-            <span class="user-name">{{ displayName }}</span>
+            <div class="user-info">
+              <div class="user-info__name">{{ displayName }}</div>
+              <div *ngIf="displayOrganism" class="user-info__organism">{{ displayOrganism }}</div>
+            </div>
           </button>
 
           <mat-menu #userMenu>
@@ -103,7 +106,10 @@
         <ng-template #userDisplay>
           <div class="UserDisplay">
             <mat-icon>person</mat-icon>
-            <span class="user-name">{{ displayName }}</span>
+            <div class="user-info">
+              <div class="user-info__name">{{ displayName }}</div>
+              <div *ngIf="displayOrganism" class="user-info__organism">{{ displayOrganism }}</div>
+            </div>
           </div>
         </ng-template>
 

--- a/frontend/src/app/components/nav-home/nav-home.component.scss
+++ b/frontend/src/app/components/nav-home/nav-home.component.scss
@@ -21,12 +21,19 @@
     align-items: flex-start;
     line-height: 1.2;
     &__name {
+      min-width: 200px;
       font-size: 15px;
+      padding-right: 1rem;
     }
     &__organism {
       font-size: 0.8em;
       color: inherit;
       opacity: 0.5;
+      width: 0;
+      min-width: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
   }
   #documentation_link {
@@ -51,4 +58,5 @@
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
+  column-gap: 0.5rem;
 }

--- a/frontend/src/app/components/nav-home/nav-home.component.scss
+++ b/frontend/src/app/components/nav-home/nav-home.component.scss
@@ -12,23 +12,23 @@
     background-color: white !important;
     outline: none;
   }
-  .user-button{
+  .user-button {
     height: 40px;
   }
   .user-info {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      line-height: 1.2;
-      &__name {
-        font-size: 15px;
-      }
-      &__organism {
-        font-size: 0.8em;
-        color: inherit;
-        opacity: 0.5;
-      }
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.2;
+    &__name {
+      font-size: 15px;
     }
+    &__organism {
+      font-size: 0.8em;
+      color: inherit;
+      opacity: 0.5;
+    }
+  }
   #documentation_link {
     color: black !important;
   }

--- a/frontend/src/app/components/nav-home/nav-home.component.scss
+++ b/frontend/src/app/components/nav-home/nav-home.component.scss
@@ -14,26 +14,29 @@
   }
   .user-button {
     height: 40px;
+    text-align: start;
   }
   .user-info {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     line-height: 1.2;
+    max-width: 400px;
+    &__name,
+    &__organism {
+      width: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
     &__name {
-      min-width: 200px;
       font-size: 15px;
-      padding-right: 1rem;
+      padding-right: 0.5rem;
     }
     &__organism {
       font-size: 0.8em;
       color: inherit;
       opacity: 0.5;
-      width: 0;
-      min-width: 100%;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
     }
   }
   #documentation_link {

--- a/frontend/src/app/components/nav-home/nav-home.component.scss
+++ b/frontend/src/app/components/nav-home/nav-home.component.scss
@@ -12,9 +12,23 @@
     background-color: white !important;
     outline: none;
   }
-  .user-name {
-    font-size: 15px;
+  .user-button{
+    height: 40px;
   }
+  .user-info {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+      &__name {
+        font-size: 15px;
+      }
+      &__organism {
+        font-size: 0.8em;
+        color: inherit;
+        opacity: 0.5;
+      }
+    }
   #documentation_link {
     color: black !important;
   }

--- a/frontend/src/app/components/nav-home/nav-home.component.ts
+++ b/frontend/src/app/components/nav-home/nav-home.component.ts
@@ -48,6 +48,7 @@ export class NavHomeComponent implements OnInit {
   }
 
   get displayOrganism(): string | null {
+    if (!this.config.FRONTEND.DISPLAY_USER_ORGANISM) return null;
     return this.currentUser?.nom_organisme ?? null;
   }
 

--- a/frontend/src/app/components/nav-home/nav-home.component.ts
+++ b/frontend/src/app/components/nav-home/nav-home.component.ts
@@ -43,8 +43,8 @@ export class NavHomeComponent implements OnInit {
   }
 
   get displayName(): string {
-    const { prenom_role, nom_role, user_login } = this.currentUser ?? {};
-    return prenom_role && nom_role ? `${prenom_role} ${nom_role}` : user_login;
+    const { nom_complet, user_login } = this.currentUser ?? {};
+    return nom_complet ? nom_complet : user_login;
   }
 
   ngOnInit() {

--- a/frontend/src/app/components/nav-home/nav-home.component.ts
+++ b/frontend/src/app/components/nav-home/nav-home.component.ts
@@ -47,6 +47,10 @@ export class NavHomeComponent implements OnInit {
     return nom_complet ? nom_complet : user_login;
   }
 
+  get displayOrganism(): string | null {
+    return this.currentUser?.nom_organisme ?? null;
+  }
+
   ngOnInit() {
     // Set the current module name in the navbar
     this.onModuleChange();


### PR DESCRIPTION
Dans le cadre de l'issue: https://github.com/PnX-SI/GeoNature/issues/4043

PR liée: https://github.com/PnX-SI/UsersHub-authentification-module/pull/159
Cette PR rajoute le nom de l'organisme dans le résultat de la requête "get_user_data"

Je n'ai pas su sur quel exemple de style m'appuyé, j'ai proposé quelque chose

## menu User activé

### Organisme éxiste

<img width="895" height="637" alt="image" src="https://github.com/user-attachments/assets/3164e5da-cfc0-43c8-b5e1-f8571265b712" />

### Organisme n'existe pas "id_organisme = -1"
<img width="338" height="212" alt="image" src="https://github.com/user-attachments/assets/c9aaad6f-7f38-4f8c-9ea6-dddd8b78bbf2" />

## menu user désactivé

### Organisme existe

<img width="736" height="356" alt="image" src="https://github.com/user-attachments/assets/ed96ea92-707d-4357-b9ab-bce8ef8ee7f6" />

### Organisme n'existe pas "id_organisme = -1"

<img width="549" height="393" alt="image" src="https://github.com/user-attachments/assets/a1a69163-7130-4ec8-a6e0-bbf919c57976" />
