### PR TITLE
http exception handler add extra props to data

### DIFF
--- a/backend/geonature/core/errors.py
+++ b/backend/geonature/core/errors.py
@@ -44,14 +44,15 @@ def handle_validation_error(e):
 def handle_http_exception(e):
     response = e.get_response()
     if request.accept_mimetypes.best == "application/json":
-        response.data = json.dumps(
-            {
-                "code": e.code,
-                "name": e.name,
-                "description": e.description,
-                "request_id": request.environ["FLASK_REQUEST_ID"],
-            }
-        )
+        data = {
+            "code": e.code,
+            "name": e.name,
+            "description": e.description,
+            "request_id": request.environ["FLASK_REQUEST_ID"],
+        }
+        if hasattr(e, "extra"):
+            data.update(e.extra)
+        response.data = json.dumps(data)
         response.content_type = "application/json"
     return response
 

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -145,6 +145,7 @@ registerLocaleData(localeEn);
     UserDataService,
     NotificationDataService,
     ConfigService,
+    MyCustomInterceptor,
     { provide: HTTP_INTERCEPTORS, useClass: MyCustomInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: UnauthorizedInterceptor, multi: true },
     {

--- a/frontend/src/app/services/http.interceptor.ts
+++ b/frontend/src/app/services/http.interceptor.ts
@@ -21,7 +21,7 @@ export class MyCustomInterceptor implements HttpInterceptor {
     public config: ConfigService
   ) {}
 
-  private handleError(error: any) {
+  handleError(error: any) {
     let errTitle: string;
     let errMsg: string;
     let enableHtml: boolean = false;


### PR DESCRIPTION
Usage example:
```
  e = BadRequest("You are doing something wrong")
  e.extra = {"reason": "geom_outside"}
  raise e
```

Permet ensuite côté frontend de regarder ces champs additionnels pour adapter le comportement de l’UI à l’erreur précise (on peut imaginer afficher un message d’erreur localisé par exemple).


Autre commit pour passer handleError en public pour pouvoir être réutilisé. Typiquement on by-pass l’interceptor pour traiter les erreurs nous même, mais pour celles sans comportement particulier, on souhaite les afficher avec handleError.