### PR TITLE
permissions: add label to objects

### DIFF
--- a/backend/geonature/core/gn_permissions/models.py
+++ b/backend/geonature/core/gn_permissions/models.py
@@ -83,7 +83,8 @@ class PermObject(db.Model):
     __tablename__ = "t_objects"
     __table_args__ = {"schema": "gn_permissions"}
     id_object = db.Column(db.Integer, primary_key=True)
-    code_object = db.Column(db.Unicode)
+    code_object = db.Column(db.Unicode(50))
+    label_object = db.Column(db.Unicode(50))
     description_object = db.Column(db.Unicode)
 
     def __str__(self):
@@ -153,7 +154,9 @@ class PermissionAvailable(db.Model):
 
     def __str__(self):
         s = self.module.module_label
-        if self.object.code_object != "ALL":
+        if self.object.label_object:
+            s += f" | {self.object.label_object}"
+        elif self.object.code_object != "ALL":
             object_label = self.object.code_object.title().replace("_", " ")
             s += f" | {object_label}"
         s += f" | {self.label}"

--- a/backend/geonature/migrations/versions/65d922a77eb5_objects_label.py
+++ b/backend/geonature/migrations/versions/65d922a77eb5_objects_label.py
@@ -1,0 +1,32 @@
+"""[permissions] add label to objects
+
+Revision ID: 65d922a77eb5
+Revises: f6a1feb3f297
+Create Date: 2026-06-10 12:58:44.981868
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "65d922a77eb5"
+down_revision = "f6a1feb3f297"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "t_objects",
+        sa.Column("label_object", sa.Unicode(50)),
+        schema="gn_permissions",
+    )
+
+
+def downgrade():
+    op.drop_column(
+        "t_objects",
+        "label_object",
+        schema="gn_permissions",
+    )


### PR DESCRIPTION
Le but est d’améliorer ça :
<img width="825" height="831" alt="2026-06-10T15:13:06,187670957+02:00" src="https://github.com/user-attachments/assets/906a461e-b537-40d1-8f87-2f053de49987" />

qui est généré par le hasardeux snippet suivant (je plaide coupable) :
```
object_label = self.object.code_object.title().replace("_", " ")
```

sauf que, les objets n’étant pas liés aux modules, dans le cas de module externe, on a tendance à juste titre de préfixer le code de l’objet par le code du module, ce qui a un rendu assez moche …