### PR TITLE
fix(metadata): wrong test if occhab is enabled

### DIFF
--- a/backend/geonature/core/gn_meta/models/datasets.py
+++ b/backend/geonature/core/gn_meta/models/datasets.py
@@ -1,6 +1,6 @@
 import datetime
 
-from flask import g
+from flask import g, current_app
 import sqlalchemy as sa
 from sqlalchemy import ForeignKey, or_, func
 from sqlalchemy.sql import select, func
@@ -373,12 +373,7 @@ class TDatasets(db.Model):
         )
         request_nb_observations = request_nb_obs_synthese
 
-        from geonature.utils.module import is_module_installed
-
-        is_module_OCCHAB_installed = is_module_installed(
-            "gn_module_occhab", check_if_all_revisions_have_been_applied=False
-        )
-        if is_module_OCCHAB_installed:
+        if "OCCHAB" in current_app.config:
             from gn_module_occhab.models import OccurenceHabitat, Station
 
             request_nb_obs_habitats = (

--- a/backend/geonature/core/gn_meta/utils.py
+++ b/backend/geonature/core/gn_meta/utils.py
@@ -35,10 +35,7 @@ def get_acquisition_framework_stats(id_acquisition_framework):
 
     nb_habitats = 0
 
-    if (
-        is_module_installed("gn_module_occhab", check_if_all_revisions_have_been_applied=False)
-        and nb_datasets > 0
-    ):
+    if "OCCHAB" in config and nb_datasets > 0:
 
         nb_habitats = db.session.execute(
             select(func.count("*"))


### PR DESCRIPTION
L’implémentation actuel pose problème quand OccHab est installé mais pas activé (en particulier pour `utils.py` où n’est pas utiliser la même condition pour importer le modèle et lorsqu’il est utilisé).