### PR TITLE
chore(pre-commit): Update black to 26.5.1 to match what gn use

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.5.1
     hooks:
       - id: black
         name: Black lint check


### PR DESCRIPTION
Actuellement le pre-commit utilise black 25 qui n'est plus la version de black utilisée par GN 