### PR TITLE
modif_since_validation: use null as default value

### DIFF
--- a/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/synthese-form.service.ts
@@ -75,7 +75,7 @@ export class SyntheseFormService {
       id_import: null,
       id_acquisition_framework: null,
       id_nomenclature_valid_status: null,
-      modif_since_validation: [false, null],
+      modif_since_validation: null,
       score: null,
       valid_distribution: null,
       valid_altitude: null,


### PR DESCRIPTION
C’est le seul paramètre qui, si pas utilisé, est à false au lieux de null, ce qui rend compliqué de savoir si le formulaire a des filtres actifs … Et le backend considère null tout comme false (utilisé que par la validation - ignoré par la synthèse) :
https://github.com/PnX-SI/GeoNature/blob/617c42d7fe3347541775824327d77b9903c662c5/contrib/gn_module_validation/backend/gn_module_validation/query_build.py#L143
https://github.com/PnX-SI/GeoNature/blob/617c42d7fe3347541775824327d77b9903c662c5/contrib/gn_module_validation/backend/gn_module_validation/query_build.py#L210-L211