### PR TITLE
fix: Now can have multiple type code for one label in metadata_area_f…

### DIFF
--- a/frontend/src/app/metadataModule/services/metadata.service.ts
+++ b/frontend/src/app/metadataModule/services/metadata.service.ts
@@ -18,6 +18,7 @@ interface MetadataSearchForm {
   date?: string | null;
   organism?: string | null;
   person?: string | null;
+
   [key: `area_${string}`]: Array<any>;
 }
 
@@ -60,7 +61,13 @@ export class MetadataService {
     });
 
     this.config.METADATA.METADATA_AREA_FILTERS.forEach((area) => {
-      const control_name = 'area_' + area['type_code'].toLowerCase();
+      let control_name: string;
+      if (typeof area['type_code'] === 'string') {
+        control_name = 'area_' + area['type_code'].toLowerCase();
+      } else if (Array.isArray(area['type_code'])) {
+        control_name =
+          'area_' + area['type_code'].map((code: string) => code.toLowerCase()).join('_');
+      }
       this.form.addControl(control_name, new UntypedFormControl(new Array()));
       const control = this.form.controls[control_name];
       area['control'] = control;
@@ -108,6 +115,7 @@ export class MetadataService {
     this.pageSize.next(page_size);
     this.pageIndex.next(page_index);
   }
+
   changePageEvent(pageEvent: PageEvent) {
     this.changePage(pageEvent.pageIndex, pageEvent.pageSize);
     this.search().subscribe(() => {


### PR DESCRIPTION
Il n'est pas possible de configurer plusieurs type de zone géographique pour un label dans metadata_area _filters alors que dans la synthese on peut. 

Cette configuration ne marchait pas
```toml
[[METADATA.METADATA_AREA_FILTERS]]
  label = "Espaces protégés"
  type_code = ["RNN", "RNR"]
```

<img width="2553" height="1285" alt="image" src="https://github.com/user-attachments/assets/5a5895d0-ab04-4e02-9f46-c5339bcc4a34" />
