### PR TITLE
feat: add taxon relationship to TIndividuals model

### DIFF
--- a/backend/geonature/core/gn_monitoring/models.py
+++ b/backend/geonature/core/gn_monitoring/models.py
@@ -22,6 +22,7 @@ from ref_geo.models import LAreas
 from utils_flask_sqla.serializers import serializable
 from utils_flask_sqla_geo.serializers import geoserializable
 
+from apptax.taxonomie.models import Taxref
 from geonature.core.gn_commons.models import TModules, TMedias
 from geonature.core.gn_meta.models import TDatasets
 from geonature.utils.env import DB
@@ -394,6 +395,8 @@ class TIndividuals(DB.Model):
         foreign_keys=[TMedias.uuid_attached_row],
         overlaps="medias",
     )
+
+    taxon = DB.relationship(Taxref, lazy="select")
 
     @classmethod
     def filter_by_scope(cls, query, scope, user=None):


### PR DESCRIPTION
Adds a taxon relationship on TIndividuals pointing to Taxref, leveraging the existing cd_nom foreign key (same pattern as gn_synthese.models.VSynthese.taxref).
Lets consumers of TIndividuals access the related taxon directly, without a manual join.