### PR TITLE
errors: improve json preferred test

### DIFF
--- a/backend/geonature/core/errors.py
+++ b/backend/geonature/core/errors.py
@@ -8,11 +8,17 @@ from urllib.parse import urlencode
 from marshmallow.exceptions import ValidationError
 
 
+def json_preferred():
+    return (
+        request.accept_mimetypes.best_match(["application/json", "text/html"]) == "application/json"
+    )
+
+
 # Unauthorized means disconnected
 # (logged but not allowed to perform an action = Forbidden)
 @current_app.errorhandler(Unauthorized)
 def handle_unauthenticated_request(e):
-    if request.accept_mimetypes.best == "application/json":
+    if json_preferred():
         response = e.get_response()
         response.data = json.dumps(
             {
@@ -43,7 +49,7 @@ def handle_validation_error(e):
 @current_app.errorhandler(HTTPException)
 def handle_http_exception(e):
     response = e.get_response()
-    if request.accept_mimetypes.best == "application/json":
+    if json_preferred():
         response.data = json.dumps(
             {
                 "code": e.code,
@@ -68,7 +74,7 @@ def handle_internal_server_error(e):
     else:
         description = e.description
     response = e.get_response()
-    if request.accept_mimetypes.best == "application/json":
+    if json_preferred():
         response.data = json.dumps(
             {
                 "code": e.code,
@@ -82,7 +88,7 @@ def handle_internal_server_error(e):
 
 @current_app.errorhandler(Exception)
 def handle_exception(e):
-    if request.accept_mimetypes.best == "application/json":
+    if json_preferred():
         # exceptions are logged by flask when not handled or when re-raised.
         # as here we construct a json error response, we have to log the exception our-self.
         current_app.log_exception(sys.exc_info())


### PR DESCRIPTION
Notre gestionnaire d’erreur renvoie une réponse en JSON ou en HTML suivant le header `Accept`.
Le but est d’avoir du json lors d’une requête d’API par le front, mais une page HTML d’erreur lorsque l’on se situe dans l’admin.

Remarque : on ne pas faire `"application/json" in request.accept_mimetypes` car les navigateurs envoient `*/*` et donc cela serait toujours vrai, amenant à des erreurs en json dans l’admin.

J’ai une API permettant de renvoyer du geojson ou du json, au choix, suivant le header `Accept`. Lorsque l’on demande du geojson, on a alors `request.accept_mimetypes.best` qui vaut `application/geo+json`, et donc les erreurs sont renvoyées en HTML ! Avec cette PR, on peut envoyer `Accept: application/geo+json/ application/json` et donc bien recevoir du geojson, mais également des erreurs en json.