### PR TITLE
docker: fixes & frontend dev stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 .git
 backend/venv/
 backend/static/node_modules/
-frontend/node_modules/
+node_modules

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -145,7 +145,7 @@ WORKDIR /sources/GeoNature
 # rw required by --editable to write .egg-info stuffs
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=bind,source=.,target=/sources/GeoNature,rw \
-    cd backend && uv pip install --system  -e .. -r requirements-dev.txt
+    cd backend && uv pip install --system  -e '..[tests]' -r requirements-dev.txt
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=bind,source=.,target=/sources/GeoNature,rw \
     uv pip install --system \

--- a/frontend/50-set-api-endpoint.sh
+++ b/frontend/50-set-api-endpoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ ! -z "${API_ENDPOINT}" ]; then
-  echo "{\"API_ENDPOINT\": ${API_ENDPOINT}}" >/usr/share/nginx/html/assets/config.json
+  echo "{\"API_ENDPOINT\": \"${API_ENDPOINT}\"}" >"${ASSETS_DIRECTORY}"/config.json
 fi

--- a/frontend/50-set-api-endpoint.sh
+++ b/frontend/50-set-api-endpoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ ! -z "${API_ENDPOINT}" ]; then
-  echo "{\"API_ENDPOINT\": \"${API_ENDPOINT}\"}" >"${ASSETS_DIRECTORY}"/config.json
+  echo "{\"API_ENDPOINT\": \"${API_ENDPOINT}\"}" >"${ASSETS_DIRECTORY:-/usr/share/nginx/html/assets}"/config.json
 fi

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,18 @@
-FROM node:20-bullseye AS source-light
+ARG NODE_IMAGE="node:20-bullseye"
+ARG NGINX_IMAGE="nginx:mainline-alpine"
+
+
+FROM ${NODE_IMAGE} AS occhab-node-modules
+
+WORKDIR /dist/gn_module_occhab
+
+COPY ./contrib/gn_module_occhab/frontend/package.json .
+COPY ./contrib/gn_module_occhab/frontend/package-lock.json .
+
+RUN --mount=type=cache,target=/root/.npm \
+  npm ci --omit=peer
+
+FROM ${NODE_IMAGE} AS source-light
 
 WORKDIR /build/
 
@@ -17,18 +31,13 @@ FROM source-light AS source
 
 WORKDIR /build/external_modules/occtax
 COPY ./contrib/occtax/frontend/ .
-#RUN --mount=type=cache,target=/root/.npm \
-#    npm ci --omit=dev
 
 WORKDIR /build/external_modules/occhab
 COPY ./contrib/gn_module_occhab/frontend/ .
-#RUN --mount=type=cache,target=/root/.npm \
-#    npm ci --omit=dev
+COPY --from=occhab-node-modules /dist/gn_module_occhab/node_modules .
 
 WORKDIR /build/external_modules/validation
 COPY ./contrib/gn_module_validation/frontend/ .
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev
 
 
 FROM source-light AS build-light
@@ -43,12 +52,13 @@ WORKDIR /build/
 RUN npm run build
 
 
-FROM nginx:mainline-alpine AS prod-base
+FROM ${NGINX_IMAGE} AS prod-base
 
 ENV NGINX_PORT=80
 ENV NGINX_HOST=localhost
 ENV NGINX_LOCATION=/
 
+ENV ASSETS_DIRECTORY=/usr/share/nginx/html/assets
 COPY ./frontend/50-set-api-endpoint.sh /docker-entrypoint.d/
 
 COPY ./frontend/nginx.conf /etc/nginx/templates/default.conf.template
@@ -64,3 +74,34 @@ COPY --from=build-light /build/dist /usr/share/nginx/html
 FROM prod-base AS prod
 
 COPY --from=build /build/dist /usr/share/nginx/html
+
+FROM ${NODE_IMAGE} AS dev
+
+WORKDIR /dist/geonature
+
+COPY ./frontend/package.json .
+COPY ./frontend/package-lock.json .
+
+RUN --mount=type=cache,target=/root/.npm \
+  npm ci
+
+COPY ./frontend/tsconfig.json .
+COPY ./frontend/angular.json .
+
+COPY --from=occhab-node-modules /dist/gn_module_occhab /dist/gn_module_occhab
+
+RUN mkdir external_modules
+RUN ln -s /dist/occtax external_modules/occtax
+RUN ln -s /dist/gn_module_occhab external_modules/occhab
+RUN ln -s /dist/gn_module_validation external_modules/validation
+
+ENV ASSETS_DIRECTORY=/dist/geonature/src/assets
+RUN mkdir /docker-entrypoint.d/
+COPY ./frontend/50-set-api-endpoint.sh /docker-entrypoint.d/
+COPY ./frontend/docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+
+CMD [ "npm", "run", "start", "--", "--host", "0.0.0.0" ]
+
+EXPOSE 4200

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,18 @@
-FROM node:20-bullseye AS source-light
+ARG NODE_IMAGE="node:20-bullseye"
+ARG NGINX_IMAGE="nginx:mainline-alpine"
+
+
+FROM ${NODE_IMAGE} AS occhab-node-modules
+
+WORKDIR /dist/gn_module_occhab
+
+COPY ./contrib/gn_module_occhab/frontend/package.json .
+COPY ./contrib/gn_module_occhab/frontend/package-lock.json .
+
+RUN --mount=type=cache,target=/root/.npm \
+  npm ci --omit=peer
+
+FROM ${NODE_IMAGE} AS source-light
 
 WORKDIR /build/
 
@@ -17,18 +31,13 @@ FROM source-light AS source
 
 WORKDIR /build/external_modules/occtax
 COPY ./contrib/occtax/frontend/ .
-#RUN --mount=type=cache,target=/root/.npm \
-#    npm ci --omit=dev
 
 WORKDIR /build/external_modules/occhab
 COPY ./contrib/gn_module_occhab/frontend/ .
-#RUN --mount=type=cache,target=/root/.npm \
-#    npm ci --omit=dev
+COPY --from=occhab-node-modules /dist/gn_module_occhab/node_modules .
 
 WORKDIR /build/external_modules/validation
 COPY ./contrib/gn_module_validation/frontend/ .
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev
 
 
 FROM source-light AS build-light
@@ -43,12 +52,13 @@ WORKDIR /build/
 RUN npm run build
 
 
-FROM nginx:mainline-alpine AS prod-base
+FROM ${NGINX_IMAGE} AS prod-base
 
 ENV NGINX_PORT=80
 ENV NGINX_HOST=localhost
 ENV NGINX_LOCATION=/
 
+ENV ASSETS_DIRECTORY=/usr/share/nginx/html/assets
 COPY ./frontend/50-set-api-endpoint.sh /docker-entrypoint.d/
 
 COPY ./frontend/nginx.conf /etc/nginx/templates/default.conf.template
@@ -64,3 +74,34 @@ COPY --from=build-light /build/dist /usr/share/nginx/html
 FROM prod-base AS prod
 
 COPY --from=build /build/dist /usr/share/nginx/html
+
+FROM ${NODE_IMAGE} AS dev
+
+WORKDIR /dist/geonature
+
+COPY ./frontend/package.json .
+COPY ./frontend/package-lock.json .
+
+RUN --mount=type=cache,target=/root/.npm \
+  npm ci
+
+COPY ./frontend/tsconfig.json .
+COPY ./frontend/angular.json .
+
+COPY --from=occhab-node-modules /dist/gn_module_occhab /dist/gn_module_occhab
+
+RUN mkdir external_modules \
+  && ln -s /dist/occtax external_modules/occtax \
+  && ln -s /dist/gn_module_occhab external_modules/occhab \
+  && ln -s /dist/gn_module_validation external_modules/validation
+
+ENV ASSETS_DIRECTORY=/dist/geonature/src/assets
+RUN mkdir /docker-entrypoint.d/
+COPY ./frontend/50-set-api-endpoint.sh /docker-entrypoint.d/
+COPY ./frontend/docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+
+CMD [ "npm", "run", "start", "--", "--host", "0.0.0.0" ]
+
+EXPOSE 4200

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+  echo "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+
+  echo "$0: Looking for shell scripts in /docker-entrypoint.d/"
+  find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+    case "$f" in
+    *.envsh)
+      if [ -x "$f" ]; then
+        echo "$0: Sourcing $f"
+        . "$f"
+      else
+        # warn on shell scripts without exec bit
+        echo "$0: Ignoring $f, not executable"
+      fi
+      ;;
+    *.sh)
+      if [ -x "$f" ]; then
+        echo "$0: Launching $f"
+        "$f"
+      else
+        # warn on shell scripts without exec bit
+        echo "$0: Ignoring $f, not executable"
+      fi
+      ;;
+    *) echo "$0: Ignoring $f" ;;
+    esac
+  done
+
+  echo "$0: Configuration complete; ready for start up"
+else
+  echo "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+fi
+
+exec "$@"


### PR DESCRIPTION
- backend : installation des dépendances de tests pour le stage de dev
- frontend :
  - set-api-endpoint
    - ajout de quotes autour de l’endpoint pour avoir un json valide ! Ce problème était contourné en indiquant dans `docker-compose.yml` (dans `traefik.yml` plus précisément) `API_ENDPOINT="${GEONATURE_API_ENDPOINT}"` mais c’est une erreur, on peut le voir avec `docker compose config` qui indique : `API_ENDPOINT: '"http://localhost:8000/api"'` (double quotations !). Il faut donc corriger aussi le `traefik.yml` …
    - utilisation de `ASSETS_DIRECTORY` pour pouvoir utiliser le script en prod & dev
   - Dockerfile
     - pas de npm ci pour le module validation qui n’a pas de dépendances
     - dépendance d’occhab installé via un stage occhab-node-module, copié ensuite dans les stages de prod & dev
     - ajout d’un stage de dev
       - on fait uniquement npm ci (mais sans --omit=dev !)
       - l’entrypoint est un quasi copier-coller de l’entrypoint de nginx