### PR TITLE
fix: AF must be opened to use the add dataset button in the AF detail page

### DIFF
--- a/frontend/src/app/metadataModule/af/af-card.component.html
+++ b/frontend/src/app/metadataModule/af/af-card.component.html
@@ -346,7 +346,7 @@
         <div class="card-header d-flex justify-content-between">
           <h3>{{ 'MetaData.AssociatedDatasets' | translate }}</h3>
           <button
-            *ngIf="_cruvedStore.cruved?.METADATA?.cruved.C !== 0"
+            *ngIf="_cruvedStore.cruved?.METADATA?.cruved.C !== 0 && af?.opened"
             [routerLink]="['/metadata/dataset']"
             [queryParams]="{ id_acquisition_framework: af?.id_acquisition_framework }"
             class="success-btn"


### PR DESCRIPTION
The add button on the dataset list of the acquisition framework (AF) detail page must be hidden if the AF is closed 