### PR TITLE
synthese: id_digitizer as synonym of id_digitiser

### DIFF
--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import (
     contains_eager,
     deferred,
     query_expression,
+    synonym,
 )
 from sqlalchemy.sql import select, func
 from sqlalchemy.schema import FetchedValue
@@ -427,6 +428,7 @@ class Synthese(DB.Model):
     determiner = DB.Column(DB.Unicode(length=1000))
     id_digitiser = DB.Column(DB.Integer, ForeignKey(User.id_role))
     digitiser = db.relationship(User, foreign_keys=[id_digitiser])
+    id_digitizer = synonym("id_digitiser")
     comment_context = DB.Column(DB.UnicodeText)
     comment_description = DB.Column(DB.UnicodeText)
     additional_data = DB.Column(JSONB)


### PR DESCRIPTION
Y’a des refacts qui se sont mis à utiliser id_digitizer (filter_by_scope) alors que le vrai champs c’est id_digitiser. Mais comme le bon terme est plutôt id_digitizer, et que partout dans metadata on utilise id_digitizer, je me suis dit que le plus simple est d’ajouter un synonyme.