### PR TITLE
featt: add optional "start_on" to permission

### DIFF
--- a/backend/geonature/core/gn_permissions/models.py
+++ b/backend/geonature/core/gn_permissions/models.py
@@ -258,6 +258,7 @@ class Permission(db.Model):
         nullable=False,
     )
     created_on = db.Column(sa.DateTime, server_default=sa.func.now())
+    start_on = db.Column(db.DateTime)
     expire_on = db.Column(db.DateTime)
     validated = db.Column(sa.Boolean, server_default=sa.true())
 
@@ -365,12 +366,15 @@ class Permission(db.Model):
     @property
     def is_active(self):
         return (
-            self.expire_on is None or self.expire_on > datetime.now()
-        ) and self.validated is True
+            (self.start_on is None or self.start_on <= datetime.now())
+            and (self.expire_on is None or self.expire_on > datetime.now())
+            and self.validated is True
+        )
 
     @classmethod
     def active_filter(cls):
         return sa.and_(
+            sa.or_(cls.start_on.is_(sa.null()), cls.start_on <= datetime.now()),
             sa.or_(cls.expire_on.is_(sa.null()), cls.expire_on > datetime.now()),
             cls.validated.is_(True),
         )

--- a/backend/geonature/migrations/versions/17929040cac1_add_permission_start_on.py
+++ b/backend/geonature/migrations/versions/17929040cac1_add_permission_start_on.py
@@ -1,0 +1,39 @@
+"""add start_on to permissions
+
+Add an optional start date to permissions. A permission is only considered
+active once this date is reached (in addition to the existing expiration and
+validation checks). A null start_on means the permission is active as soon
+as it is validated, preserving the previous behaviour.
+
+Revision ID: 17929040cac1
+Revises: f6a1feb3f297
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import Column, DateTime
+
+
+# revision identifiers, used by Alembic.
+revision = "17929040cac1"
+down_revision = "f6a1feb3f297"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        schema="gn_permissions",
+        table_name="t_permissions",
+        column=Column("start_on", DateTime, nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column(
+        schema="gn_permissions",
+        table_name="t_permissions",
+        column_name="start_on",
+    )

--- a/backend/geonature/tests/test_permissions.py
+++ b/backend/geonature/tests/test_permissions.py
@@ -354,6 +354,19 @@ class TestPermissions:
 
         assert_cruved("r1", "110100")
 
+    def test_start_on_perm(self, permissions, assert_cruved):
+        """
+        Permissions with a start_on in the future should not be taken into
+        account yet. A start_on in the past or NULL means the permission is
+        active (provided it is validated and not expired).
+        """
+        permissions("r1", "1-----")  # start_on default to NULL -> active
+        permissions("r1", "-1----", start_on=None)  # explicit NULL -> active
+        permissions("r1", "--1---", start_on=datetime.now() - timedelta(days=1))  # started
+        permissions("r1", "---1--", start_on=datetime.now() + timedelta(days=1))  # not yet
+
+        assert_cruved("r1", "111000")
+
     def test_validation_perm(self, permissions, assert_cruved):
         """
         Permission not yet validated or refused should be ignored.


### PR DESCRIPTION
Closes #4154 

Ajout de `start_on`: model, migration, et prise en compte dans `active_filter` / `is_active`.

L'ensemble du développement se plaque sur la logique de expire_on (le nommage, les tests, l'utilisation).