### PR TITLE
fix synthese fixtures srid

### DIFF
--- a/backend/geonature/tests/fixtures.py
+++ b/backend/geonature/tests/fixtures.py
@@ -47,11 +47,11 @@ from pypnusershub.db.models import Application, Organisme
 from pypnusershub.db.models import Profils as Profil
 from pypnusershub.db.models import User, UserApplicationRight
 from ref_geo.models import BibAreasTypes, LAreas
+from ref_geo.utils import get_local_srid
 from utils_flask_sqla.tests.utils import JSONClient
 from werkzeug.datastructures import Headers
 
 from .utils import get_id_nomenclature
-
 
 __all__ = [
     "datasets",
@@ -586,7 +586,7 @@ def create_synthese(
         cd_hab=3,
         the_geom_4326=geom,
         the_geom_point=geom,
-        the_geom_local=func.ST_Transform(geom, 2154),  # FIXME
+        the_geom_local=func.ST_Transform(geom, get_local_srid(db.session)),
         date_min=date_min,
         date_max=date_max,
         altitude_min=altitude_min,


### PR DESCRIPTION
Mes tests ne passe pas localement avec une base de données installée en SRID 4326. J’ai l’impression que les tests sont écrit pour ne passer qu’avec une base en 2154. Cette PR est censé aller vers des tests qui passe peu importe le SRID, mais il reste des soucis semble-t-il …