### PR TITLE
Update geonature_apache.conf with missing slash character

### DIFF
--- a/install/assets/geonature_apache.conf
+++ b/install/assets/geonature_apache.conf
@@ -28,7 +28,7 @@ RewriteRule "^${BACKEND_PREFIX}${STATIC_URL}/(.*)$" "${CUSTOM_STATIC_FOLDER}/$1"
     Options -Indexes
 </Directory>
 
-AliasMatch "^${FRONTEND_PREFIX}(.*)$" "${FRONTEND_FOLDER}$1"
+AliasMatch "^${FRONTEND_PREFIX}(.*)$" "${FRONTEND_FOLDER}/$1"
 <Directory "${FRONTEND_FOLDER}">
     Require all granted
 </Directory>


### PR DESCRIPTION
missing slash character lead to http permission error, had to be changed in /etc/apache2/conf-available/geonature.conf
