### PR TITLE
feat: extend install script to facilitate multi-instance on a same server

### DIFF
--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -66,7 +66,7 @@ TRAP_ALL_EXCEPTIONS = false
 PUBLIC_ACCESS_USERNAME = ""
 
 # Active (=true) ou pas (=false) l'envoi d'email pour chaque erreur du backend de GeoNature
-# Attention : si activé, il est nécessaire de remplir la secetion 'MAIL_CONFIG'.
+# Attention : si activé, il est nécessaire de remplir la section 'MAIL_CONFIG'.
 MAIL_ON_ERROR = false
 
 # Notifications (true / false)

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -2,6 +2,10 @@
 
 # Set mode to 'dev' to install GeoNature in dev mode
 MODE=prod
+GEONATURE_APP_NAME="geonature"
+BACKEND_PORT=8000
+DOMAIN_NAME="localhost"
+
 
 # Langue du serveur
 # valeur possible : fr_FR.UTF-8, en_US.utf8 

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -16,7 +16,7 @@ my_local=fr_FR.UTF-8
 # Protocole pour accéder à GeoNature (http ou https)
 host_protocol=http
 # Nom de domaine pour accéder à GeoNature (sans http ni / à la fin)
-domaine_name="localhost"
+domain_name="localhost"
 # subpath d'accès à GeoNature (ex: /geonature donnera http://<domain_name>/geonature)
 base_path="/geonature"
 
@@ -25,6 +25,10 @@ base_path="/geonature"
 # Port du backend de GeoNature. Si vous installez plusieurs instances de GeoNature sur le même serveur,
 # il faudra leur attribuer des ports différent.
 backend_port=8000
+
+# Usershub (Pour migration.sh, à compléter)
+
+usershub_app_name="usershub"
 
 # PostgreSQL Configuration
 ##########################

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -3,21 +3,28 @@
 # Set mode to 'dev' to install GeoNature in dev mode
 MODE=prod
 geonature_app_name="geonature"
-backend_port=8000
-domaine__name="localhost"
 
 
-# Langue du serveur
-# valeur possible : fr_FR.UTF-8, en_US.utf8 
+# Langue du serveur - Valeurs possibles : fr_FR.UTF-8, en_US.utf8 
 # locale -a pour voir la liste des locales disponible
+
 my_local=fr_FR.UTF-8
 
 # URL Configuration
 ###################
 
-# My host URL or IP, starting with http and with / at the end
-my_url=http://url.com/
+# Protocole pour accéder à GeoNature (http ou https)
+host_protocol=http
+# Nom de domaine pour accéder à GeoNature (sans http ni / à la fin)
+domaine_name="localhost"
+# subpath d'accès à GeoNature (ex: /geonature donnera http://<domain_name>/geonature)
+base_path="/geonature"
 
+# Backend 
+#########
+# Port du backend de GeoNature. Si vous installez plusieurs instances de GeoNature sur le même serveur,
+# il faudra leur attribuer des ports différent.
+backend_port=8000
 
 # PostgreSQL Configuration
 ##########################

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -2,9 +2,9 @@
 
 # Set mode to 'dev' to install GeoNature in dev mode
 MODE=prod
-GEONATURE_APP_NAME="geonature"
-BACKEND_PORT=8000
-DOMAIN_NAME="localhost"
+geonature_app_name="geonature"
+backend_port=8000
+domaine__name="localhost"
 
 
 # Langue du serveur

--- a/install/01_install_backend.sh
+++ b/install/01_install_backend.sh
@@ -48,6 +48,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 parseScriptOptions "${@}"
 
 
+my_url="${host_protocol}://${domain_name}${base_path}/"
+api_endpoint="${host_protocol}://${domain_name}${base_path}/api"
+
 cd "${BASE_DIR}"
 
 if [ -f config/geonature_config.toml ]; then
@@ -57,8 +60,8 @@ else
   cp config/geonature_config.toml.sample config/geonature_config.toml
   echo "Préparation du fichier de configuration..."
   sed -i "s|^SQLALCHEMY_DATABASE_URI = .*$|SQLALCHEMY_DATABASE_URI = \"postgresql:\/\/$user_pg:$user_pg_pass@$db_host:$db_port\/$db_name?application_name=geonature\"|" config/geonature_config.toml
-  sed -i "s|^URL_APPLICATION = .*$|URL_APPLICATION = '${my_url}geonature'|" config/geonature_config.toml
-  sed -i "s|^API_ENDPOINT = .*$|API_ENDPOINT = '${my_url}geonature\/api'|" config/geonature_config.toml 
+  sed -i "s|^URL_APPLICATION = .*$|URL_APPLICATION = '${my_url}'|" config/geonature_config.toml
+  sed -i "s|^API_ENDPOINT = .*$|API_ENDPOINT = '${api_endpoint}'|" config/geonature_config.toml
   sed -i "s|^SECRET_KEY = .*$|SECRET_KEY = '`openssl rand -hex 16`'|" config/geonature_config.toml
   sed -i "s|^DEFAULT_LANGUAGE = .*$|DEFAULT_LANGUAGE = '${default_language}'|" config/geonature_config.toml
   sed -i "s|^SECRET_KEY = .*$|SECRET_KEY = '`openssl rand -hex 32`'|" config/geonature_config.toml

--- a/install/01_install_backend.sh
+++ b/install/01_install_backend.sh
@@ -53,6 +53,18 @@ api_endpoint="${host_protocol}://${domain_name}${base_path}/api"
 
 cd "${BASE_DIR}"
 
+# for compatibility with multiple_instances_base_install :
+if [ -z "$usershub_app_name" ]; then
+    usershub_app_name="usershub"
+fi
+
+if [ -z "$geonature_app_name" ]; then
+    geonature_app_name="geonature"
+fi
+
+# TODO later : check if GEONATURE_APP_NAME and USERSHUB_APP_NAME are present in
+# geonature_config.toml and add them with default values if necessary
+
 if [ -f config/geonature_config.toml ]; then
   echo "Utilisation du fichier de configuration GeoNature exisant"
 else
@@ -62,6 +74,8 @@ else
   sed -i "s|^SQLALCHEMY_DATABASE_URI = .*$|SQLALCHEMY_DATABASE_URI = \"postgresql:\/\/$user_pg:$user_pg_pass@$db_host:$db_port\/$db_name?application_name=geonature\"|" config/geonature_config.toml
   sed -i "s|^URL_APPLICATION = .*$|URL_APPLICATION = '${my_url}'|" config/geonature_config.toml
   sed -i "s|^API_ENDPOINT = .*$|API_ENDPOINT = '${api_endpoint}'|" config/geonature_config.toml
+  sed -i "s|^GEONATURE_APP_NAME = .*$|GEONATURE_APP_NAME = '${geonature_app_name}'|" config/geonature_config.toml
+  sed -i "s|^USERSHUB_APP_NAME = .*$|USERSHUB_APP_NAME = '${usershub_app_name}'|" config/geonature_config.toml
   sed -i "s|^SECRET_KEY = .*$|SECRET_KEY = '`openssl rand -hex 16`'|" config/geonature_config.toml
   sed -i "s|^DEFAULT_LANGUAGE = .*$|DEFAULT_LANGUAGE = '${default_language}'|" config/geonature_config.toml
   sed -i "s|^SECRET_KEY = .*$|SECRET_KEY = '`openssl rand -hex 32`'|" config/geonature_config.toml

--- a/install/02_configure_systemd.sh
+++ b/install/02_configure_systemd.sh
@@ -1,38 +1,41 @@
 #!/usr/bin/env bash
 
-
 set -eo pipefail
-
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 . "${SCRIPT_DIR}/utils"
-
 
 if [[ "${MODE}" = "dev" ]]; then
     echo "Skip configuration of systemd as not in prod mode"
     exit 0
 fi
 
-echo "Installation de la configuration systemd-tmpfiles…"
-envsubst '${USER}' < "${BASE_DIR}/install/assets/tmpfiles-geonature.conf" | sudo tee /etc/tmpfiles.d/geonature.conf
-sudo systemd-tmpfiles --create /etc/tmpfiles.d/geonature.conf
+# Définir le nom de l'application (par défaut "geonature" si non défini)
+export GEONATURE_APP_NAME="${GEONATURE_APP_NAME:-geonature}"
+export BACKEND_PORT="${BACKEND_PORT:-8000}"
+export BASE_DIR
 
-echo "Installation des fichiers de service systemd…"
-envsubst '${USER} ${BASE_DIR}' < "${BASE_DIR}/install/assets/geonature.service" | sudo tee /etc/systemd/system/geonature.service
-envsubst '${USER} ${BASE_DIR}' < "${BASE_DIR}/install/assets/geonature-worker.service" | sudo tee /etc/systemd/system/geonature-worker.service
-cat "${BASE_DIR}/install/assets/geonature-reload.service" | sudo tee /etc/systemd/system/geonature-reload.service
-envsubst '${BASE_DIR}' < "${BASE_DIR}/install/assets/geonature-reload@.path" | sudo tee /etc/systemd/system/geonature-reload@.path
+echo "Installation de la configuration systemd-tmpfiles…"
+envsubst '${USER} ${GEONATURE_APP_NAME}' < "${BASE_DIR}/install/assets/tmpfiles-geonature.conf" | sudo tee "/etc/tmpfiles.d/${GEONATURE_APP_NAME}.conf"
+sudo systemd-tmpfiles --create "/etc/tmpfiles.d/${GEONATURE_APP_NAME}.conf"
+
+echo "Installation des fichiers de service systemletestd…"
+envsubst '${USER} ${BASE_DIR} ${GEONATURE_APP_NAME} ${BACKEND_PORT}' < "${BASE_DIR}/install/assets/geonature.service" | cat
+envsubst '${USER} ${BASE_DIR} ${GEONATURE_APP_NAME} ${BACKEND_PORT}' < "${BASE_DIR}/install/assets/geonature.service" | sudo tee "/etc/systemd/system/${GEONATURE_APP_NAME}.service"
+envsubst '${USER} ${BASE_DIR} ${GEONATURE_APP_NAME}' < "${BASE_DIR}/install/assets/geonature-worker.service" | sudo tee "/etc/systemd/system/${GEONATURE_APP_NAME}-worker.service"
+envsubst '${GEONATURE_APP_NAME}' < "${BASE_DIR}/install/assets/geonature-reload.service" | sudo tee "/etc/systemd/system/${GEONATURE_APP_NAME}-reload.service"
+envsubst '${BASE_DIR} ${GEONATURE_APP_NAME}' < "${BASE_DIR}/install/assets/geonature-reload@.path" | sudo tee "/etc/systemd/system/${GEONATURE_APP_NAME}-reload@.path"
 sudo mkdir -p /etc/systemd/system-generators/
-envsubst '${BASE_DIR}' < "${BASE_DIR}/install/assets/geonature-generator" | sudo tee /etc/systemd/system-generators/geonature-generator
-sudo chmod +x /etc/systemd/system-generators/geonature-generator
+envsubst '${BASE_DIR} ${GEONATURE_APP_NAME}' < "${BASE_DIR}/install/assets/geonature-generator" | sudo tee "/etc/systemd/system-generators/${GEONATURE_APP_NAME}-generator"
+sudo chmod +x "/etc/systemd/system-generators/${GEONATURE_APP_NAME}-generator"
 sudo systemctl daemon-reload
 
 echo "Installation de la configuration logrotate…"
-envsubst '${USER}' < "${BASE_DIR}/install/assets/log_rotate" | sudo tee /etc/logrotate.d/geonature
+envsubst '${USER} ${GEONATURE_APP_NAME}' < "${BASE_DIR}/install/assets/log_rotate" | sudo tee "/etc/logrotate.d/${GEONATURE_APP_NAME}"
 
-echo "Activation de geonature au démarrage…"
-sudo systemctl enable geonature.service
-sudo systemctl enable geonature-worker.service
+echo "Activation de ${GEONATURE_APP_NAME} au démarrage…"
+sudo systemctl enable "${GEONATURE_APP_NAME}.service"
+sudo systemctl enable "${GEONATURE_APP_NAME}-worker.service"
 
-echo "Vous pouvez maintenant démarrer GeoNature avec la commande : sudo systemctl start geonature"
-echo "Vous pouvez maintenant démarrer le worker GeoNature avec la commande : sudo systemctl start geonature-worker"
+echo "Vous pouvez maintenant démarrer ${GEONATURE_APP_NAME} avec la commande : sudo systemctl start ${GEONATURE_APP_NAME}"
+echo "Vous pouvez maintenant démarrer le worker ${GEONATURE_APP_NAME} avec la commande : sudo systemctl start ${GEONATURE_APP_NAME}-worker"

--- a/install/02_configure_systemd.sh
+++ b/install/02_configure_systemd.sh
@@ -11,8 +11,8 @@ if [[ "${MODE}" = "dev" ]]; then
 fi
 
 # Définir le nom de l'application (par défaut "geonature" si non défini)
-export GEONATURE_APP_NAME="${GEONATURE_APP_NAME:-geonature}"
-export BACKEND_PORT="${BACKEND_PORT:-8000}"
+export GEONATURE_APP_NAME="${geonature_app_name:-geonature}"
+export BACKEND_PORT="${backend_port:-8000}"
 export BASE_DIR
 
 echo "Installation de la configuration systemd-tmpfiles…"

--- a/install/06_configure_apache.sh
+++ b/install/06_configure_apache.sh
@@ -14,9 +14,9 @@ export CUSTOM_STATIC_FOLDER=$(geonature get-config CUSTOM_STATIC_FOLDER)
 export STATIC_URL=$(geonature get-config STATIC_URL)
 export FRONTEND_FOLDER="${BASE_DIR}"/frontend/dist
 export FRONTEND_PREFIX=$(geonature get-config URL_APPLICATION | python -c "import sys; from urllib.parse import urlsplit; print(urlsplit(sys.stdin.read()).path)")
+export BACKEND_PORT="${backend_port:-8000}"
 export GUNICORN_URL="http://127.0.0.1:${BACKEND_PORT}"
 export GEONATURE_APP_NAME="${geonature_app_name:-"geonature"}"
-export BACKEND_PORT="${backend_port:-8000}"
 export DOMAIN_NAME=${domain_name:-"localhost"}
 
 deactivate

--- a/install/06_configure_apache.sh
+++ b/install/06_configure_apache.sh
@@ -15,9 +15,9 @@ export STATIC_URL=$(geonature get-config STATIC_URL)
 export FRONTEND_FOLDER="${BASE_DIR}"/frontend/dist
 export FRONTEND_PREFIX=$(geonature get-config URL_APPLICATION | python -c "import sys; from urllib.parse import urlsplit; print(urlsplit(sys.stdin.read()).path)")
 export GUNICORN_URL="http://127.0.0.1:${BACKEND_PORT}"
-export GEONATURE_APP_NAME="${GEONATURE_APP_NAME:-geonature}"
-export BACKEND_PORT="${BACKEND_PORT:-8000}"
-export DOMAIN_NAME=${DOMAIN_NAME:-test.geonature.fr}
+export GEONATURE_APP_NAME="${geonature_app_name:-geonature}"
+export BACKEND_PORT="${backend_port:-8000}"
+export DOMAIN_NAME=${domain_name:-localhost}
 
 deactivate
 

--- a/install/06_configure_apache.sh
+++ b/install/06_configure_apache.sh
@@ -14,12 +14,16 @@ export CUSTOM_STATIC_FOLDER=$(geonature get-config CUSTOM_STATIC_FOLDER)
 export STATIC_URL=$(geonature get-config STATIC_URL)
 export FRONTEND_FOLDER="${BASE_DIR}"/frontend/dist
 export FRONTEND_PREFIX=$(geonature get-config URL_APPLICATION | python -c "import sys; from urllib.parse import urlsplit; print(urlsplit(sys.stdin.read()).path)")
-export GUNICORN_URL="http://127.0.0.1:8000"
+export GUNICORN_URL="http://127.0.0.1:${BACKEND_PORT}"
+export GEONATURE_APP_NAME="${GEONATURE_APP_NAME:-geonature}"
+export BACKEND_PORT="${BACKEND_PORT:-8000}"
+export DOMAIN_NAME=${DOMAIN_NAME:-test.geonature.fr}
 
 deactivate
 
 echo "Configuration Apache"
-envsubst '${BACKEND_PREFIX} ${MEDIA_FOLDER} ${MEDIA_URL} ${STATIC_FOLDER} ${CUSTOM_STATIC_FOLDER} ${STATIC_URL} ${FRONTEND_FOLDER} ${FRONTEND_PREFIX} ${GUNICORN_URL}' < "${BASE_DIR}/install/assets/geonature_apache.conf" | sudo tee /etc/apache2/conf-available/geonature.conf || exit 1
+envsubst '${BACKEND_PREFIX} ${MEDIA_FOLDER} ${MEDIA_URL} ${STATIC_FOLDER} ${CUSTOM_STATIC_FOLDER} ${STATIC_URL} ${FRONTEND_FOLDER} ${FRONTEND_PREFIX} ${GUNICORN_URL}' < "${BASE_DIR}/install/assets/geonature_apache.conf" | sudo tee /etc/apache2/conf-available/${GEONATURE_APP_NAME}-geonature.conf || exit 1
+envsubst '${DOMAIN_NAME} ${GEONATURE_APP_NAME}' < "${BASE_DIR}/install/assets/vhost_apache.conf" | sudo tee /etc/apache2/sites-available/${GEONATURE_APP_NAME}-geonature.conf || exit 1
 sudo a2enmod rewrite || exit 1
 sudo a2enmod proxy || exit 1
 sudo a2enmod proxy_http || exit 1

--- a/install/06_configure_apache.sh
+++ b/install/06_configure_apache.sh
@@ -15,9 +15,9 @@ export STATIC_URL=$(geonature get-config STATIC_URL)
 export FRONTEND_FOLDER="${BASE_DIR}"/frontend/dist
 export FRONTEND_PREFIX=$(geonature get-config URL_APPLICATION | python -c "import sys; from urllib.parse import urlsplit; print(urlsplit(sys.stdin.read()).path)")
 export GUNICORN_URL="http://127.0.0.1:${BACKEND_PORT}"
-export GEONATURE_APP_NAME="${geonature_app_name:-geonature}"
+export GEONATURE_APP_NAME="${geonature_app_name:-"geonature"}"
 export BACKEND_PORT="${backend_port:-8000}"
-export DOMAIN_NAME=${domain_name:-localhost}
+export DOMAIN_NAME=${domain_name:-"localhost"}
 
 deactivate
 

--- a/install/assets/geonature-generator
+++ b/install/assets/geonature-generator
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-service="/etc/systemd/system/geonature-reload@.path"
-wantdir="$1/geonature.service.wants"
+service="/etc/systemd/system/${GEONATURE_APP_NAME}-reload@.path"
+wantdir="$1/${GEONATURE_APP_NAME}.service.wants"
 
 mkdir -p "$wantdir"
 
 for conf in "${BASE_DIR}"/config/*_config.toml; do
 	confname=$(basename ${conf%"_config.toml"})
-	ln -s "$service" "$wantdir/geonature-reload@$confname.path"
+	ln -s "$service" "$wantdir/${GEONATURE_APP_NAME}-reload@$confname.path"
 done

--- a/install/assets/geonature-reload.service
+++ b/install/assets/geonature-reload.service
@@ -1,6 +1,6 @@
 [Unit]
-Description=Reload GeoNature
+Description=Reload GeoNature - ${GEONATURE_APP_NAME}
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/systemctl reload geonature
+ExecStart=/usr/bin/systemctl reload ${GEONATURE_APP_NAME}

--- a/install/assets/geonature-reload@.path
+++ b/install/assets/geonature-reload@.path
@@ -3,7 +3,7 @@ StopWhenUnneeded=true
 
 [Path]
 PathModified=${BASE_DIR}/config/%i_config.toml
-Unit=geonature-reload.service
+Unit=${GEONATURE_APP_NAME}-reload.service
 
 [Install]
 WantedBy=multi-user.target

--- a/install/assets/geonature-worker.service
+++ b/install/assets/geonature-worker.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=GeoNature Celery Worker Service
+Description=GeoNature Celery Worker Service - ${GEONATURE_APP_NAME}
 After=redis-server.service
 After=postgresql.service
-ReloadPropagatedFrom=geonature.service
+ReloadPropagatedFrom=${GEONATURE_APP_NAME}.service
 
 [Service]
 Type=simple
@@ -10,9 +10,9 @@ User=${USER}
 Group=${USER}
 WorkingDirectory=${BASE_DIR}/
 Environment=CELERY_APP="geonature.celery_app:app"
-Environment=CELERYD_LOG_FILE="/var/log/geonature/%N%I.log"
+Environment=CELERYD_LOG_FILE="/var/log/${GEONATURE_APP_NAME}/%N%I.log"
 Environment=CELERYD_LOG_LEVEL="INFO"
-Environment=CELERYD_SCHEDULE_FILENAME="/var/lib/geonature/celerybeat-schedule.db"
+Environment=CELERYD_SCHEDULE_FILENAME="/var/lib/${GEONATURE_APP_NAME}/celerybeat-schedule.db"
 EnvironmentFile=-${BASE_DIR}/environ
 ExecStart=${BASE_DIR}/backend/venv/bin/celery -A ${CELERY_APP} worker \
                         --beat --schedule-filename=${CELERYD_SCHEDULE_FILENAME} \

--- a/install/assets/geonature.service
+++ b/install/assets/geonature.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=GeoNature
+Description=GeoNature - ${GEONATURE_APP_NAME}
 After=postgresql.service
 After=network.target
 
@@ -8,12 +8,12 @@ Type=simple
 User=${USER}
 Group=${USER}
 WorkingDirectory=${BASE_DIR}/
-Environment=GUNICORN_PROC_NAME=geonature
+Environment=GUNICORN_PROC_NAME=${GEONATURE_APP_NAME}
 Environment=GUNICORN_NUM_WORKERS=4
 Environment=GUNICORN_HOST=127.0.0.1
-Environment=GUNICORN_PORT=8000
+Environment=GUNICORN_PORT=${BACKEND_PORT}
 Environment=GUNICORN_TIMEOUT=30
-Environment=GUNICORN_LOG_FILE=/var/log/geonature/%N%I.log
+Environment=GUNICORN_LOG_FILE=/var/log/${GEONATURE_APP_NAME}/%N%I.log
 EnvironmentFile=-${BASE_DIR}/environ
 ExecStart=${BASE_DIR}/backend/venv/bin/gunicorn geonature:create_app() \
                 --name "${GUNICORN_PROC_NAME}" --workers "${GUNICORN_NUM_WORKERS}" \

--- a/install/assets/geonature_apache.conf
+++ b/install/assets/geonature_apache.conf
@@ -1,4 +1,4 @@
-# Alias: first have precedence, so static & media aliases must be defined before /geonature alias
+# Alias: first have precedence, so static & media aliases must be defined before /${GEONATURE_APP_NAME} alias
 
 Alias "${BACKEND_PREFIX}${MEDIA_URL}" "${MEDIA_FOLDER}"
 <Directory "${MEDIA_FOLDER}">

--- a/install/assets/log_rotate
+++ b/install/assets/log_rotate
@@ -1,4 +1,4 @@
-/var/log/geonature/geonature.log {
+/var/log/${GEONATURE_APP_NAME}/${GEONATURE_APP_NAME}.log {
     su ${USER} ${USER}
     daily
     rotate 8
@@ -6,10 +6,10 @@
     create
     compress
     postrotate
-    systemctl reload geonature || true
+    systemctl reload ${GEONATURE_APP_NAME} || true
     endscript
 }
-/var/log/geonature/geonature-worker.log {
+/var/log/${GEONATURE_APP_NAME}/${GEONATURE_APP_NAME}-worker.log {
     su ${USER} ${USER}
     daily
     rotate 8
@@ -17,6 +17,6 @@
     create
     compress
     postrotate
-    systemctl reload geonature-worker || true
+    systemctl reload ${GEONATURE_APP_NAME}-worker || true
     endscript
 }

--- a/install/assets/tmpfiles-geonature.conf
+++ b/install/assets/tmpfiles-geonature.conf
@@ -1,3 +1,3 @@
-d /run/geonature 0750 ${USER} ${USER} -
-d /var/log/geonature 0750 ${USER} ${USER} -
-d /var/lib/geonature 0750 ${USER} ${USER} -
+d /run/${GEONATURE_APP_NAME} 0750 ${USER} ${USER} -
+d /var/log/${GEONATURE_APP_NAME} 0750 ${USER} ${USER} -
+d /var/lib/${GEONATURE_APP_NAME} 0750 ${USER} ${USER} -

--- a/install/assets/vhost_apache.conf
+++ b/install/assets/vhost_apache.conf
@@ -1,9 +1,9 @@
 <VirtualHost *:80>
     ServerName ${DOMAIN_NAME}
 
-    IncludeOptional /etc/apache2/conf-available/geonature.conf
+    IncludeOptional /etc/apache2/conf-available/${GEONATURE_APP_NAME}-geonature.conf
     IncludeOptional /etc/apache2/conf-available/usershub.conf
 
-    ErrorLog "/var/log/apache2/geonature_error.log"
-    CustomLog "/var/log/apache2/geonature_access.log" combined
+    ErrorLog "/var/log/apache2/${GEONATURE_APP_NAME}-geonature_error.log"
+    CustomLog "/var/log/apache2/${GEONATURE_APP_NAME}-geonature_access.log" combined
 </VirtualHost>

--- a/install/assets/vhost_apache_maintenance.conf
+++ b/install/assets/vhost_apache_maintenance.conf
@@ -1,13 +1,13 @@
 <VirtualHost *:80>
     ServerName ${DOMAIN_NAME}
 
-    Alias /geonature /var/www/geonature_maintenance/
-    <Directory /var/www/geonature_maintenance>
+    Alias /${GEONATURE_APP_NAME} /var/www/${GEONATURE_APP_NAME}_maintenance/
+    <Directory /var/www/${GEONATURE_APP_NAME}_maintenance>
            Require all granted
     </Directory>
 
-    ErrorLog "/var/log/apache2/geonature_error.log"
-    CustomLog "/var/log/apache2/geonature_access.log" combined
+    ErrorLog "/var/log/apache2/${GEONATURE_APP_NAME}_error.log"
+    CustomLog "/var/log/apache2/${GEONATURE_APP_NAME}_access.log" combined
 
     <IfModule mod_headers.c>
         Header set Cache-Control "no-cache, no-store, must-revalidate"

--- a/install/install_all/install_all.ini
+++ b/install/install_all/install_all.ini
@@ -9,13 +9,17 @@ backend_port=8000
 # Nom de domaine pour accéder à GeoNature (sans http ni / à la fin)
 domain_name="localhost"
 
+# subpath d'accès à GeoNature (ex: /geonature donnera http://domain_name/geonature)
+base_path="/geonature"
+
+# Protocole pour accéder à GeoNature (http ou https)
+host_protocol="http"
+
 # Langue du serveur
 # valeur possible : fr_FR.UTF-8, en_US.utf8
 # locale -a pour voir la liste des locales disponible
 my_local=fr_FR.UTF-8
 
-# My host URL or IP, starting with http and with / at the end
-my_url=http://mon.domaine.com/
 
 ### CONFIGURATION PostgreSQL ###
 

--- a/install/install_all/install_all.ini
+++ b/install/install_all/install_all.ini
@@ -2,6 +2,13 @@
 # Indiquer dev pour une installation de developement
 mode=prod
 
+# Nom de l'application GeoNature (sera utilisé pour le nom du service systemd, du socket et du projet gunicorn)
+geonature_app_name="geonature"
+# Port du backend de GeoNature 
+backend_port=8000
+# Nom de domaine pour accéder à GeoNature (sans http ni / à la fin)
+domain_name="localhost"
+
 # Langue du serveur
 # valeur possible : fr_FR.UTF-8, en_US.utf8
 # locale -a pour voir la liste des locales disponible

--- a/install/install_all/install_all.sh
+++ b/install/install_all/install_all.sh
@@ -118,6 +118,10 @@ sed -i "s/install_module_validation=.*$/install_module_validation=$install_modul
 sed -i "s/install_module_occhab=.*$/install_module_occhab=$install_module_occhab/g" config/settings.ini
 sed -i "s/proxy_http=.*$/proxy_http=$proxy_http/g" config/settings.ini
 sed -i "s/proxy_https=.*$/proxy_https=$proxy_https/g" config/settings.ini
+sed -i "s/geonature_app_name=.*$/geonature_app_name=$geonature_app_name/g" config/settings.ini
+sed -i "s/backend_port=.*$/backend_port=$backend_port/g" config/settings.ini
+sed -i "s/domain_name=.*$/domain_name=$domain_name/g" config/settings.ini
+
 
 cd "${GEONATURE_DIR}/install"
 

--- a/install/install_all/install_all.sh
+++ b/install/install_all/install_all.sh
@@ -18,17 +18,8 @@ if [ !"$OS_BITS" == "64" ]; then
    exit 1
 fi
 
-# Format my_url to set a / at the end
-if [ "${my_url: -1}" != '/' ]
-then
-my_url=$my_url/
-fi
 
-# Remove http:// and remove final / from $my_url to create $my_domain
-# No more used actually but can be useful if we want to create a Servername in Apache configuration
-my_domain=$(echo $my_url | sed -r 's|^.*\/\/(.*)$|\1|')
-my_domain=$(echo $my_domain | sed s'/.$//')
-export DOMAIN_NAME="$my_domain"
+export DOMAIN_NAME=${domain_name:-localhost}
 
 # Check OS and versions
 if [ "$OS_NAME" != "debian" ]
@@ -91,14 +82,13 @@ cd "${GEONATURE_DIR}"
 # Updating GeoNature settings
 cp config/settings.ini.sample config/settings.ini
 echo "Installation de la base de données et configuration de l'application GeoNature ..."
-my_url="${my_url//\//\\/}"
+my_url=${host_protocol}://${domain_name}${base_path}/
 proxy_http="${proxy_http//\//\\/}"
 proxy_https="${proxy_https//\//\\/}"
 
 
 sed -i "s/MODE=.*$/MODE=$mode/g" config/settings.ini
 sed -i "s/my_local=.*$/my_local=$my_local/g" config/settings.ini
-sed -i "s/my_url=.*$/my_url=$my_url/g" config/settings.ini
 sed -i "s/drop_apps_db=.*$/drop_apps_db=$drop_geonaturedb/g" config/settings.ini
 sed -i "s/db_name=.*$/db_name=$geonaturedb_name/g" config/settings.ini
 sed -i "s/user_pg=.*$/user_pg=$user_pg/g" config/settings.ini
@@ -121,6 +111,7 @@ sed -i "s/proxy_https=.*$/proxy_https=$proxy_https/g" config/settings.ini
 sed -i "s/geonature_app_name=.*$/geonature_app_name=$geonature_app_name/g" config/settings.ini
 sed -i "s/backend_port=.*$/backend_port=$backend_port/g" config/settings.ini
 sed -i "s/domain_name=.*$/domain_name=$domain_name/g" config/settings.ini
+sed -i "s/base_path=.*$/base_path=$base_path/g" config/settings.ini
 
 
 cd "${GEONATURE_DIR}/install"
@@ -174,7 +165,7 @@ if [ "$install_usershub_app" = true ]; then
     sed -i "s/db_name=.*$/db_name=$geonaturedb_name/g" config/settings.ini
     sed -i "s/user_pg=.*$/user_pg=$user_pg/g" config/settings.ini
     sed -i "s/user_pg_pass=.*$/user_pg_pass=$user_pg_pass/g" config/settings.ini
-    sed -i 's#url_application=.*#url_application='$my_url'usershub#g' config/settings.ini
+    sed -i 's#url_application=.*#url_application='$host_protocol'://'$domain_name'/usershub#g' config/settings.ini
 
     # Installation of UsersHub application
     ./install_app.sh

--- a/install/migration/migration.sh
+++ b/install/migration/migration.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 
-SERVICES=("geonature" "geonature-worker" "usershub")
 
 newdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd )"
 if (($# > 0)); then
@@ -48,6 +47,23 @@ if [ "$choice" != 'y' ] && [ "$choice" != 'Y' ]; then
 else
     echo "Lancement de la migration..."
 fi
+
+# Getting services names by loading original settings file:
+
+. ${olddir}/config/settings.ini
+
+# If values are absent set them to default :
+
+if [ -z "$usershub_app_name" ]; then
+    usershub_app_name="usershub"
+fi
+
+if [ -z "$geonature_app_name" ]; then
+    geonature_app_name="geonature"
+fi
+
+
+SERVICES=( ${geonature_app_name} "${geonature_app_name}-worker" ${usershub_app_name} )
 
 echo "Arrêt des services…"
 for service in ${SERVICES[@]}; do
@@ -197,10 +213,10 @@ fi
 
 echo "Mise à jour des scripts systemd…"
 cd ${newdir}/install
-if [ -f /etc/systemd/system/geonature-reload.path ]; then  # before GN 2.12
-    sudo systemctl stop geonature-reload.path
-    sudo systemctl disable geonature-reload.path
-    sudo rm /etc/systemd/system/geonature-reload.path
+if [ -f /etc/systemd/system/${geonature_app_name}-reload.path ]; then  # before GN 2.12
+    sudo systemctl stop ${geonature_app_name}-reload.path
+    sudo systemctl disable ${geonature_app_name}-reload.path
+    sudo rm /etc/systemd/system/${geonature_app_name}-reload.path
 fi
 ./02_configure_systemd.sh
 cd ${newdir}/
@@ -212,10 +228,10 @@ sudo apachectl configtest && sudo systemctl reload apache2 || echo "Attention, c
 
 # before GeoNature 2.10
 if [ -f "/var/log/geonature.log" ]; then
-    echo "Déplacement des fichiers de logs /var/log/geonature.log → /var/log/geonature/geonature.log …"
-    sudo mkdir -p /var/log/geonature/
-    sudo mv /var/log/geonature.log /var/log/geonature/geonature.log
-    sudo chown $USER: -R /var/log/geonature/
+    echo "Déplacement des fichiers de logs /var/log/geonature.log → /var/log/${geonature_app_name}/${geonature_app_name}.log …"
+    sudo mkdir -p /var/log/${geonature_app_name}/
+    sudo mv /var/log/geonature.log /var/log/${geonature_app_name}/${geonature_app_name}.log
+    sudo chown $USER: -R /var/log/${geonature_app_name}/
 fi
 
 # Update the API ENDPOINT in frontend configuration file


### PR DESCRIPTION
resolves #2269

This PR propose to add new parameter in the settings.ini file to enable an easy deployement of multiple instance of GeoNature on the same server using the install scripts.

The new parameters are : 
- `geonature_app_name`  (default geonature)
- `backend_port` (default 8000)
- `domain_name` (default localhost)
- `base_path` (default /geonature)
- `host_protocol` (default http)

The consequences are : 
- if GEONATURE_APP_NAME modified, system services `geonature.service` and `geonature-worker.service` are renamed to `$GEONATURE_APP_NAME.service` and `$GEONATURE_APP_NAME-worker.service`
- Apache config file are renamed from `geonature.conf `to `${GEONATURE_APP_NAME}-geonature.conf`
- Logs file are now located in /var/log/${GEONATURE_APP_NAME}/${GEONATURE_APP_NAME}.log
 