### PR TITLE
feat ID_ATTRIBUT_TAXHUB_FILTERS

### DIFF
--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -418,9 +418,13 @@ class Synthese(Schema):
 
     # --------------------------------------------------------------------
     # SYNTHESE - OBSERVATION DETAILS
-    # Liste des id attributs Taxhub à afficher sur la fiche détaile de la synthese
-    # et sur les filtres taxonomiques avancés
+    # Liste des id attributs Taxhub à afficher sur la fiche détaillée de la synthese
     ID_ATTRIBUT_TAXHUB = fields.List(fields.Integer(), load_default=[102, 103])
+    # Liste des id attributs Taxhub à utiliser dans les filtres taxonomiques avancés.
+    # Si la valeur est absente, le frontend utilise ID_ATTRIBUT_TAXHUB par rétrocompatibilité.
+    ID_ATTRIBUT_TAXHUB_FILTERS = fields.List(
+        fields.Integer(), allow_none=True, load_default=None
+    )
     # Display email on synthese and validation info obs modal
     DISPLAY_EMAIL = fields.Boolean(load_default=True)
 

--- a/backend/geonature/utils/config_schema.py
+++ b/backend/geonature/utils/config_schema.py
@@ -422,9 +422,7 @@ class Synthese(Schema):
     ID_ATTRIBUT_TAXHUB = fields.List(fields.Integer(), load_default=[102, 103])
     # Liste des id attributs Taxhub à utiliser dans les filtres taxonomiques avancés.
     # Si la valeur est absente, le frontend utilise ID_ATTRIBUT_TAXHUB par rétrocompatibilité.
-    ID_ATTRIBUT_TAXHUB_FILTERS = fields.List(
-        fields.Integer(), allow_none=True, load_default=None
-    )
+    ID_ATTRIBUT_TAXHUB_FILTERS = fields.List(fields.Integer(), allow_none=True, load_default=None)
     # Display email on synthese and validation info obs modal
     DISPLAY_EMAIL = fields.Boolean(load_default=True)
 

--- a/config/default_config.toml.example
+++ b/config/default_config.toml.example
@@ -271,10 +271,14 @@ MEDIA_CLEAN_CRONTAB = "0 1 * * *"
     # Nombre de résultats à afficher pour la recherche autocompletée de taxon
     TAXON_RESULT_NUMBER = 20
 
-    # Liste de 'id_attribut' TaxHub à afficher dans :
-    # - la modale du détail d'une observation
-    # - les filtres taxonomique avancés
+    # Liste de 'id_attribut' TaxHub à afficher dans la modale du détail Taxonomie
+    # d'une observation pour les Attribut(s) Taxonomique(s) locaux.
     ID_ATTRIBUT_TAXHUB = [102, 103]
+
+    # Liste de 'id_attribut' TaxHub à proposer dans les filtres taxonomiques avancés.
+    # Si ce paramètre est absent, ID_ATTRIBUT_TAXHUB est utilisé.
+    # Une liste vide désactive ces filtres.
+    ID_ATTRIBUT_TAXHUB_FILTERS = [102, 103]
 
     # Colonne de la table `gn_synthese.synthese` à masquer dans les filtres
     # du formulaire 'occurrence avancé'. Par défaut, c'est un tableau vide.

--- a/frontend/cypress/fixtures/config.json
+++ b/frontend/cypress/fixtures/config.json
@@ -122,6 +122,7 @@
       "dataset_name"
     ],
     "ID_ATTRIBUT_TAXHUB": [102, 103],
+    "ID_ATTRIBUT_TAXHUB_FILTERS": [102, 103],
     "DISPLAY_EMAIL": true,
     "EXPORT_GEOJSON_4326_COL": "geojson_4326",
     "EXPORT_OBSERVERS_COL": "observateurs",

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form-store.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form-store.service.ts
@@ -15,11 +15,10 @@ export class TaxonAdvancedStoreService {
   public taxonTree: any;
   public treeModel: TreeModel;
   public taxonTreeState: any;
-  public taxhubAttributes: any;
-  public formBuilded: boolean;
-  public taxonomyHab: Array<any>;
-  public taxonomyGroup2Inpn: Array<any>;
-  public taxonomyGroup3Inpn: Array<any>;
+  public taxhubAttributes: Array<any> = [];
+  public taxonomyHab: Array<any> = [];
+  public taxonomyGroup2Inpn: Array<any> = [];
+  public taxonomyGroup3Inpn: Array<any> = [];
   public redListsValues: any = {};
 
   constructor(
@@ -51,25 +50,7 @@ export class TaxonAdvancedStoreService {
       });
     });
 
-    // Get TaxHub attributes
-    this._dataService.getTaxhubBibAttributes().subscribe((attrs) => {
-      // Display only the taxhub attributes set in the config
-      this.taxhubAttributes = attrs
-        .filter((attr) => {
-          return this.config.SYNTHESE.ID_ATTRIBUT_TAXHUB.indexOf(attr.id_attribut) !== -1;
-        })
-        .map((attr) => {
-          // Format attributes to fit with the GeoNature dynamicFormComponent
-          attr['values'] = JSON.parse(attr['liste_valeur_attribut']).values;
-          attr['attribut_name'] = 'taxhub_attribut_' + attr['id_attribut'];
-          attr['required'] = attr['obligatoire'];
-          attr['attribut_label'] = attr['label_attribut'];
-          this._formGen.addNewControl(attr, this._formService.searchForm);
-
-          return attr;
-        });
-      this.formBuilded = true;
-    });
+    this.loadTaxhubAttributes();
 
     // Load habitat and group2inpn
     this._dataService.getTaxonomyHabitat().subscribe((data) => {
@@ -93,5 +74,73 @@ export class TaxonAdvancedStoreService {
     this._dataService.getGroup3Inpn().subscribe((data) => {
       this.taxonomyGroup3Inpn = data.map((item) => ({ value: item }));
     });
+  }
+
+  private loadTaxhubAttributes(): void {
+    const configuredFilterIds =
+      this.config.SYNTHESE.ID_ATTRIBUT_TAXHUB_FILTERS ??
+      this.config.SYNTHESE.ID_ATTRIBUT_TAXHUB ??
+      [];
+
+    if (configuredFilterIds.length === 0) {
+      return;
+    }
+
+    this._dataService.getTaxhubBibAttributes().subscribe({
+      next: (attributes) => {
+        this.taxhubAttributes = attributes.reduce((formDefinitions: Array<any>, attribute) => {
+          if (!configuredFilterIds.includes(attribute.id_attribut)) {
+            return formDefinitions;
+          }
+
+          const formDefinition = this.buildTaxhubFilter(attribute);
+          if (formDefinition) {
+            this._formGen.addNewControl(formDefinition, this._formService.searchForm);
+            formDefinitions.push(formDefinition);
+          }
+          return formDefinitions;
+        }, []);
+      },
+      error: (error) => {
+        console.error('Unable to load TaxHub attributes used as filters', error);
+        this.taxhubAttributes = [];
+      },
+    });
+  }
+
+  private buildTaxhubFilter(attribute: any): any | null {
+    if (!attribute.liste_valeur_attribut) {
+      console.warn(
+        `TaxHub attribute ${attribute.id_attribut} cannot be used as an advanced filter: ` +
+          'liste_valeur_attribut is empty.'
+      );
+      return null;
+    }
+
+    try {
+      const definition = JSON.parse(attribute.liste_valeur_attribut);
+      if (!Array.isArray(definition?.values)) {
+        console.warn(
+          `TaxHub attribute ${attribute.id_attribut} cannot be used as an advanced filter: ` +
+            'liste_valeur_attribut does not contain a values array.'
+        );
+        return null;
+      }
+
+      return {
+        ...attribute,
+        values: definition.values,
+        attribut_name: `taxhub_attribut_${attribute.id_attribut}`,
+        required: attribute.obligatoire,
+        attribut_label: attribute.label_attribut,
+      };
+    } catch (error) {
+      console.warn(
+        `TaxHub attribute ${attribute.id_attribut} cannot be used as an advanced filter: ` +
+          'liste_valeur_attribut is not valid JSON.',
+        error
+      );
+      return null;
+    }
   }
 }

--- a/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form.component.html
+++ b/frontend/src/app/GN2CommonModule/form/synthese-form/advanced-form/synthese-advanced-form.component.html
@@ -114,48 +114,50 @@
     </div>
   </div>
 
-  <div *ngIf="formService.formBuilded && formService.statusFilters.length > 0">
-    <h5>Statuts</h5>
-    <div
-      class="form-group"
-      *ngFor="let status of formService.statusFilters; let i = index"
-    >
-      <pnx-multiselect
-        *ngIf="status.show && status.status_types.length > 1"
-        [values]="status.values"
-        [parentFormControl]="status.control"
-        keyLabel="display"
-        keyValue="cd_type_statut"
-        [label]="status.display_name"
-        (onChange)="onStatusSelected($event)"
-        (onDelete)="onStatusDeleted($event)"
-      ></pnx-multiselect>
-
+  <div>
+    <div *ngIf="formService.statusFilters.length > 0">
+      <h5>Statuts</h5>
       <div
-        *ngIf="status.show && status.status_types.length == 1"
         class="form-group"
+        *ngFor="let status of formService.statusFilters; let i = index"
       >
-        <div class="custom-control custom-checkbox">
-          <input
-            type="checkbox"
-            [id]="status.control_name"
-            class="custom-control-input"
-            [formControl]="status.control"
-            [value]="status.status_types[0]"
-            [checked]="formService.selectedStatus.includes(status.status_types[0])"
-            (change)="onStatusCheckboxChanged($event)"
-          />
-          <label
-            [for]="status.control_name"
-            class="custom-control-label"
-          >
-            <small>{{ status.display_name }}</small>
-          </label>
+        <pnx-multiselect
+          *ngIf="status.show && status.status_types.length > 1"
+          [values]="status.values"
+          [parentFormControl]="status.control"
+          keyLabel="display"
+          keyValue="cd_type_statut"
+          [label]="status.display_name"
+          (onChange)="onStatusSelected($event)"
+          (onDelete)="onStatusDeleted($event)"
+        ></pnx-multiselect>
+
+        <div
+          *ngIf="status.show && status.status_types.length == 1"
+          class="form-group"
+        >
+          <div class="custom-control custom-checkbox">
+            <input
+              type="checkbox"
+              [id]="status.control_name"
+              class="custom-control-input"
+              [formControl]="status.control"
+              [value]="status.status_types[0]"
+              [checked]="formService.selectedStatus.includes(status.status_types[0])"
+              (change)="onStatusCheckboxChanged($event)"
+            />
+            <label
+              [for]="status.control_name"
+              class="custom-control-label"
+            >
+              <small>{{ status.display_name }}</small>
+            </label>
+          </div>
         </div>
       </div>
     </div>
 
-    <div *ngIf="formService.formBuilded && formService.redListsFilters.length > 0">
+    <div *ngIf="formService.redListsFilters.length > 0">
       <h5>Listes rouges</h5>
       <div
         class="form-group"
@@ -174,7 +176,7 @@
       </div>
     </div>
 
-    <div *ngIf="storeService.formBuilded">
+    <div>
       <h5>Attributs TaxRef</h5>
 
       <div class="form-group">
@@ -213,7 +215,7 @@
       </div>
     </div>
 
-    <div *ngIf="storeService.formBuilded && storeService.taxhubAttributes.length > 0">
+    <div *ngIf="storeService.taxhubAttributes.length > 0">
       <h5>Attributs TaxHub</h5>
       <div
         class="dynamic-form padding-sm"


### PR DESCRIPTION
Bonjour,
PR pour faire la décorrélation des filtres avancés et des attributs dans l'onglet taxonomie.

Nous commençons a bien remplir la table taxonomie.bib_attributs
avec des attributs locaux
<img width="1376" height="622" alt="image" src="https://github.com/user-attachments/assets/d9531698-3e67-4700-92e6-9963c90f542b" />

Comme le nom des espèces en breton ou les dates "officielles" de repro et migration
<img width="882" height="905" alt="image" src="https://github.com/user-attachments/assets/f24cfe51-eebb-4202-8456-58a9f4f1c5a0" />

Cependant beaucoup de ces attributs ne sont pas compatibles avec les filtres avancés de la synthèse.
Ce qui faisait disparaitre la section "attributs taxref" où la recherche par groupe inpn2 est beaucoup utilisée
<img width="1450" height="916" alt="image" src="https://github.com/user-attachments/assets/228e96c3-939b-47ea-bbd2-b9e6c68a3a4b" />


J'ai fait le moins de changements possibles, tout en ayant des tests pour les attributs taxhub, avec warning non bloquant dans le navigateur.
<img width="958" height="261" alt="image" src="https://github.com/user-attachments/assets/c6a57587-0571-431d-977f-50f9d8b86d3d" />
Et pour le html, j'ai légèrement modifié pour que chaque bloc ai sa div et test quand nécessaire

Dev assisté avec codex, testé en prod