### PR TITLE
feat: add id_individual to synthese and cor_counting_occtax

### DIFF
--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -42,6 +42,7 @@ from geonature.core.imports.models import TImports as Import
 from ref_geo.models import LAreas
 
 from geonature.core.gn_meta.models import TDatasets
+from geonature.core.gn_monitoring.models import TIndividuals
 from geonature.core.gn_commons.models import (
     TValidations,
     last_validation,
@@ -270,6 +271,8 @@ class Synthese(DB.Model):
         TDatasets,
         backref=DB.backref("synthese_records", lazy="dynamic", cascade_backrefs=False),
     )
+    id_individual = DB.Column(DB.Integer, ForeignKey(TIndividuals.id_individual))
+    individual = DB.relationship(TIndividuals)
     grp_method = DB.Column(DB.Unicode(length=255))
 
     id_nomenclature_geo_object_nature = db.Column(

--- a/backend/geonature/core/gn_synthese/schemas.py
+++ b/backend/geonature/core/gn_synthese/schemas.py
@@ -2,6 +2,7 @@ from geonature.utils.env import db, ma
 from geonature.utils.config import config
 
 from geonature.core.gn_commons.schemas import ModuleSchema, MediaSchema, TValidationSchema
+from geonature.core.gn_monitoring.schema import TIndividualsSchema
 from geonature.core.gn_synthese.models import (
     BibReportsTypes,
     TReport,
@@ -60,6 +61,7 @@ class SyntheseSchema(SmartRelationshipsMixin, GeoAlchemyAutoSchema):
     source = ma.Nested(SourceSchema, dump_only=True)
     module = ma.Nested(ModuleSchema, dump_only=True)
     dataset = ma.Nested("DatasetSchema", dump_only=True)
+    individual = ma.Nested(TIndividualsSchema, dump_only=True)
     habitat = ma.Nested(HabrefSchema, dump_only=True)
     digitiser = ma.Nested(UserSchema, dump_only=True)
     cor_observers = ma.Nested(UserSchema, many=True, dump_only=True)

--- a/backend/geonature/migrations/versions/daeaa45e4cc0_add_id_individual_to_synthese.py
+++ b/backend/geonature/migrations/versions/daeaa45e4cc0_add_id_individual_to_synthese.py
@@ -1,7 +1,7 @@
 """add id_individual to synthese
 
 Revision ID: daeaa45e4cc0
-Revises: 1f223c509a80
+Revises: f6a1feb3f297
 Create Date: 2026-06-22 00:00:00.000000
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "daeaa45e4cc0"
-down_revision = "1f223c509a80"
+down_revision = "f6a1feb3f297"
 branch_labels = None
 depends_on = None
 

--- a/backend/geonature/migrations/versions/daeaa45e4cc0_add_id_individual_to_synthese.py
+++ b/backend/geonature/migrations/versions/daeaa45e4cc0_add_id_individual_to_synthese.py
@@ -1,0 +1,38 @@
+"""add id_individual to synthese
+
+Revision ID: daeaa45e4cc0
+Revises: 1f223c509a80
+Create Date: 2026-06-22 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "daeaa45e4cc0"
+down_revision = "1f223c509a80"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "synthese",
+        sa.Column(
+            "id_individual",
+            sa.Integer(),
+            sa.ForeignKey(
+                "gn_monitoring.t_individuals.id_individual",
+                name="fk_synthese_id_individual",
+                onupdate="CASCADE",
+                ondelete="SET NULL",
+            ),
+            nullable=True,
+        ),
+        schema="gn_synthese",
+    )
+
+
+def downgrade():
+    op.drop_column("synthese", "id_individual", schema="gn_synthese")

--- a/backend/geonature/tests/test_synthese.py
+++ b/backend/geonature/tests/test_synthese.py
@@ -28,6 +28,7 @@ from geonature.core.gn_synthese.utils.query_select_sqla import remove_accents
 from geonature.core.sensitivity.models import cor_sensitivity_area_type
 from geonature.core.gn_meta.models import TDatasets
 from geonature.core.gn_synthese.models import Synthese, TSources, VSyntheseForWebApp
+from geonature.core.gn_monitoring.models import TIndividuals
 from geonature.core.gn_synthese.synthese_config import MANDATORY_COLUMNS
 
 from geonature.core.gn_synthese.schemas import SyntheseSchema
@@ -1468,6 +1469,28 @@ class TestSynthese:
             )
         )
         assert response.status_code == Forbidden.code
+
+    def test_synthese_schema_individual(self, users, synthese_data):
+        synthese_obs = synthese_data["obs1"]
+
+        individual = TIndividuals(
+            individual_name="Test schema individual",
+            cd_nom=synthese_obs.cd_nom,
+            digitiser=users["admin_user"],
+        )
+        with db.session.begin_nested():
+            db.session.add(individual)
+        with db.session.begin_nested():
+            synthese_obs.individual = individual
+
+        dumped = SyntheseSchema().dump(synthese_obs)
+        assert dumped["id_individual"] == individual.id_individual
+
+        with db.session.begin_nested():
+            synthese_obs.individual = None
+
+        dumped = SyntheseSchema().dump(synthese_obs)
+        assert dumped["id_individual"] is None
 
     def test_taxon_observer(self, synthese_data, users):
         set_logged_user(self.client, users["stranger_user"])

--- a/contrib/occtax/backend/occtax/migrations/b089ac1a2973_add_id_individual_in_cor_counting_occtax.py
+++ b/contrib/occtax/backend/occtax/migrations/b089ac1a2973_add_id_individual_in_cor_counting_occtax.py
@@ -1,0 +1,429 @@
+"""add id_individual in cor_counting_occtax
+
+Revision ID: b089ac1a2973
+Revises: 4d4e4b7350fe
+Create Date: 2026-06-22 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "b089ac1a2973"
+down_revision = "4d4e4b7350fe"
+branch_labels = None
+depends_on = ("84f40d008640",)  # gn_monitoring.t_individuals creation
+
+
+def upgrade():
+    op.add_column(
+        "cor_counting_occtax",
+        sa.Column(
+            "id_individual",
+            sa.Integer(),
+            sa.ForeignKey(
+                "gn_monitoring.t_individuals.id_individual",
+                name="fk_cor_counting_occtax_id_individual",
+                onupdate="CASCADE",
+                ondelete="SET NULL",
+            ),
+            nullable=True,
+        ),
+        schema="pr_occtax",
+    )
+
+    op.execute("""
+        CREATE OR REPLACE FUNCTION pr_occtax.insert_in_synthese(my_id_counting integer)
+            RETURNS integer[]
+            LANGUAGE plpgsql
+            AS $function$  DECLARE
+            new_count RECORD;
+            occurrence RECORD;
+            releve RECORD;
+            id_source integer;
+            id_nomenclature_source_status integer;
+            myobservers RECORD;
+            id_role_loop integer;
+
+            BEGIN
+            --recupération du counting à partir de son ID
+            SELECT INTO new_count * FROM pr_occtax.cor_counting_occtax WHERE id_counting_occtax = my_id_counting;
+
+            -- Récupération de l'occurrence
+            SELECT INTO occurrence * FROM pr_occtax.t_occurrences_occtax occ WHERE occ.id_occurrence_occtax = new_count.id_occurrence_occtax;
+
+            -- Récupération du relevé
+            SELECT INTO releve * FROM pr_occtax.t_releves_occtax rel WHERE occurrence.id_releve_occtax = rel.id_releve_occtax;
+
+            -- Récupération de la source
+            SELECT INTO id_source s.id_source FROM gn_synthese.t_sources s WHERE id_module = releve.id_module;
+
+            -- Récupération du status_source depuis le JDD
+            SELECT INTO id_nomenclature_source_status d.id_nomenclature_source_status FROM gn_meta.t_datasets d WHERE id_dataset = releve.id_dataset;
+
+            --Récupération et formatage des observateurs
+            SELECT INTO myobservers array_to_string(array_agg(rol.nom_role || ' ' || rol.prenom_role), ', ') AS observers_name,
+            array_agg(rol.id_role) AS observers_id
+            FROM pr_occtax.cor_role_releves_occtax cor
+            JOIN utilisateurs.t_roles rol ON rol.id_role = cor.id_role
+            WHERE cor.id_releve_occtax = releve.id_releve_occtax;
+
+            -- insertion dans la synthese
+            INSERT INTO gn_synthese.synthese (
+            unique_id_sinp,
+            unique_id_sinp_grp,
+            id_source,
+            entity_source_pk_value,
+            id_dataset,
+            id_module,
+            id_nomenclature_geo_object_nature,
+            id_nomenclature_grp_typ,
+            grp_method,
+            id_nomenclature_obs_technique,
+            id_nomenclature_bio_status,
+            id_nomenclature_bio_condition,
+            id_nomenclature_naturalness,
+            id_nomenclature_exist_proof,
+            id_nomenclature_diffusion_level,
+            id_nomenclature_life_stage,
+            id_nomenclature_sex,
+            id_nomenclature_obj_count,
+            id_nomenclature_type_count,
+            id_nomenclature_observation_status,
+            id_nomenclature_blurring,
+            id_nomenclature_source_status,
+            id_nomenclature_info_geo_type,
+            id_nomenclature_behaviour,
+            count_min,
+            count_max,
+            cd_nom,
+            cd_hab,
+            nom_cite,
+            meta_v_taxref,
+            sample_number_proof,
+            digital_proof,
+            non_digital_proof,
+            altitude_min,
+            altitude_max,
+            depth_min,
+            depth_max,
+            place_name,
+            precision,
+            the_geom_4326,
+            the_geom_point,
+            the_geom_local,
+            date_min,
+            date_max,
+            observers,
+            determiner,
+            id_digitiser,
+            id_nomenclature_determination_method,
+            comment_context,
+            comment_description,
+            last_action,
+            additional_data,
+            id_individual
+            )
+            VALUES(
+                new_count.unique_id_sinp_occtax,
+                releve.unique_id_sinp_grp,
+                id_source,
+                new_count.id_counting_occtax,
+                releve.id_dataset,
+                releve.id_module,
+                releve.id_nomenclature_geo_object_nature,
+                releve.id_nomenclature_grp_typ,
+                releve.grp_method,
+                occurrence.id_nomenclature_obs_technique,
+                occurrence.id_nomenclature_bio_status,
+                occurrence.id_nomenclature_bio_condition,
+                occurrence.id_nomenclature_naturalness,
+                occurrence.id_nomenclature_exist_proof,
+                occurrence.id_nomenclature_diffusion_level,
+                new_count.id_nomenclature_life_stage,
+                new_count.id_nomenclature_sex,
+                new_count.id_nomenclature_obj_count,
+                new_count.id_nomenclature_type_count,
+                occurrence.id_nomenclature_observation_status,
+                occurrence.id_nomenclature_blurring,
+                -- status_source récupéré depuis le JDD
+                id_nomenclature_source_status,
+                -- id_nomenclature_info_geo_type: type de rattachement = non saisissable: georeferencement
+                ref_nomenclatures.get_id_nomenclature('TYP_INF_GEO', '1'),
+                occurrence.id_nomenclature_behaviour,
+                new_count.count_min,
+                new_count.count_max,
+                occurrence.cd_nom,
+                releve.cd_hab,
+                occurrence.nom_cite,
+                occurrence.meta_v_taxref,
+                occurrence.sample_number_proof,
+                occurrence.digital_proof,
+                occurrence.non_digital_proof,
+                releve.altitude_min,
+                releve.altitude_max,
+                releve.depth_min,
+                releve.depth_max,
+                releve.place_name,
+                releve.precision,
+                releve.geom_4326,
+                ST_CENTROID(releve.geom_4326),
+                releve.geom_local,
+                date_trunc('day',releve.date_min)+COALESCE(releve.hour_min,'00:00:00'::time),
+                date_trunc('day',releve.date_max)+COALESCE(releve.hour_max,'00:00:00'::time),
+                COALESCE (myobservers.observers_name, releve.observers_txt),
+                occurrence.determiner,
+                releve.id_digitiser,
+                occurrence.id_nomenclature_determination_method,
+                releve.comment,
+                occurrence.comment,
+                'I',
+                COALESCE(releve.additional_fields, '{}'::jsonb) || COALESCE(occurrence.additional_fields, '{}'::jsonb) || COALESCE(new_count.additional_fields, '{}'::jsonb),
+                new_count.id_individual
+            );
+
+                RETURN myobservers.observers_id ;
+            END;
+            $function$;
+        """)
+
+    op.execute("""
+        CREATE OR REPLACE FUNCTION pr_occtax.fct_tri_synthese_update_counting()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $function$DECLARE
+        occurrence RECORD;
+        releve RECORD;
+        BEGIN
+
+        -- Récupération de l'occurrence
+        SELECT INTO occurrence * FROM pr_occtax.t_occurrences_occtax occ WHERE occ.id_occurrence_occtax = NEW.id_occurrence_occtax;
+        -- Récupération du relevé
+        SELECT INTO releve * FROM pr_occtax.t_releves_occtax rel WHERE occurrence.id_releve_occtax = rel.id_releve_occtax;
+
+        -- Update dans la synthese
+        UPDATE gn_synthese.synthese
+        SET
+        entity_source_pk_value = NEW.id_counting_occtax,
+        id_nomenclature_life_stage = NEW.id_nomenclature_life_stage,
+        id_nomenclature_sex = NEW.id_nomenclature_sex,
+        id_nomenclature_obj_count = NEW.id_nomenclature_obj_count,
+        id_nomenclature_type_count = NEW.id_nomenclature_type_count,
+        count_min = NEW.count_min,
+        count_max = NEW.count_max,
+        last_action = 'U',
+        --CHAMPS ADDITIONNELS OCCTAX
+        additional_data = COALESCE(releve.additional_fields, '{}'::jsonb) || COALESCE(occurrence.additional_fields, '{}'::jsonb) || COALESCE(NEW.additional_fields, '{}'::jsonb),
+        id_individual = NEW.id_individual
+        WHERE unique_id_sinp = NEW.unique_id_sinp_occtax;
+        IF(NEW.unique_id_sinp_occtax <> OLD.unique_id_sinp_occtax) THEN
+            RAISE EXCEPTION 'ATTENTION : %', 'Le champ "unique_id_sinp_occtax" est généré par GeoNature et ne doit pas être changé.'
+                || chr(10) || 'Il est utilisé par le SINP pour identifier de manière unique une observation.'
+                || chr(10) || 'Si vous le changez, le SINP considérera cette observation comme une nouvelle observation.'
+                || chr(10) || 'Si vous souhaitez vraiment le changer, désactivez ce trigger, faite le changement, réactiez ce trigger'
+                || chr(10) || 'ET répercutez manuellement les changements dans "gn_synthese.synthese".';
+        END IF;
+        RETURN NULL;
+        END;
+        $function$
+        ;
+        """)
+
+
+def downgrade():
+    op.execute("""
+        CREATE OR REPLACE FUNCTION pr_occtax.fct_tri_synthese_update_counting()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $function$DECLARE
+        occurrence RECORD;
+        releve RECORD;
+        BEGIN
+
+        -- Récupération de l'occurrence
+        SELECT INTO occurrence * FROM pr_occtax.t_occurrences_occtax occ WHERE occ.id_occurrence_occtax = NEW.id_occurrence_occtax;
+        -- Récupération du relevé
+        SELECT INTO releve * FROM pr_occtax.t_releves_occtax rel WHERE occurrence.id_releve_occtax = rel.id_releve_occtax;
+
+        -- Update dans la synthese
+        UPDATE gn_synthese.synthese
+        SET
+        entity_source_pk_value = NEW.id_counting_occtax,
+        id_nomenclature_life_stage = NEW.id_nomenclature_life_stage,
+        id_nomenclature_sex = NEW.id_nomenclature_sex,
+        id_nomenclature_obj_count = NEW.id_nomenclature_obj_count,
+        id_nomenclature_type_count = NEW.id_nomenclature_type_count,
+        count_min = NEW.count_min,
+        count_max = NEW.count_max,
+        last_action = 'U',
+        --CHAMPS ADDITIONNELS OCCTAX
+        additional_data = COALESCE(releve.additional_fields, '{}'::jsonb) || COALESCE(occurrence.additional_fields, '{}'::jsonb) || COALESCE(NEW.additional_fields, '{}'::jsonb)
+        WHERE unique_id_sinp = NEW.unique_id_sinp_occtax;
+        IF(NEW.unique_id_sinp_occtax <> OLD.unique_id_sinp_occtax) THEN
+            RAISE EXCEPTION 'ATTENTION : %', 'Le champ "unique_id_sinp_occtax" est généré par GeoNature et ne doit pas être changé.'
+                || chr(10) || 'Il est utilisé par le SINP pour identifier de manière unique une observation.'
+                || chr(10) || 'Si vous le changez, le SINP considérera cette observation comme une nouvelle observation.'
+                || chr(10) || 'Si vous souhaitez vraiment le changer, désactivez ce trigger, faite le changement, réactiez ce trigger'
+                || chr(10) || 'ET répercutez manuellement les changements dans "gn_synthese.synthese".';
+        END IF;
+        RETURN NULL;
+        END;
+        $function$
+        ;
+        """)
+
+    op.execute("""
+        CREATE OR REPLACE FUNCTION pr_occtax.insert_in_synthese(my_id_counting integer)
+            RETURNS integer[]
+            LANGUAGE plpgsql
+            AS $function$  DECLARE
+            new_count RECORD;
+            occurrence RECORD;
+            releve RECORD;
+            id_source integer;
+            id_nomenclature_source_status integer;
+            myobservers RECORD;
+            id_role_loop integer;
+
+            BEGIN
+            --recupération du counting à partir de son ID
+            SELECT INTO new_count * FROM pr_occtax.cor_counting_occtax WHERE id_counting_occtax = my_id_counting;
+
+            -- Récupération de l'occurrence
+            SELECT INTO occurrence * FROM pr_occtax.t_occurrences_occtax occ WHERE occ.id_occurrence_occtax = new_count.id_occurrence_occtax;
+
+            -- Récupération du relevé
+            SELECT INTO releve * FROM pr_occtax.t_releves_occtax rel WHERE occurrence.id_releve_occtax = rel.id_releve_occtax;
+
+            -- Récupération de la source
+            SELECT INTO id_source s.id_source FROM gn_synthese.t_sources s WHERE id_module = releve.id_module;
+
+            -- Récupération du status_source depuis le JDD
+            SELECT INTO id_nomenclature_source_status d.id_nomenclature_source_status FROM gn_meta.t_datasets d WHERE id_dataset = releve.id_dataset;
+
+            --Récupération et formatage des observateurs
+            SELECT INTO myobservers array_to_string(array_agg(rol.nom_role || ' ' || rol.prenom_role), ', ') AS observers_name,
+            array_agg(rol.id_role) AS observers_id
+            FROM pr_occtax.cor_role_releves_occtax cor
+            JOIN utilisateurs.t_roles rol ON rol.id_role = cor.id_role
+            WHERE cor.id_releve_occtax = releve.id_releve_occtax;
+
+            -- insertion dans la synthese
+            INSERT INTO gn_synthese.synthese (
+            unique_id_sinp,
+            unique_id_sinp_grp,
+            id_source,
+            entity_source_pk_value,
+            id_dataset,
+            id_module,
+            id_nomenclature_geo_object_nature,
+            id_nomenclature_grp_typ,
+            grp_method,
+            id_nomenclature_obs_technique,
+            id_nomenclature_bio_status,
+            id_nomenclature_bio_condition,
+            id_nomenclature_naturalness,
+            id_nomenclature_exist_proof,
+            id_nomenclature_diffusion_level,
+            id_nomenclature_life_stage,
+            id_nomenclature_sex,
+            id_nomenclature_obj_count,
+            id_nomenclature_type_count,
+            id_nomenclature_observation_status,
+            id_nomenclature_blurring,
+            id_nomenclature_source_status,
+            id_nomenclature_info_geo_type,
+            id_nomenclature_behaviour,
+            count_min,
+            count_max,
+            cd_nom,
+            cd_hab,
+            nom_cite,
+            meta_v_taxref,
+            sample_number_proof,
+            digital_proof,
+            non_digital_proof,
+            altitude_min,
+            altitude_max,
+            depth_min,
+            depth_max,
+            place_name,
+            precision,
+            the_geom_4326,
+            the_geom_point,
+            the_geom_local,
+            date_min,
+            date_max,
+            observers,
+            determiner,
+            id_digitiser,
+            id_nomenclature_determination_method,
+            comment_context,
+            comment_description,
+            last_action,
+            additional_data
+            )
+            VALUES(
+                new_count.unique_id_sinp_occtax,
+                releve.unique_id_sinp_grp,
+                id_source,
+                new_count.id_counting_occtax,
+                releve.id_dataset,
+                releve.id_module,
+                releve.id_nomenclature_geo_object_nature,
+                releve.id_nomenclature_grp_typ,
+                releve.grp_method,
+                occurrence.id_nomenclature_obs_technique,
+                occurrence.id_nomenclature_bio_status,
+                occurrence.id_nomenclature_bio_condition,
+                occurrence.id_nomenclature_naturalness,
+                occurrence.id_nomenclature_exist_proof,
+                occurrence.id_nomenclature_diffusion_level,
+                new_count.id_nomenclature_life_stage,
+                new_count.id_nomenclature_sex,
+                new_count.id_nomenclature_obj_count,
+                new_count.id_nomenclature_type_count,
+                occurrence.id_nomenclature_observation_status,
+                occurrence.id_nomenclature_blurring,
+                -- status_source récupéré depuis le JDD
+                id_nomenclature_source_status,
+                -- id_nomenclature_info_geo_type: type de rattachement = non saisissable: georeferencement
+                ref_nomenclatures.get_id_nomenclature('TYP_INF_GEO', '1'),
+                occurrence.id_nomenclature_behaviour,
+                new_count.count_min,
+                new_count.count_max,
+                occurrence.cd_nom,
+                releve.cd_hab,
+                occurrence.nom_cite,
+                occurrence.meta_v_taxref,
+                occurrence.sample_number_proof,
+                occurrence.digital_proof,
+                occurrence.non_digital_proof,
+                releve.altitude_min,
+                releve.altitude_max,
+                releve.depth_min,
+                releve.depth_max,
+                releve.place_name,
+                releve.precision,
+                releve.geom_4326,
+                ST_CENTROID(releve.geom_4326),
+                releve.geom_local,
+                date_trunc('day',releve.date_min)+COALESCE(releve.hour_min,'00:00:00'::time),
+                date_trunc('day',releve.date_max)+COALESCE(releve.hour_max,'00:00:00'::time),
+                COALESCE (myobservers.observers_name, releve.observers_txt),
+                occurrence.determiner,
+                releve.id_digitiser,
+                occurrence.id_nomenclature_determination_method,
+                releve.comment,
+                occurrence.comment,
+                'I',
+                COALESCE(releve.additional_fields, '{}'::jsonb) || COALESCE(occurrence.additional_fields, '{}'::jsonb) || COALESCE(new_count.additional_fields, '{}'::jsonb)
+            );
+
+                RETURN myobservers.observers_id ;
+            END;
+            $function$;
+        """)
+
+    op.drop_column("cor_counting_occtax", "id_individual", schema="pr_occtax")

--- a/contrib/occtax/backend/occtax/models.py
+++ b/contrib/occtax/backend/occtax/models.py
@@ -13,6 +13,7 @@ from utils_flask_sqla_geo.serializers import geoserializable
 
 from geonature.core.gn_commons.models import TMedias
 from geonature.core.gn_meta.models import TDatasets
+from geonature.core.gn_monitoring.models import TIndividuals
 from geonature.core.gn_permissions.tools import get_scopes_by_action
 from geonature.utils.env import DB, db
 
@@ -65,6 +66,10 @@ class CorCountingOccurrence(DB.Model):
     # additional fields dans occtax MET 14/10/2020
     additional_fields = DB.Column(JSONB)
     occurrence = db.relationship("TOccurrencesOccurrence", back_populates="cor_counting_occtax")
+
+    id_individual = DB.Column(DB.Integer, ForeignKey("gn_monitoring.t_individuals.id_individual"))
+    individual = DB.relationship(TIndividuals)
+
     readonly_fields = [
         "id_counting_occtax",
         "unique_id_sinp_occtax",

--- a/contrib/occtax/backend/occtax/schemas.py
+++ b/contrib/occtax/backend/occtax/schemas.py
@@ -14,7 +14,6 @@ from geonature.utils.env import MA
 from .models import CorCountingOccurrence, TOccurrencesOccurrence, TRelevesOccurrence
 from geonature.core.gn_meta.schemas import DatasetSchema
 from geonature.core.gn_commons.schemas import MediaSchema
-from geonature.core.gn_monitoring.schema import TIndividualsSchema
 from geonature.core.taxonomie.schemas import TaxrefSchema
 from geonature.utils.config import config
 from pypnusershub.db.models import User
@@ -74,7 +73,6 @@ class CountingSchema(MA.SQLAlchemyAutoSchema):
 
     medias = MA.Nested(MediaSchema, many=True)
     id_individual = MA.auto_field()
-    individual = MA.Nested(TIndividualsSchema, dump_only=True)
 
     @pre_load
     def make_counting(self, data, **kwargs):

--- a/contrib/occtax/backend/occtax/schemas.py
+++ b/contrib/occtax/backend/occtax/schemas.py
@@ -14,6 +14,7 @@ from geonature.utils.env import MA
 from .models import CorCountingOccurrence, TOccurrencesOccurrence, TRelevesOccurrence
 from geonature.core.gn_meta.schemas import DatasetSchema
 from geonature.core.gn_commons.schemas import MediaSchema
+from geonature.core.gn_monitoring.schema import TIndividualsSchema
 from geonature.core.taxonomie.schemas import TaxrefSchema
 from geonature.utils.config import config
 from pypnusershub.db.models import User
@@ -72,6 +73,8 @@ class CountingSchema(MA.SQLAlchemyAutoSchema):
         load_instance = True
 
     medias = MA.Nested(MediaSchema, many=True)
+    id_individual = MA.auto_field()
+    individual = MA.Nested(TIndividualsSchema, dump_only=True)
 
     @pre_load
     def make_counting(self, data, **kwargs):


### PR DESCRIPTION
To allow individual management in Occtax and Synthese

- Adds id_individual (FK → gn_monitoring.t_individuals) to gn_synthese.synthese and pr_occtax.cor_counting_occtax, mirroring the existing id_dataset pattern on both tables.
- Updates pr_occtax.insert_in_synthese() and pr_occtax.fct_tri_synthese_update_counting() so the id propagates from Occtax countings to synthese on insert/update.
- Adds individual relationship + schema field on Synthese and CorCountingOccurrence.
- Adds test_synthese_schema_individual in TestSynthese