### PR TITLE
Add a label on all additionnal (json)  nomenclature field

### DIFF
--- a/backend/geonature/core/gn_meta/schemas.py
+++ b/backend/geonature/core/gn_meta/schemas.py
@@ -13,6 +13,7 @@ from geonature.utils.env import MA, db
 from geonature.utils.schema import CruvedSchemaMixin
 from geonature.core.gn_commons.models import TModules
 from geonature.core.gn_commons.schemas import ModuleSchema
+from geonature.core.schemas import AdditionnalDataDuplicateField
 
 # Note: import of SourceSchema is importent as it trigger import of synthese models
 # which define TDatasets.sources and TDatasets.nb_observations_synthese, and these must be
@@ -72,6 +73,9 @@ class DatasetSchema(CruvedSchemaMixin, SmartRelationshipsMixin, MA.SQLAlchemyAut
     )
 
     creator = MA.Nested(UserSchema, dump_only=True)
+    additional_data = AdditionnalDataDuplicateField(
+        module_code="METADATA", object_code="METADATA_JEU_DE_DONNEES"
+    )
     nomenclature_data_type = MA.Nested(NomenclatureSchema, dump_only=True)
     nomenclature_collecting_method = MA.Nested(NomenclatureSchema, dump_only=True)
     nomenclature_data_origin = MA.Nested(NomenclatureSchema, dump_only=True)
@@ -199,6 +203,10 @@ class AcquisitionFrameworkSchema(
     # omit — see TAcquisitionFramework model for the defaults.
     unique_acquisition_framework_id = MA.auto_field(required=False, allow_none=True)
     acquisition_framework_start_date = MA.auto_field(required=False)
+    additional_data = AdditionnalDataDuplicateField(
+        module_code="METADATA", object_code="METADATA_CADRE_ACQUISITION"
+    )
+
     t_datasets = MA.Nested(DatasetSchema, many=True)
     datasets = MA.Nested(DatasetSchema, many=True)
     bibliographical_references = MA.Nested(BibliographicReferenceSchema, many=True)

--- a/backend/geonature/core/gn_meta/schemas.py
+++ b/backend/geonature/core/gn_meta/schemas.py
@@ -13,7 +13,7 @@ from geonature.utils.env import MA, db
 from geonature.utils.schema import CruvedSchemaMixin
 from geonature.core.gn_commons.models import TModules
 from geonature.core.gn_commons.schemas import ModuleSchema
-from geonature.core.schemas import AdditionnalDataDuplicateField
+from geonature.core.schemas import AdditionalDataWithNomenclatureField
 
 # Note: import of SourceSchema is importent as it trigger import of synthese models
 # which define TDatasets.sources and TDatasets.nb_observations_synthese, and these must be
@@ -73,7 +73,7 @@ class DatasetSchema(CruvedSchemaMixin, SmartRelationshipsMixin, MA.SQLAlchemyAut
     )
 
     creator = MA.Nested(UserSchema, dump_only=True)
-    additional_data = AdditionnalDataDuplicateField(
+    additional_data = AdditionalDataWithNomenclatureField(
         module_code="METADATA", object_code="METADATA_JEU_DE_DONNEES"
     )
     nomenclature_data_type = MA.Nested(NomenclatureSchema, dump_only=True)
@@ -203,7 +203,7 @@ class AcquisitionFrameworkSchema(
     # omit — see TAcquisitionFramework model for the defaults.
     unique_acquisition_framework_id = MA.auto_field(required=False, allow_none=True)
     acquisition_framework_start_date = MA.auto_field(required=False)
-    additional_data = AdditionnalDataDuplicateField(
+    additional_data = AdditionalDataWithNomenclatureField(
         module_code="METADATA", object_code="METADATA_CADRE_ACQUISITION"
     )
 

--- a/backend/geonature/core/schemas.py
+++ b/backend/geonature/core/schemas.py
@@ -1,3 +1,4 @@
+from flask import g
 from geonature.core.gn_commons.models.base import BibWidgets
 from marshmallow import fields
 from sqlalchemy import select
@@ -42,7 +43,11 @@ class AdditionalDataWithNomenclatureField(fields.Dict):
     def _deserialize(self, value, attr, data, **kwargs):
         # module_code may only be known at request time (eg. g.current_module),
         # in which case it's set on the parent schema instance instead of here.
-        module_code = self.module_code or self.parent.module_code
+        module_code = self.module_code or (
+            self.parent.module_code if hasattr(self.parent, "module_code") else None
+        )
+        if not module_code:
+            module_code = g.current_module.module_code if hasattr(g, "current_module") else None
         if module_code is None:
             raise BadRequest("No module code provided in NomenclatureAdditionalDataField")
         return _add_label_nomenclature_data_dict(

--- a/backend/geonature/core/schemas.py
+++ b/backend/geonature/core/schemas.py
@@ -1,0 +1,48 @@
+from marshmallow import fields
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+from werkzeug.exceptions import BadRequest
+
+from geonature.utils.env import db
+from geonature.core.gn_commons.models import TAdditionalFields
+from pypnnomenclature.models import TNomenclatures
+
+
+def _duplicate_nomenclature(value, module_code, object_code):
+    duplicate_key_dict = {}
+    fields = (
+        db.session.execute(
+            select(TAdditionalFields)
+            .options(joinedload(TAdditionalFields.type_widget))
+            .where(TAdditionalFields.modules.any(module_code=module_code))
+            .where(TAdditionalFields.objects.any(code_object=object_code))
+        )
+        .scalars()
+        .all()
+    )
+    nomenclature_fields_name = [
+        field.field_name for field in fields if field.type_widget.widget_name == "nomenclature"
+    ]
+    for key, val in (value or {}).items():
+        duplicate_key_dict[key] = val
+        if key in nomenclature_fields_name:
+            nomenclature = db.session.get(TNomenclatures, val)
+            if nomenclature:
+                duplicate_key_dict["_label_" + key] = nomenclature.label_default
+    return duplicate_key_dict
+
+
+class AdditionnalDataDuplicateField(fields.Dict):
+    def __init__(self, object_code, module_code=None, keys=None, values=None, **kwargs):
+        kwargs.setdefault("allow_none", True)
+        super().__init__(keys, values, **kwargs)
+        self.module_code = module_code
+        self.object_code = object_code
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        # module_code may only be known at request time (eg. g.current_module),
+        # in which case it's set on the parent schema instance instead of here.
+        module_code = self.module_code or self.parent.module_code
+        if module_code is None:
+            raise BadRequest("No module code provided in AdditionnalDataDuplicateField")
+        return _duplicate_nomenclature(value, module_code=module_code, object_code=self.object_code)

--- a/backend/geonature/core/schemas.py
+++ b/backend/geonature/core/schemas.py
@@ -1,3 +1,4 @@
+from geonature.core.gn_commons.models.base import BibWidgets
 from marshmallow import fields
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
@@ -8,7 +9,7 @@ from geonature.core.gn_commons.models import TAdditionalFields
 from pypnnomenclature.models import TNomenclatures
 
 
-def _duplicate_nomenclature(value, module_code, object_code):
+def _add_label_nomenclature_data_dict(value, module_code, object_code):
     duplicate_key_dict = {}
     fields = (
         db.session.execute(
@@ -26,13 +27,12 @@ def _duplicate_nomenclature(value, module_code, object_code):
     for key, val in (value or {}).items():
         duplicate_key_dict[key] = val
         if key in nomenclature_fields_name:
-            nomenclature = db.session.get(TNomenclatures, val)
-            if nomenclature:
-                duplicate_key_dict["_label_" + key] = nomenclature.label_default
+            if nomenclature := db.session.get(TNomenclatures, val):
+                duplicate_key_dict[f"_label_{key}"] = nomenclature.label_default
     return duplicate_key_dict
 
 
-class AdditionnalDataDuplicateField(fields.Dict):
+class AdditionalDataWithNomenclatureField(fields.Dict):
     def __init__(self, object_code, module_code=None, keys=None, values=None, **kwargs):
         kwargs.setdefault("allow_none", True)
         super().__init__(keys, values, **kwargs)
@@ -44,5 +44,7 @@ class AdditionnalDataDuplicateField(fields.Dict):
         # in which case it's set on the parent schema instance instead of here.
         module_code = self.module_code or self.parent.module_code
         if module_code is None:
-            raise BadRequest("No module code provided in AdditionnalDataDuplicateField")
-        return _duplicate_nomenclature(value, module_code=module_code, object_code=self.object_code)
+            raise BadRequest("No module code provided in NomenclatureAdditionalDataField")
+        return _add_label_nomenclature_data_dict(
+            value, module_code=module_code, object_code=self.object_code
+        )

--- a/backend/geonature/tests/fixtures/general.py
+++ b/backend/geonature/tests/fixtures/general.py
@@ -383,8 +383,17 @@ def celery_eager(app, monkeypatch):
     monkeypatch.setattr(celery_app.conf, "task_eager_propagates", True)
 
 
+@pytest.fixture(scope="session")
+def first_nomenclature(app):
+    """
+    A single nomenclature, shared by fixtures and tests needing one so they
+    all agree on the exact same id_nomenclature / label_default.
+    """
+    return db.session.execute(select(TNomenclatures).limit(1)).scalar_one()
+
+
 @pytest.fixture(scope="class")
-def acquisition_frameworks(users):
+def acquisition_frameworks(users, first_nomenclature):
     principal_actor_role = db.session.execute(
         select(TNomenclatures)
         .join(BibNomenclaturesTypes, BibNomenclaturesTypes.mnemonique == "ROLE_ACTEUR")
@@ -434,7 +443,8 @@ def acquisition_frameworks(users):
     # Add additional data to "af_1"
     afs["af_1"].additional_data = {
         "select_field_used": "value1",
-        "nomenclature_field_used": "Valeur De Nomenclature",
+        "nomenclature_field_used": first_nomenclature.id_nomenclature,
+        "_label_nomenclature_field_used": first_nomenclature.label_default,
         "text_field_used": "test",
         "date_field_used": {"day": 31, "year": 2025, "month": 10},
         "number_field_used": 1,
@@ -444,7 +454,7 @@ def acquisition_frameworks(users):
 
 
 @pytest.fixture(scope="class")
-def datasets(users, acquisition_frameworks, module):
+def datasets(users, acquisition_frameworks, module, first_nomenclature):
     principal_actor_role = db.session.execute(
         select(TNomenclatures)
         .join(BibNomenclaturesTypes, TNomenclatures.id_type == BibNomenclaturesTypes.id_type)
@@ -493,7 +503,8 @@ def datasets(users, acquisition_frameworks, module):
             if name == "own_dataset":
                 dataset.additional_data = {
                     "select_field_used": "value1",
-                    "nomenclature_field_used": "Valeur De Nomenclature",
+                    "nomenclature_field_used": first_nomenclature.id_nomenclature,
+                    "_label_nomenclature_field_used": first_nomenclature.label_default,
                     "text_field_used": "test",
                     "date_field_used": {"day": 31, "year": 2025, "month": 10},
                     "number_field_used": 1,
@@ -627,7 +638,7 @@ def create_synthese(
 
 
 @pytest.fixture(scope="class")
-def synthese_data(app, users, datasets, source, sources_modules, individual):
+def synthese_data(app, users, datasets, source, sources_modules, individuals):
     point1 = Point(5.92, 45.56)
     point2 = Point(-1.54, 46.85)
     point3 = Point(-3.486786, 48.832182)
@@ -669,7 +680,7 @@ def synthese_data(app, users, datasets, source, sources_modules, individual):
                 date_1,
                 altitude_1,
                 altitude_1,
-                individual.id_individual,
+                individuals[0].id_individual,
             ),
             (
                 "obs2",

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -18,7 +18,7 @@ from geonature.core.gn_meta.repositories import (
 from geonature.core.gn_meta.routes import get_af_from_id
 from geonature.core.gn_meta.schemas import AcquisitionFrameworkSchema, DatasetSchema
 from geonature.core.gn_synthese.models import Synthese
-from geonature.core.schemas import AdditionnalDataDuplicateField
+from geonature.core.schemas import AdditionalDataWithNomenclatureField
 from geonature.utils.env import db
 from pypnusershub.schemas import UserSchema
 from ref_geo.models import BibAreasTypes, LAreas
@@ -153,7 +153,7 @@ def test_dataset_schema_additional_data_field():
     scoped to METADATA / METADATA_JEU_DE_DONNEES, not a plain Dict field.
     """
     field = DatasetSchema()._declared_fields["additional_data"]
-    assert isinstance(field, AdditionnalDataDuplicateField)
+    assert isinstance(field, AdditionalDataWithNomenclatureField)
     assert field.module_code == "METADATA"
     assert field.object_code == "METADATA_JEU_DE_DONNEES"
 
@@ -165,7 +165,7 @@ def test_acquisition_framework_schema_additional_data_field():
     not a plain Dict field.
     """
     field = AcquisitionFrameworkSchema()._declared_fields["additional_data"]
-    assert isinstance(field, AdditionnalDataDuplicateField)
+    assert isinstance(field, AdditionalDataWithNomenclatureField)
     assert field.module_code == "METADATA"
     assert field.object_code == "METADATA_CADRE_ACQUISITION"
 

--- a/backend/geonature/tests/test_gn_meta.py
+++ b/backend/geonature/tests/test_gn_meta.py
@@ -16,8 +16,9 @@ from geonature.core.gn_meta.repositories import (
     cruved_ds_filter,
 )
 from geonature.core.gn_meta.routes import get_af_from_id
-from geonature.core.gn_meta.schemas import DatasetSchema
+from geonature.core.gn_meta.schemas import AcquisitionFrameworkSchema, DatasetSchema
 from geonature.core.gn_synthese.models import Synthese
+from geonature.core.schemas import AdditionnalDataDuplicateField
 from geonature.utils.env import db
 from pypnusershub.schemas import UserSchema
 from ref_geo.models import BibAreasTypes, LAreas
@@ -146,6 +147,30 @@ def get_csv_from_response(data):
 
 
 @pytest.mark.usefixtures("client_class")
+def test_dataset_schema_additional_data_field():
+    """
+    DatasetSchema.additional_data must be an AdditionnalDataDuplicateField
+    scoped to METADATA / METADATA_JEU_DE_DONNEES, not a plain Dict field.
+    """
+    field = DatasetSchema()._declared_fields["additional_data"]
+    assert isinstance(field, AdditionnalDataDuplicateField)
+    assert field.module_code == "METADATA"
+    assert field.object_code == "METADATA_JEU_DE_DONNEES"
+
+
+def test_acquisition_framework_schema_additional_data_field():
+    """
+    AcquisitionFrameworkSchema.additional_data must be an
+    AdditionnalDataDuplicateField scoped to METADATA / METADATA_CADRE_ACQUISITION,
+    not a plain Dict field.
+    """
+    field = AcquisitionFrameworkSchema()._declared_fields["additional_data"]
+    assert isinstance(field, AdditionnalDataDuplicateField)
+    assert field.module_code == "METADATA"
+    assert field.object_code == "METADATA_CADRE_ACQUISITION"
+
+
+@pytest.mark.usefixtures("client_class", "temporary_transaction")
 class TestGNMeta:
 
     class TestGetAcquisitionFrameworkRoute:
@@ -913,7 +938,7 @@ class TestGNMeta:
         assert response.status_code == 400
         assert response.json["description"].get("active")
 
-    def test_get_dataset(self, users, datasets, additional_fields):
+    def test_get_dataset(self, users, datasets, additional_fields, first_nomenclature):
         ds = datasets["own_dataset"]
 
         response = self.client.get(url_for("gn_meta.get_dataset", id_dataset=ds.id_dataset))
@@ -935,7 +960,8 @@ class TestGNMeta:
         assert DatasetSchema().validate(response.json)
         assert response.json["additional_data"] == {
             "select_field_used": "value1",
-            "nomenclature_field_used": "Valeur De Nomenclature",
+            "nomenclature_field_used": first_nomenclature.id_nomenclature,
+            "_label_nomenclature_field_used": first_nomenclature.label_default,
             "text_field_used": "test",
             "date_field_used": {"day": 31, "year": 2025, "month": 10},
             "number_field_used": 1,

--- a/backend/geonature/tests/test_pr_occtax.py
+++ b/backend/geonature/tests/test_pr_occtax.py
@@ -15,7 +15,7 @@ from sqlalchemy import func, select
 from click.testing import CliRunner
 
 from geonature.core.gn_synthese.models import Synthese
-from geonature.core.schemas import AdditionnalDataDuplicateField
+from geonature.core.schemas import AdditionalDataWithNomenclatureField
 from geonature.utils.env import db
 from geonature.utils.config import config
 from .utils import set_logged_user
@@ -390,7 +390,7 @@ class TestOcctaxReleve:
         }
         for schema_cls, object_code in expected.items():
             field = schema_cls()._declared_fields["additional_fields"]
-            assert isinstance(field, AdditionnalDataDuplicateField)
+            assert isinstance(field, AdditionalDataWithNomenclatureField)
             assert field.object_code == object_code
 
     def test_get_releve(self, users: dict, releve_occtax: Any):

--- a/backend/geonature/tests/test_pr_occtax.py
+++ b/backend/geonature/tests/test_pr_occtax.py
@@ -210,7 +210,7 @@ def additional_field(app, datasets):
 @pytest.fixture(scope="function")
 def additional_field_nomenclature(app, datasets):
     """
-    Nomenclature-widget additional field on OCCTAX_OCCURENCE, restricted to
+    Nomenclature-widget additional field on OCCTAX_OCCURRENCE, restricted to
     datasets["own_dataset"] only, used to check that CSV export replaces the
     nomenclature id with its label.
     """
@@ -218,7 +218,7 @@ def additional_field_nomenclature(app, datasets):
         select(TModules).where(TModules.module_code == "OCCTAX")
     ).scalar_one()
     obj = db.session.execute(
-        select(PermObject).where(PermObject.code_object == "OCCTAX_OCCURENCE")
+        select(PermObject).where(PermObject.code_object == "OCCTAX_OCCURRENCE")
     ).scalar_one()
     nomenclature_widget = db.session.execute(
         select(BibWidgets).where(BibWidgets.widget_name == "nomenclature")
@@ -299,7 +299,7 @@ def additional_fields_occtax_nomenclature(app, datasets):
     fields = {}
     for key, code_object, field_name in [
         ("releve", "OCCTAX_RELEVE", "releve_nomenclature_field"),
-        ("occurrence", "OCCTAX_OCCURENCE", "occurrence_nomenclature_field"),
+        ("occurrence", "OCCTAX_OCCURRENCE", "occurrence_nomenclature_field"),
         ("counting", "OCCTAX_DENOMBREMENT", "counting_nomenclature_field"),
     ]:
         obj = db.session.execute(
@@ -385,7 +385,7 @@ class TestOcctaxReleve:
         g.current_module = occtax_module
         expected = {
             ReleveSchema: "OCCTAX_RELEVE",
-            OccurrenceSchema: "OCCTAX_OCCURENCE",
+            OccurrenceSchema: "OCCTAX_OCCURRENCE",
             CountingSchema: "OCCTAX_DENOMBREMENT",
         }
         for schema_cls, object_code in expected.items():

--- a/backend/geonature/tests/test_pr_occtax.py
+++ b/backend/geonature/tests/test_pr_occtax.py
@@ -1,8 +1,11 @@
+import csv
+from io import StringIO
 from typing import Any
-from geonature.core.gn_commons.models.base import TModules
+from geonature.core.gn_commons.models.base import TModules, BibWidgets
 from geonature.core.gn_commons.models.additional_fields import TAdditionalFields
 from geonature.core.gn_meta.models import TDatasets
 from geonature.core.gn_permissions.models import PermissionAvailable, PermObject
+from pypnnomenclature.models import TNomenclatures
 import pytest
 
 
@@ -12,6 +15,7 @@ from sqlalchemy import func, select
 from click.testing import CliRunner
 
 from geonature.core.gn_synthese.models import Synthese
+from geonature.core.schemas import AdditionnalDataDuplicateField
 from geonature.utils.env import db
 from geonature.utils.config import config
 from .utils import set_logged_user
@@ -25,7 +29,7 @@ from occtax.models import (
     TOccurrencesOccurrence,
     CorCountingOccurrence,
 )
-from occtax.schemas import OccurrenceSchema, ReleveSchema
+from occtax.schemas import OccurrenceSchema, ReleveSchema, CountingSchema
 from occtax.commands import create_duplicated_module
 
 
@@ -203,6 +207,118 @@ def additional_field(app, datasets):
     return additional_field
 
 
+@pytest.fixture(scope="function")
+def additional_field_nomenclature(app, datasets):
+    """
+    Nomenclature-widget additional field on OCCTAX_OCCURENCE, restricted to
+    datasets["own_dataset"] only, used to check that CSV export replaces the
+    nomenclature id with its label.
+    """
+    module = db.session.execute(
+        select(TModules).where(TModules.module_code == "OCCTAX")
+    ).scalar_one()
+    obj = db.session.execute(
+        select(PermObject).where(PermObject.code_object == "OCCTAX_OCCURENCE")
+    ).scalar_one()
+    nomenclature_widget = db.session.execute(
+        select(BibWidgets).where(BibWidgets.widget_name == "nomenclature")
+    ).scalar_one()
+    additional_field = TAdditionalFields(
+        field_name="occurrence_nomenclature_export_field",
+        field_label="Champ nomenclature export",
+        required=False,
+        id_widget=nomenclature_widget.id_widget,
+        modules=[module],
+        objects=[obj],
+        datasets=[datasets["own_dataset"]],
+    )
+    with db.session.begin_nested():
+        db.session.add(additional_field)
+    return additional_field
+
+
+@pytest.fixture(scope="function")
+def additional_fields_releve(app, datasets):
+    """
+    Additional fields scoped to module OCCTAX / object OCCTAX_RELEVE, used to
+    test AdditionnalDataDuplicateField on ReleveSchema.
+    """
+    module = db.session.execute(
+        select(TModules).where(TModules.module_code == "OCCTAX")
+    ).scalar_one()
+    obj = db.session.execute(
+        select(PermObject).where(PermObject.code_object == "OCCTAX_RELEVE")
+    ).scalar_one()
+    text_widget = db.session.execute(
+        select(BibWidgets).where(BibWidgets.widget_name == "text")
+    ).scalar_one()
+    nomenclature_widget = db.session.execute(
+        select(BibWidgets).where(BibWidgets.widget_name == "nomenclature")
+    ).scalar_one()
+    datasets = list(datasets.values())
+
+    text_field = TAdditionalFields(
+        field_name="releve_text_field",
+        field_label="Champ texte",
+        required=False,
+        id_widget=text_widget.id_widget,
+        modules=[module],
+        objects=[obj],
+        datasets=datasets,
+    )
+    nomenclature_field = TAdditionalFields(
+        field_name="releve_nomenclature_field",
+        field_label="Champ nomenclature",
+        required=False,
+        id_widget=nomenclature_widget.id_widget,
+        modules=[module],
+        objects=[obj],
+        datasets=datasets,
+    )
+    with db.session.begin_nested():
+        db.session.add_all([text_field, nomenclature_field])
+    return {"text": text_field, "nomenclature": nomenclature_field}
+
+
+@pytest.fixture(scope="function")
+def additional_fields_occtax_nomenclature(app, datasets):
+    """
+    One nomenclature-widget additional field per OccTax object
+    (releve / occurrence / counting), used to test that
+    insertOrUpdateOneReleve duplicates nomenclature additional fields with a
+    "_label_" prefixed key.
+    """
+    module = db.session.execute(
+        select(TModules).where(TModules.module_code == "OCCTAX")
+    ).scalar_one()
+    nomenclature_widget = db.session.execute(
+        select(BibWidgets).where(BibWidgets.widget_name == "nomenclature")
+    ).scalar_one()
+    datasets = list(datasets.values())
+
+    fields = {}
+    for key, code_object, field_name in [
+        ("releve", "OCCTAX_RELEVE", "releve_nomenclature_field"),
+        ("occurrence", "OCCTAX_OCCURENCE", "occurrence_nomenclature_field"),
+        ("counting", "OCCTAX_DENOMBREMENT", "counting_nomenclature_field"),
+    ]:
+        obj = db.session.execute(
+            select(PermObject).where(PermObject.code_object == code_object)
+        ).scalar_one()
+        fields[key] = TAdditionalFields(
+            field_name=field_name,
+            field_label=field_name,
+            required=False,
+            id_widget=nomenclature_widget.id_widget,
+            modules=[module],
+            objects=[obj],
+            datasets=datasets,
+        )
+    with db.session.begin_nested():
+        db.session.add_all(fields.values())
+    return fields
+
+
 @pytest.fixture()
 def media_in_export_enabled(monkeypatch):
     monkeypatch.setitem(current_app.config["OCCTAX"], "ADD_MEDIA_IN_EXPORT", True)
@@ -260,6 +376,23 @@ def unexisting_id_releve():
 
 @pytest.mark.usefixtures("client_class", "datasets")
 class TestOcctaxReleve:
+    def test_occtax_schemas_additional_fields_field(self, occtax_module):
+        """
+        ReleveSchema/OccurrenceSchema/CountingSchema.additional_fields must be
+        AdditionnalDataDuplicateField instances scoped to the right object_code,
+        not plain Dict fields.
+        """
+        g.current_module = occtax_module
+        expected = {
+            ReleveSchema: "OCCTAX_RELEVE",
+            OccurrenceSchema: "OCCTAX_OCCURENCE",
+            CountingSchema: "OCCTAX_DENOMBREMENT",
+        }
+        for schema_cls, object_code in expected.items():
+            field = schema_cls()._declared_fields["additional_fields"]
+            assert isinstance(field, AdditionnalDataDuplicateField)
+            assert field.object_code == object_code
+
     def test_get_releve(self, users: dict, releve_occtax: Any):
         set_logged_user(self.client, users["user"])
 
@@ -297,9 +430,102 @@ class TestOcctaxReleve:
         )
         assert response.status_code == 200
 
-    def test_insertOrUpdate_releve(
-        self, users: dict, releve_mobile_data: dict[str, dict[str, Any]]
+    def test_releve_additional_fields_load(
+        self,
+        app: Flask,
+        users: dict,
+        releve_data: dict[str, Any],
+        occtax_module: Any,
+        additional_fields_releve: dict[str, TAdditionalFields],
     ):
+        """
+        ReleveSchema.load() must duplicate nomenclature additional fields with a
+        "_label_" prefixed key holding the nomenclature default label -- this is
+        where additional_fields values get persisted to DB, dump is left untouched
+        -- and leave non-nomenclature additional fields untouched.
+        """
+        g.current_module = occtax_module
+        text_field = additional_fields_releve["text"]
+        nomenclature_field = additional_fields_releve["nomenclature"]
+        nomenclature = db.session.execute(select(TNomenclatures).limit(1)).scalar_one()
+
+        data = releve_data["properties"]
+        data["geom_4326"] = releve_data["geometry"]
+        data["observers"] = [users["user"].id_role]
+        data["additional_fields"] = {
+            text_field.field_name: "some value",
+            nomenclature_field.field_name: nomenclature.id_nomenclature,
+        }
+
+        releve = ReleveSchema().load(data)
+
+        assert releve.additional_fields[text_field.field_name] == "some value"
+        assert (
+            releve.additional_fields[nomenclature_field.field_name] == nomenclature.id_nomenclature
+        )
+        assert (
+            releve.additional_fields["_label_" + nomenclature_field.field_name]
+            == nomenclature.label_default
+        )
+        assert "_label_" + text_field.field_name not in releve.additional_fields
+
+    def test_releve_additional_fields_load_unknown_nomenclature(
+        self,
+        app: Flask,
+        users: dict,
+        releve_data: dict[str, Any],
+        occtax_module: Any,
+        additional_fields_releve: dict[str, TAdditionalFields],
+    ):
+        """
+        When the posted value does not match any existing nomenclature, no
+        "_label_" key should be added.
+        """
+        g.current_module = occtax_module
+        nomenclature_field = additional_fields_releve["nomenclature"]
+        unexisting_id_nomenclature = (
+            db.session.execute(select(func.max(TNomenclatures.id_nomenclature))).scalar() or 0
+        ) + 1
+
+        data = releve_data["properties"]
+        data["geom_4326"] = releve_data["geometry"]
+        data["observers"] = [users["user"].id_role]
+        data["additional_fields"] = {
+            nomenclature_field.field_name: unexisting_id_nomenclature,
+        }
+
+        releve = ReleveSchema().load(data)
+
+        assert releve.additional_fields[nomenclature_field.field_name] == (
+            unexisting_id_nomenclature
+        )
+        assert "_label_" + nomenclature_field.field_name not in releve.additional_fields
+
+    def test_insertOrUpdate_releve(
+        self,
+        users: dict,
+        releve_mobile_data: dict[str, dict[str, Any]],
+        additional_fields_occtax_nomenclature: dict[str, TAdditionalFields],
+    ):
+        """
+        insertOrUpdateOneReleve must duplicate nomenclature additional fields
+        (on the releve, its occurrences and their countings) with a
+        "_label_" prefixed key holding the nomenclature default label.
+        """
+        releve_field = additional_fields_occtax_nomenclature["releve"]
+        occurrence_field = additional_fields_occtax_nomenclature["occurrence"]
+        counting_field = additional_fields_occtax_nomenclature["counting"]
+        nomenclature = db.session.execute(select(TNomenclatures).limit(1)).scalar_one()
+
+        releve_mobile_data["properties"]["additional_fields"] = {
+            releve_field.field_name: nomenclature.id_nomenclature,
+        }
+        occ = releve_mobile_data["properties"]["t_occurrences_occtax"][0]
+        occ["additional_fields"] = {occurrence_field.field_name: nomenclature.id_nomenclature}
+        occ["cor_counting_occtax"][0]["additional_fields"] = {
+            counting_field.field_name: nomenclature.id_nomenclature
+        }
+
         set_logged_user(self.client, users["stranger_user"])
         response = self.client.post(
             url_for("pr_occtax.insertOrUpdateOneReleve"), json=releve_mobile_data
@@ -313,6 +539,30 @@ class TestOcctaxReleve:
         assert response.status_code == 200
         result = db.get_or_404(TRelevesOccurrence, response.json["id"])
         assert result
+
+        assert result.additional_fields[releve_field.field_name] == nomenclature.id_nomenclature
+        assert (
+            result.additional_fields["_label_" + releve_field.field_name]
+            == nomenclature.label_default
+        )
+        occurrence_result = result.t_occurrences_occtax[0]
+        assert (
+            occurrence_result.additional_fields[occurrence_field.field_name]
+            == nomenclature.id_nomenclature
+        )
+        assert (
+            occurrence_result.additional_fields["_label_" + occurrence_field.field_name]
+            == nomenclature.label_default
+        )
+        counting_result = occurrence_result.cor_counting_occtax[0]
+        assert (
+            counting_result.additional_fields[counting_field.field_name]
+            == nomenclature.id_nomenclature
+        )
+        assert (
+            counting_result.additional_fields["_label_" + counting_field.field_name]
+            == nomenclature.label_default
+        )
 
         # Passage en Update
         releve_mobile_data["properties"]["altitude_min"] = 200
@@ -380,6 +630,35 @@ class TestOcctaxReleve:
         releve_data["properties"]["date_min"] = None
         response = self.client.post(url_for("pr_occtax.createReleve"), json=releve_data)
         assert response.status_code == BadRequest.code
+
+    def test_post_releve_additional_fields_nomenclature(
+        self,
+        users: dict,
+        releve_data: dict[str, Any],
+        additional_fields_releve: dict[str, TAdditionalFields],
+    ):
+        """
+        POST pr_occtax.createReleve must duplicate nomenclature additional
+        fields in its response, adding a "_label_" prefixed key holding the
+        nomenclature default label.
+        """
+        nomenclature_field = additional_fields_releve["nomenclature"]
+        nomenclature = db.session.execute(select(TNomenclatures).limit(1)).scalar_one()
+
+        set_logged_user(self.client, users["user"])
+        releve_data["properties"]["additional_fields"] = {
+            nomenclature_field.field_name: nomenclature.id_nomenclature,
+        }
+
+        response = self.client.post(url_for("pr_occtax.createReleve"), json=releve_data)
+
+        assert response.status_code == 200
+        additional_fields = response.json["properties"]["additional_fields"]
+        assert additional_fields[nomenclature_field.field_name] == nomenclature.id_nomenclature
+        assert (
+            additional_fields["_label_" + nomenclature_field.field_name]
+            == nomenclature.label_default
+        )
 
     def test_post_releve_in_module_bis(
         self,
@@ -780,10 +1059,20 @@ class TestOcctaxGetReleveFilter:
         users: dict,
         datasets: dict[Any, TDatasets],
         additional_field,
+        additional_field_nomenclature,
         occurrence,
         media_in_export_enabled,
     ):
-        # FIX ME: CHECK CONTENT
+        nomenclature = db.session.execute(select(TNomenclatures).limit(1)).scalar_one()
+        field_name = additional_field_nomenclature.field_name
+        occurrence.additional_fields = {
+            **(occurrence.additional_fields or {}),
+            field_name: nomenclature.id_nomenclature,
+            "_label_" + field_name: nomenclature.label_default,
+        }
+        db.session.add(occurrence)
+        db.session.flush()
+
         set_logged_user(self.client, users["user"])
         response = self.client.get(
             url_for(
@@ -791,6 +1080,16 @@ class TestOcctaxGetReleveFilter:
             ),
         )
         assert response.status_code == 200
+
+        # the additional nomenclature field must be exported with its label,
+        # not the raw id_nomenclature
+        csv_reader = csv.DictReader(StringIO(response.data.decode("utf-8")), delimiter=";")
+        rows = list(csv_reader)
+        assert field_name in csv_reader.fieldnames
+        assert len(rows) >= 1
+        for row in rows:
+            assert row[field_name] == nomenclature.label_default
+            assert row[field_name] != str(nomenclature.id_nomenclature)
 
         response = self.client.get(
             url_for("pr_occtax.export", id_dataset=datasets["own_dataset"].id_dataset),

--- a/contrib/occtax/backend/occtax/blueprint.py
+++ b/contrib/occtax/backend/occtax/blueprint.py
@@ -36,7 +36,7 @@ from .repositories import (
     get_query_occtax_filters,
     get_query_occtax_order,
 )
-from geonature.core.schemas import _duplicate_nomenclature
+from geonature.core.schemas import _add_label_nomenclature_data_dict
 from .schemas import OccurrenceSchema, ReleveCruvedSchema, ReleveSchema
 from .utils import as_dict_with_add_cols
 from geonature.utils.utilsgeometrytools import export_as_geo_file
@@ -276,7 +276,7 @@ def insertOrUpdateOneReleve():
     releve = TRelevesOccurrence(**data["properties"])
     two_dimension_geom = remove_third_dimension(shape(data["geometry"]))
     releve.geom_4326 = from_shape(two_dimension_geom, srid=4326)
-    releve.additional_fields = _duplicate_nomenclature(
+    releve.additional_fields = _add_label_nomenclature_data_dict(
         releve.additional_fields, module_code="OCCTAX", object_code="OCCTAX_RELEVE"
     )
 
@@ -300,7 +300,7 @@ def insertOrUpdateOneReleve():
         if "id_occurrence_occtax" in occ and occ["id_occurrence_occtax"] is None:
             occ.pop("id_occurrence_occtax")
         occtax = TOccurrencesOccurrence(**occ)
-        occtax.additional_fields = _duplicate_nomenclature(
+        occtax.additional_fields = _add_label_nomenclature_data_dict(
             occtax.additional_fields, module_code="OCCTAX", object_code="OCCTAX_OCCURENCE"
         )
 
@@ -315,7 +315,7 @@ def insertOrUpdateOneReleve():
             if "id_counting_occtax" in cnt and cnt["id_counting_occtax"] is None:
                 cnt.pop("id_counting_occtax")
             countingOccurrence = CorCountingOccurrence(**cnt)
-            countingOccurrence.additional_fields = _duplicate_nomenclature(
+            countingOccurrence.additional_fields = _add_label_nomenclature_data_dict(
                 countingOccurrence.additional_fields,
                 module_code="OCCTAX",
                 object_code="OCCTAX_DENOMBREMENT",

--- a/contrib/occtax/backend/occtax/blueprint.py
+++ b/contrib/occtax/backend/occtax/blueprint.py
@@ -36,6 +36,7 @@ from .repositories import (
     get_query_occtax_filters,
     get_query_occtax_order,
 )
+from geonature.core.schemas import _duplicate_nomenclature
 from .schemas import OccurrenceSchema, ReleveCruvedSchema, ReleveSchema
 from .utils import as_dict_with_add_cols
 from geonature.utils.utilsgeometrytools import export_as_geo_file
@@ -275,6 +276,9 @@ def insertOrUpdateOneReleve():
     releve = TRelevesOccurrence(**data["properties"])
     two_dimension_geom = remove_third_dimension(shape(data["geometry"]))
     releve.geom_4326 = from_shape(two_dimension_geom, srid=4326)
+    releve.additional_fields = _duplicate_nomenclature(
+        releve.additional_fields, module_code="OCCTAX", object_code="OCCTAX_RELEVE"
+    )
 
     if observersList is not None:
         observers = db.session.scalars(select(User).where(User.id_role.in_(observersList))).all()
@@ -296,6 +300,9 @@ def insertOrUpdateOneReleve():
         if "id_occurrence_occtax" in occ and occ["id_occurrence_occtax"] is None:
             occ.pop("id_occurrence_occtax")
         occtax = TOccurrencesOccurrence(**occ)
+        occtax.additional_fields = _duplicate_nomenclature(
+            occtax.additional_fields, module_code="OCCTAX", object_code="OCCTAX_OCCURENCE"
+        )
 
         for cnt in cor_counting_occtax:
             # Test et suppression
@@ -308,6 +315,12 @@ def insertOrUpdateOneReleve():
             if "id_counting_occtax" in cnt and cnt["id_counting_occtax"] is None:
                 cnt.pop("id_counting_occtax")
             countingOccurrence = CorCountingOccurrence(**cnt)
+            countingOccurrence.additional_fields = _duplicate_nomenclature(
+                countingOccurrence.additional_fields,
+                module_code="OCCTAX",
+                object_code="OCCTAX_DENOMBREMENT",
+            )
+
             occtax.cor_counting_occtax.append(countingOccurrence)
         releve.t_occurrences_occtax.append(occtax)
     # if its a update
@@ -622,8 +635,6 @@ def export(scope):
 
     data = db.session.execute(q)
 
-    print(data)
-
     file_name = datetime.datetime.now().strftime("%Y_%m_%d_%Hh%Mm%S")
     file_name = filemanager.removeDisallowedFilenameChars(file_name)
 
@@ -635,6 +646,7 @@ def export(scope):
     global_add_fields = db.session.scalars(
         query_add_fields.where(~TAdditionalFields.datasets.any())
     ).all()
+    dataset_add_fields = []
     if "id_dataset" in request.args:
         dataset_add_fields = db.session.scalars(
             query_add_fields.where(
@@ -644,6 +656,11 @@ def export(scope):
         global_add_fields = [*global_add_fields, *dataset_add_fields]
 
     additional_col_names = [field.field_name for field in global_add_fields]
+    additional_nomenclature_col_name = [
+        field.field_name
+        for field in global_add_fields
+        if field.type_widget.widget_name == "nomenclature"
+    ]
     if export_format == "csv":
         # set additional data col at the end (remove it and inset it ...)
         if export_col_name_additional_data in columns:
@@ -653,7 +670,11 @@ def export(scope):
         if additional_col_names:
             serialize_result = [
                 as_dict_with_add_cols(
-                    export_view, row, export_col_name_additional_data, additional_col_names
+                    export_view,
+                    row,
+                    export_col_name_additional_data,
+                    additional_col_names,
+                    additional_nomenclature_col_name,
                 )
                 for row in data
             ]

--- a/contrib/occtax/backend/occtax/blueprint.py
+++ b/contrib/occtax/backend/occtax/blueprint.py
@@ -301,7 +301,7 @@ def insertOrUpdateOneReleve():
             occ.pop("id_occurrence_occtax")
         occtax = TOccurrencesOccurrence(**occ)
         occtax.additional_fields = _add_label_nomenclature_data_dict(
-            occtax.additional_fields, module_code="OCCTAX", object_code="OCCTAX_OCCURENCE"
+            occtax.additional_fields, module_code="OCCTAX", object_code="OCCTAX_OCCURRENCE"
         )
 
         for cnt in cor_counting_occtax:

--- a/contrib/occtax/backend/occtax/migrations/26f11ef2fe77_object_rename_occtax_occurence_to_.py
+++ b/contrib/occtax/backend/occtax/migrations/26f11ef2fe77_object_rename_occtax_occurence_to_.py
@@ -1,0 +1,28 @@
+"""[object] rename OCCTAX_OCCURENCE to OCCTAX_OCCURRENCE
+
+Revision ID: 26f11ef2fe77
+Revises: a22f59a3912c
+Create Date: 2026-08-27 10:59:00.346923
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "26f11ef2fe77"
+down_revision = "a22f59a3912c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "UPDATE gn_permissions.t_objects SET code_object = 'OCCTAX_OCCURRENCE' WHERE code_object = 'OCCTAX_OCCURENCE'"
+    )
+
+
+def downgrade():
+    op.execute(
+        "UPDATE gn_permissions.t_objects SET code_object = 'OCCTAX_OCCURENCE' WHERE code_object = 'OCCTAX_OCCURRENCE'"
+    )

--- a/contrib/occtax/backend/occtax/migrations/a22f59a3912c_mobile_additional_fields_process_.py
+++ b/contrib/occtax/backend/occtax/migrations/a22f59a3912c_mobile_additional_fields_process_.py
@@ -1,0 +1,189 @@
+"""MOBILE : Additional fields - process nomenclature
+
+Revision ID: a22f59a3912c
+Revises: b5b0d26c1fcc
+Create Date: 2026-08-10 10:36:15.272438
+
+Migration des données des champs additionnels de type nomenclature d'occtax saisies dans le formulaire mobile
+Concerne les tables :
+    - t_releves_occtax
+    - t_occurrences_occtax
+    - cor_counting_occtax
+
+Transformation :
+    {'mon_champ' : id_nomenclature} -> {'mon_champ' : id_nomenclature, '_label_mon_champ' : 'label_default'}
+Exception :
+    - Si le champ à été transformé pour correspondre au label_nomenclature
+        {'mon_champ' : 'label_default'} -> {'mon_champ' : 'id_nomenclature', '_label_mon_champ' : 'label_default'}
+    - Si l'id n'est pas retrouvé dans la nomenclature  {'mon_champ' : id_nomenclature , '_label_mon_champ' : null}
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = "a22f59a3912c"
+down_revision = "b5b0d26c1fcc"
+branch_labels = None
+depends_on = None
+
+
+SOURCES = [
+    {
+        "id_field": "id_releve_occtax",
+        "table_name": "t_releves_occtax",
+        "object_code": "OCCTAX_RELEVE",
+    },
+    {
+        "id_field": "id_occurrence_occtax",
+        "table_name": "t_occurrences_occtax",
+        "object_code": "OCCTAX_OCCURENCE",
+    },
+    {
+        "id_field": "id_counting_occtax",
+        "table_name": "cor_counting_occtax",
+        "object_code": "OCCTAX_DENOMBREMENT",
+    },
+]
+
+
+def upgrade():
+    for source in SOURCES:
+        sql = generate_upgrade(
+            id_field=source["id_field"],
+            table_name=source["table_name"],
+            object_code=source["object_code"],
+        )
+        op.execute(text(sql))
+
+
+def downgrade():
+    for source in SOURCES:
+        op.execute(generate_downgrade(**source))
+
+
+def generate_upgrade(id_field, table_name, object_code):
+    sql = f"""
+        WITH ids AS (
+            SELECT
+                DISTINCT tro.id_releve_occtax ,
+                too.id_occurrence_occtax ,
+                cco.id_counting_occtax
+            FROM pr_occtax.t_releves_occtax tro
+            JOIN pr_occtax.t_occurrences_occtax too
+            ON tro.id_releve_occtax = too.id_releve_occtax
+            JOIN pr_occtax.cor_counting_occtax cco
+            ON too.id_occurrence_occtax = cco.id_occurrence_occtax
+            WHERE
+                tro.meta_device_entry = 'mobile'
+        ),
+        fields AS (
+            SELECT
+                taf.field_name,
+                taf.code_nomenclature_type
+            FROM gn_commons.t_additional_fields taf
+            JOIN gn_commons.bib_widgets bw
+            ON bw.id_widget = taf.id_widget
+            JOIN gn_commons.cor_field_object cfo
+            ON cfo.id_field = taf.id_field
+            JOIN gn_permissions.t_objects t
+            ON
+                t.id_object = cfo.id_object
+            WHERE
+                bw.widget_name = 'nomenclature'
+                AND t.code_object = '{object_code}'
+        ),
+        final_data AS (
+            SELECT
+                tro.{id_field},
+                jsonb_object_agg(
+                COALESCE(kv.key, e.key),
+                COALESCE(kv.value, e.value)
+                ) AS merged
+            FROM pr_occtax.{table_name} tro
+            JOIN ids
+            ON ids.{id_field} = tro.{id_field}
+            CROSS JOIN LATERAL jsonb_each(tro.additional_fields) e(key, value)
+            LEFT JOIN fields f
+            ON f.field_name = e.key
+            LEFT JOIN ref_nomenclatures.t_nomenclatures tn
+            ON tn.id_nomenclature::text  = e.value #>> '{{}}' OR  tn.label_default = e.value #>> '{{}}'
+            AND tn.id_type =ref_nomenclatures.get_id_nomenclature_type(f.code_nomenclature_type)
+            LEFT JOIN LATERAL (
+                SELECT *
+                FROM jsonb_each(
+                    jsonb_build_object(
+                        e.key, tn.id_nomenclature,
+                        '_label_' || e.key, COALESCE(tn.label_default, e.value #>> '{{}}')
+                    )
+                )
+            ) kv
+            ON f.field_name IS NOT NULL
+            WHERE tro.additional_fields IS NOT NULL
+            GROUP BY tro.{id_field}
+        )
+        UPDATE pr_occtax.{table_name} tro
+            SET additional_fields = d.merged
+        FROM final_data d
+        WHERE d.{id_field} = tro.{id_field};
+    """
+    return sql
+
+
+def generate_downgrade(id_field, table_name, object_code):
+    sql = f"""
+        WITH ids AS (
+                    SELECT
+                        DISTINCT tro.id_releve_occtax ,
+                        too.id_occurrence_occtax ,
+                        cco.id_counting_occtax
+                    FROM pr_occtax.t_releves_occtax tro
+                    JOIN pr_occtax.t_occurrences_occtax too
+                    ON tro.id_releve_occtax = too.id_releve_occtax
+                    JOIN pr_occtax.cor_counting_occtax cco
+                    ON too.id_occurrence_occtax = cco.id_occurrence_occtax
+                    WHERE
+                        tro.meta_device_entry = 'mobile'
+                ),
+        fields AS (
+            SELECT
+                taf.field_name,
+                taf.code_nomenclature_type
+            FROM gn_commons.t_additional_fields taf
+            JOIN gn_commons.bib_widgets bw
+            ON bw.id_widget = taf.id_widget
+            JOIN gn_commons.cor_field_object cfo
+            ON cfo.id_field = taf.id_field
+            JOIN gn_permissions.t_objects t
+            ON
+                t.id_object = cfo.id_object
+            WHERE
+                bw.widget_name = 'nomenclature'
+                AND t.code_object = '{object_code}'
+        ),
+        final_data AS (
+            SELECT
+            tro.{id_field},
+            jsonb_object_agg(
+                e.key,
+                CASE
+                    WHEN e.value = 'null'::jsonb AND tro.additional_fields ? ('_label_' || e.key)
+                        THEN tro.additional_fields -> ('_label_' || e.key)
+                ELSE e.value
+                END
+            ) AS merged
+            FROM pr_occtax.{table_name} tro
+            JOIN ids
+            ON ids.{id_field} = tro.{id_field}
+            CROSS JOIN LATERAL jsonb_each(tro.additional_fields) e(key, value)
+            WHERE e.key NOT LIKE '_label_%'
+            GROUP BY tro.{id_field}
+        )
+        UPDATE pr_occtax.{table_name} tro
+            SET additional_fields = d.merged
+        FROM final_data d
+        WHERE d.{id_field} = tro.{id_field};
+    """
+    return sql

--- a/contrib/occtax/backend/occtax/migrations/b5b0d26c1fcc_web_additional_fields_process_.py
+++ b/contrib/occtax/backend/occtax/migrations/b5b0d26c1fcc_web_additional_fields_process_.py
@@ -1,0 +1,190 @@
+"""WEB : Additional fields - process nomenclature
+
+Revision ID: b5b0d26c1fcc
+Revises: 174f0d2fc3a4
+Create Date: 2026-08-06 17:04:32.446593
+
+Migration des données des champs additionnels de type nomenclature d'occtax saisies dans le formulaire web
+Concerne les tables :
+    - t_releves_occtax
+    - t_occurrences_occtax
+    - cor_counting_occtax
+
+Transformation :
+    {'mon_champ' : 'label_default'} -> {'mon_champ' : 'id_nomenclature', '_label_mon_champ' : 'label_default'}
+Exception :
+    - Si le label n'est pas retrouvé dans la nomenclature  {'mon_champ' : null , '_label_mon_champ' : 'label'}
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = "b5b0d26c1fcc"
+down_revision = "174f0d2fc3a4"
+branch_labels = None
+depends_on = None
+
+SOURCES = [
+    {
+        "id_field": "id_releve_occtax",
+        "table_name": "t_releves_occtax",
+        "object_code": "OCCTAX_RELEVE",
+    },
+    {
+        "id_field": "id_occurrence_occtax",
+        "table_name": "t_occurrences_occtax",
+        "object_code": "OCCTAX_OCCURENCE",
+    },
+    {
+        "id_field": "id_counting_occtax",
+        "table_name": "cor_counting_occtax",
+        "object_code": "OCCTAX_DENOMBREMENT",
+    },
+]
+
+
+def upgrade():
+    for source in SOURCES:
+        sql = generate_upgrade(
+            id_field=source["id_field"],
+            table_name=source["table_name"],
+            object_code=source["object_code"],
+        )
+        op.execute(text(sql))
+
+
+def downgrade():
+    for source in SOURCES:
+        op.execute(generate_downgrade(**source))
+
+
+def generate_upgrade(id_field, table_name, object_code):
+    return f"""
+    WITH ids AS (
+        SELECT DISTINCT tro.id_releve_occtax , too.id_occurrence_occtax , cco.id_counting_occtax
+        FROM pr_occtax.t_releves_occtax tro
+        JOIN pr_occtax.t_occurrences_occtax too
+        ON tro.id_releve_occtax = too.id_releve_occtax
+        JOIN pr_occtax.cor_counting_occtax cco
+        ON too.id_occurrence_occtax = cco.id_occurrence_occtax
+        WHERE tro.meta_device_entry = 'web' OR tro.meta_device_entry IS NULL
+    ), fields AS (
+        SELECT taf.field_name, taf.code_nomenclature_type
+        FROM gn_commons.t_additional_fields taf
+        JOIN gn_commons.bib_widgets bw
+        ON bw.id_widget = taf.id_widget
+        JOIN gn_commons.cor_field_object cfo
+        ON cfo.id_field = taf.id_field
+        JOIN gn_permissions.t_objects t
+        ON t.id_object = cfo.id_object
+        WHERE bw.widget_name = 'nomenclature' AND t.code_object = '{object_code}'
+    ), r AS (
+        SELECT tro.{id_field} , tro.additional_fields  ,  jsonb_object_keys(additional_fields) AS k
+        FROM pr_occtax.{table_name} tro
+        WHERE NOT tro.additional_fields IS NULL
+    ), d AS (
+        SELECT r.{id_field} ,
+            jsonb_build_object(
+            '_label_' || k,
+            r.additional_fields->>k ,
+            k,
+            tn.id_nomenclature
+            ) AS n
+        FROM r
+        JOIN fields ON fields.field_name = k
+        LEFT JOIN ref_nomenclatures.t_nomenclatures tn
+        ON tn.label_default  = r.additional_fields->>fields.field_name
+            AND tn.id_type = ref_nomenclatures.get_id_nomenclature_type(fields.code_nomenclature_type)
+    ), con AS (
+        SELECT tro.additional_fields - f.names  || d.n AS d, d.{id_field}
+        FROM d
+        JOIN pr_occtax.{table_name} tro
+        ON tro.{id_field} = d.{id_field}
+        JOIN (SELECT array_agg(field_name) names FROM fields) f ON true
+        WHERE NOT tro.additional_fields IS NULL
+    ) , final_data AS (
+        SELECT a.{id_field},
+            jsonb_object_agg(key, value) AS merged
+        FROM (
+            SELECT {id_field}, key, value
+            FROM con
+            CROSS JOIN LATERAL jsonb_each(con.d)
+        ) as a
+        JOIN ids
+        ON a.{id_field} = ids.{id_field}
+        GROUP BY a.{id_field}
+    )
+    UPDATE pr_occtax.{table_name} tro
+        SET additional_fields = d.merged
+    FROM final_data d
+    WHERE d.{id_field} = tro.{id_field};
+"""
+
+
+def generate_downgrade(id_field, table_name, object_code):
+    return f"""
+    WITH ids AS (
+        SELECT DISTINCT tro.id_releve_occtax , too.id_occurrence_occtax , cco.id_counting_occtax
+        FROM pr_occtax.t_releves_occtax tro
+        JOIN pr_occtax.t_occurrences_occtax too
+        ON tro.id_releve_occtax = too.id_releve_occtax
+        JOIN pr_occtax.cor_counting_occtax cco
+        ON too.id_occurrence_occtax = cco.id_occurrence_occtax
+        WHERE tro.meta_device_entry = 'web' OR tro.meta_device_entry IS NULL
+    ), fields AS (
+        SELECT taf.field_name, taf.code_nomenclature_type
+        FROM gn_commons.t_additional_fields taf
+        JOIN gn_commons.bib_widgets bw
+        ON bw.id_widget = taf.id_widget
+        JOIN gn_commons.cor_field_object cfo
+        ON cfo.id_field = taf.id_field
+        JOIN gn_permissions.t_objects t
+        ON t.id_object = cfo.id_object
+        WHERE bw.widget_name = 'nomenclature' AND t.code_object = '{object_code}'
+    ), r AS (
+        SELECT tro.{id_field} , tro.additional_fields ,  jsonb_object_keys(additional_fields) AS k
+        FROM pr_occtax.{table_name} tro
+        WHERE NOT tro.additional_fields IS NULL
+    ), d AS (
+        SELECT r.{id_field} ,
+            jsonb_build_object(
+            k,
+            tn.label_default
+            ) AS n
+        FROM r
+        JOIN fields ON fields.field_name = k
+        LEFT JOIN ref_nomenclatures.t_nomenclatures tn
+        ON tn.id_nomenclature::text = r.additional_fields->>fields.field_name
+    ), new_value AS (SELECT {id_field},
+            jsonb_object_agg(key, value) AS merged
+        FROM (
+            SELECT {id_field}, key, value
+            FROM d
+            CROSS JOIN LATERAL jsonb_each(d.n)
+        ) as a
+        GROUP BY {id_field}
+        ), remove_key AS (
+        SELECT tro.{id_field} , tro.additional_fields -  names as n_data
+        FROM pr_occtax.{table_name} tro
+        JOIN LATERAL (
+            SELECT array_agg(jsonb_object_keys) names
+                FROM jsonb_object_keys(additional_fields)  WHERE jsonb_object_keys ILIKE '_label_%'
+            )  k
+        ON true
+        WHERE NOT tro.additional_fields IS NULL
+    ) , final_data AS (
+        SELECT r.{id_field} , n_data || merged  AS merged
+        FROM remove_key r
+        JOIN new_value n
+        ON r.{id_field} = n.{id_field}
+        JOIN ids
+        ON r.{id_field} = ids.{id_field}
+    )
+    UPDATE pr_occtax.{table_name} tro
+        SET additional_fields = d.merged
+    FROM final_data d
+    WHERE d.{id_field} = tro.{id_field};
+    """

--- a/contrib/occtax/backend/occtax/schemas.py
+++ b/contrib/occtax/backend/occtax/schemas.py
@@ -16,7 +16,7 @@ from geonature.core.gn_meta.schemas import DatasetSchema
 from geonature.core.gn_commons.schemas import MediaSchema
 from geonature.core.taxonomie.schemas import TaxrefSchema
 from geonature.core.gn_monitoring.schema import TIndividualsSchema
-from geonature.core.schemas import AdditionnalDataDuplicateField
+from geonature.core.schemas import AdditionalDataWithNomenclatureField
 from geonature.utils.config import config
 from pypnusershub.db.models import User
 from pypn_habref_api.schemas import HabrefSchema
@@ -77,7 +77,7 @@ class CountingSchema(MA.SQLAlchemyAutoSchema):
         model = CorCountingOccurrence
         load_instance = True
 
-    additional_fields = AdditionnalDataDuplicateField(object_code="OCCTAX_DENOMBREMENT")
+    additional_fields = AdditionalDataWithNomenclatureField(object_code="OCCTAX_DENOMBREMENT")
     medias = MA.Nested(MediaSchema, many=True)
     id_individual = MA.auto_field()
     individual = MA.Nested(TIndividualsSchema, dump_only=True)
@@ -99,7 +99,7 @@ class OccurrenceSchema(MA.SQLAlchemyAutoSchema):
         load_instance = True
         include_fk = True
 
-    additional_fields = AdditionnalDataDuplicateField(object_code="OCCTAX_OCCURENCE")
+    additional_fields = AdditionalDataWithNomenclatureField(object_code="OCCTAX_OCCURENCE")
     cor_counting_occtax = MA.Nested(CountingSchema, many=True)
     taxref = MA.Nested(TaxrefSchema, dump_only=True)
 
@@ -128,7 +128,7 @@ class ReleveSchema(MA.SQLAlchemyAutoSchema):
     digitiser = MA.Nested(ObserverSchema, dump_only=True)
     dataset = MA.Nested(DatasetSchema, dump_only=True)
     habitat = MA.Nested(HabrefSchema, dump_only=True)
-    additional_fields = AdditionnalDataDuplicateField(object_code="OCCTAX_RELEVE")
+    additional_fields = AdditionalDataWithNomenclatureField(object_code="OCCTAX_RELEVE")
 
     # __init__ is overridden because g.module_conf is only available during
     # a request context (i.e., at instantiation time), not at class definition time.

--- a/contrib/occtax/backend/occtax/schemas.py
+++ b/contrib/occtax/backend/occtax/schemas.py
@@ -99,7 +99,7 @@ class OccurrenceSchema(MA.SQLAlchemyAutoSchema):
         load_instance = True
         include_fk = True
 
-    additional_fields = AdditionalDataWithNomenclatureField(object_code="OCCTAX_OCCURENCE")
+    additional_fields = AdditionalDataWithNomenclatureField(object_code="OCCTAX_OCCURRENCE")
     cor_counting_occtax = MA.Nested(CountingSchema, many=True)
     taxref = MA.Nested(TaxrefSchema, dump_only=True)
 

--- a/contrib/occtax/backend/occtax/schemas.py
+++ b/contrib/occtax/backend/occtax/schemas.py
@@ -16,6 +16,7 @@ from geonature.core.gn_meta.schemas import DatasetSchema
 from geonature.core.gn_commons.schemas import MediaSchema
 from geonature.core.taxonomie.schemas import TaxrefSchema
 from geonature.core.gn_monitoring.schema import TIndividualsSchema
+from geonature.core.schemas import AdditionnalDataDuplicateField
 from geonature.utils.config import config
 from pypnusershub.db.models import User
 from pypn_habref_api.schemas import HabrefSchema
@@ -68,10 +69,15 @@ class ObserverSchema(MA.SQLAlchemyAutoSchema):
 
 
 class CountingSchema(MA.SQLAlchemyAutoSchema):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.module_code = g.current_module.module_code
+
     class Meta:
         model = CorCountingOccurrence
         load_instance = True
 
+    additional_fields = AdditionnalDataDuplicateField(object_code="OCCTAX_DENOMBREMENT")
     medias = MA.Nested(MediaSchema, many=True)
     id_individual = MA.auto_field()
     individual = MA.Nested(TIndividualsSchema, dump_only=True)
@@ -84,16 +90,25 @@ class CountingSchema(MA.SQLAlchemyAutoSchema):
 
 
 class OccurrenceSchema(MA.SQLAlchemyAutoSchema):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.module_code = g.current_module.module_code
+
     class Meta:
         model = TOccurrencesOccurrence
         load_instance = True
         include_fk = True
 
+    additional_fields = AdditionnalDataDuplicateField(object_code="OCCTAX_OCCURENCE")
     cor_counting_occtax = MA.Nested(CountingSchema, many=True)
     taxref = MA.Nested(TaxrefSchema, dump_only=True)
 
 
 class ReleveSchema(MA.SQLAlchemyAutoSchema):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.module_code = g.current_module.module_code
+
     class Meta:
         model = TRelevesOccurrence
         load_instance = True
@@ -113,6 +128,7 @@ class ReleveSchema(MA.SQLAlchemyAutoSchema):
     digitiser = MA.Nested(ObserverSchema, dump_only=True)
     dataset = MA.Nested(DatasetSchema, dump_only=True)
     habitat = MA.Nested(HabrefSchema, dump_only=True)
+    additional_fields = AdditionnalDataDuplicateField(object_code="OCCTAX_RELEVE")
 
     # __init__ is overridden because g.module_conf is only available during
     # a request context (i.e., at instantiation time), not at class definition time.
@@ -140,7 +156,7 @@ class GeojsonReleveSchema(MA.Schema):
     # load_instance = True
 
     id = fields.Integer()
-    properties = fields.Nested(ReleveSchema(exclude=("geom_4326",)))
+    properties = fields.Nested(ReleveSchema, exclude=("geom_4326",))
     geometry = GeojsonSerializationField()
     af_opened = fields.Boolean()
 

--- a/contrib/occtax/backend/occtax/utils.py
+++ b/contrib/occtax/backend/occtax/utils.py
@@ -49,7 +49,11 @@ def get_nomenclature_filters(params):
 
 
 def as_dict_with_add_cols(
-    export_view, row, additional_cols_key: str, addition_cols_to_export: list
+    export_view,
+    row,
+    additional_cols_key: str,
+    addition_cols_to_export: list,
+    nomenclature_fields: list = [],
 ):
     row_as_dict = export_view.as_dict(row)
     if g.module_conf["ADD_MEDIA_IN_EXPORT"]:
@@ -65,5 +69,8 @@ def as_dict_with_add_cols(
             row_as_dict["urlMedia"] = ""
     additional_data = row_as_dict.get(additional_cols_key, {}) or {}
     for col_name in addition_cols_to_export:
-        row_as_dict[col_name] = additional_data.get(col_name, "")
+        if col_name in nomenclature_fields:
+            row_as_dict[col_name] = additional_data.get("_label_" + col_name, "")
+        else:
+            row_as_dict[col_name] = additional_data.get(col_name, "")
     return row_as_dict

--- a/contrib/occtax/backend/occtax/utils.py
+++ b/contrib/occtax/backend/occtax/utils.py
@@ -70,7 +70,7 @@ def as_dict_with_add_cols(
     additional_data = row_as_dict.get(additional_cols_key, {}) or {}
     for col_name in addition_cols_to_export:
         if col_name in nomenclature_fields:
-            row_as_dict[col_name] = additional_data.get("_label_" + col_name, "")
+            row_as_dict[col_name] = additional_data.get(f"_label_{col_name}", "")
         else:
             row_as_dict[col_name] = additional_data.get(col_name, "")
     return row_as_dict

--- a/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.service.ts
+++ b/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.service.ts
@@ -95,7 +95,7 @@ export class OcctaxFormOccurrenceService {
       switchMap((occurrence): Observable<any[]> => {
         //observable : get occurrence & countinf filed in same array, explode for separate into double array (occ array & couting array)
         const $_globalFieldsObservable = this.occtaxFormService
-          .getAdditionnalFields(['OCCTAX_OCCURENCE'])
+          .getAdditionnalFields(['OCCTAX_OCCURRENCE'])
           .pipe(catchError(() => of([])));
 
         return forkJoin(of(occurrence), $_globalFieldsObservable);
@@ -110,7 +110,7 @@ export class OcctaxFormOccurrenceService {
       filter((id_dataset) => id_dataset !== undefined && id_dataset !== null),
       switchMap((id_dataset): Observable<any[]> => {
         return this.occtaxFormService
-          .getAdditionnalFields(['OCCTAX_OCCURENCE'], id_dataset)
+          .getAdditionnalFields(['OCCTAX_OCCURRENCE'], id_dataset)
           .pipe(catchError(() => of([])));
       })
     );
@@ -123,7 +123,7 @@ export class OcctaxFormOccurrenceService {
           return [occurrence, additional_fields];
         }),
         tap(([occurrence, additional_fields]) => {
-          if(occurrence.additional_fields) {
+          if (occurrence.additional_fields) {
             //manage occ_additional_f
             additional_fields.forEach((field) => {
               //Formattage des dates
@@ -136,13 +136,12 @@ export class OcctaxFormOccurrenceService {
                     );
                 }
               }
-  
+
               //set value of field (eq patchValue)
               if (occurrence.additional_fields[field.attribut_name] !== undefined) {
                 field.value = occurrence.additional_fields[field.attribut_name];
               }
             });
-
           }
 
           return [occurrence, additional_fields];

--- a/contrib/occtax/frontend/app/occtax-map-info/occtax-map-info.component.html
+++ b/contrib/occtax/frontend/app/occtax-map-info/occtax-map-info.component.html
@@ -97,7 +97,10 @@
                       <div *ngIf="dynamiqueField.type_widget != 'html'">
                         <div class="label">{{ dynamiqueField.attribut_label }} :</div>
                         <div class="value">
-                          {{ releve?.additional_fields[dynamiqueField.attribut_name] }}
+                          {{
+                            releve?.additional_fields
+                              | additionalFieldValue: dynamiqueField.attribut_name
+                          }}
                         </div>
                       </div>
                     </ng-container>
@@ -323,9 +326,8 @@
                           <div class="label">{{ dynamiqueField.attribut_label }} :</div>
                           <div class="value">
                             {{
-                              (displayOccurrence | async)?.additional_fields[
-                                dynamiqueField.attribut_name
-                              ]
+                              (displayOccurrence | async)?.additional_fields
+                                | additionalFieldValue: dynamiqueField.attribut_name
                             }}
                           </div>
                         </div>
@@ -413,7 +415,10 @@
                           <div>
                             <div class="label">{{ dynamiqueField.attribut_label }} :</div>
                             <div class="value">
-                              {{ counting?.additional_fields[dynamiqueField.attribut_name] }}
+                              {{
+                                counting?.additional_fields
+                                  | additionalFieldValue: dynamiqueField.attribut_name
+                              }}
                             </div>
                           </div>
                         </ng-container>

--- a/contrib/occtax/frontend/app/occtax-map-info/occtax-map-info.component.ts
+++ b/contrib/occtax/frontend/app/occtax-map-info/occtax-map-info.component.ts
@@ -52,7 +52,6 @@ export class OcctaxMapInfoComponent implements OnInit, AfterViewInit {
   public occurrenceAddFields: Array<any> = [];
   public countingAddFields: Array<any> = [];
 
-
   get releve() {
     return this.occtaxData.getValue() ? this.occtaxData.getValue().properties : null;
   }
@@ -168,7 +167,7 @@ export class OcctaxMapInfoComponent implements OnInit, AfterViewInit {
               additionalFields.forEach((field) => {
                 const map = {
                   OCCTAX_RELEVE: this.releveAddFields,
-                  OCCTAX_OCCURENCE: this.occurrenceAddFields,
+                  OCCTAX_OCCURRENCE: this.occurrenceAddFields,
                   OCCTAX_DENOMBREMENT: this.countingAddFields,
                 };
                 if (field.type_widget != 'html') {
@@ -189,7 +188,7 @@ export class OcctaxMapInfoComponent implements OnInit, AfterViewInit {
               additionalFields.forEach((field) => {
                 const map = {
                   OCCTAX_RELEVE: this.releveAddFields,
-                  OCCTAX_OCCURENCE: this.occurrenceAddFields,
+                  OCCTAX_OCCURRENCE: this.occurrenceAddFields,
                   OCCTAX_DENOMBREMENT: this.countingAddFields,
                 };
                 field.objects.forEach((object) => {
@@ -273,7 +272,6 @@ export class OcctaxMapInfoComponent implements OnInit, AfterViewInit {
       this.translate
     );
   }
-
 
   isActionAllowed(action: 'U' | 'D'): boolean {
     return this.actionService.isActionAllowed(this.userReleveCruved, this.afOpened, action);

--- a/docs/occtax-additional-fields.md
+++ b/docs/occtax-additional-fields.md
@@ -1,39 +1,35 @@
-Occtax - Champs additionnels
-============================
+# Occtax - Champs additionnels
 
-Les champs additionnels peuvent être définis à chacun des trois niveaux du formulaire (objet de rattachement): 
+Les champs additionnels peuvent être définis à chacun des trois niveaux du formulaire (objet de rattachement):
 
-* releve
-* occurrence
-* dénombrement
+- releve
+- occurrence
+- dénombrement
 
-Le endpoint pour connaitre les champs additionnels est : 
+Le endpoint pour connaitre les champs additionnels est :
 
-* <https://URL/geonature/api/gn_commons/additional_fields?module_code=OCCTAX>
+- <https://URL/geonature/api/gn_commons/additional_fields?module_code=OCCTAX>
 
 Le JSON renvoie le tableau de champs additionnels d'Occtax (trois niveaux du formulaire confondu).
 
 Pour connaitre le niveau (releve, occurrence, dénombrement), on regarde la tableau de l'attribut "objects" qui contient un attribut "code_object"
 
-* revele = OCCTAX_OCCURENCE
-* occurrence = OCCTAX_OCCURENCE
-* denombrement = OCCTAX_RELEVE
+- revele = OCCTAX_RELEVE
+- occurrence = OCCTAX_OCCURRENCE
+- denombrement = OCCTAX_DENOMBREMENT
 
-Il y a aussi la possibilité de faire trois appels pour les distinguer : 
+Il y a aussi la possibilité de faire trois appels pour les distinguer :
 
-* <https://URL/geonature/api/gn_commons/additional_fields?module_code=OCCTAX&object_code=OCCTAX_RELEVE>
-* <https://URL/geonature/api/gn_commons/additional_fields?module_code=OCCTAX&object_code=OCCTAX_OCCURENCE>
-* <https://URL/geonature/api/gn_commons/additional_fields?&module_code=OCCTAX&object_code=OCCTAX_DENOMBREMENT>
-
+- <https://URL/geonature/api/gn_commons/additional_fields?module_code=OCCTAX&object_code=OCCTAX_RELEVE>
+- <https://URL/geonature/api/gn_commons/additional_fields?module_code=OCCTAX&object_code=OCCTAX_OCCURRENCE>
+- <https://URL/geonature/api/gn_commons/additional_fields?&module_code=OCCTAX&object_code=OCCTAX_DENOMBREMENT>
 
 Les champs additionnels peuvent également être globaux à tout le module (à afficher tout le temps), ou simplement rattaché à un jeu de données (à afficher uniquement si ce jeu de donnée est selectionné)
 
-On distingue les champs additionnels globaux de ceux rattaché à un JDD via l'attribut "datasets". Si le tableau est vide alors ils sont globaux, sinon ils sont affichés uniquement quand un des JDD de ce tableau est 
+On distingue les champs additionnels globaux de ceux rattaché à un JDD via l'attribut "datasets". Si le tableau est vide alors ils sont globaux, sinon ils sont affichés uniquement quand un des JDD de ce tableau est
 selectionné en interface.
 
-
-Type de champs
---------------
+## Type de champs
 
 Le JSON renvoyé par les routes précédentes contient un dictionnaire "type_widget" qui contient lui même l'information du type de widget sous l'attribut "widget_name".
 
@@ -42,11 +38,11 @@ Les champs additionnels peuvent définir les "widgets" suivants :
 - text (un champ comportant du texte libre : input type text)
 - textarea (input type textarea - champ comportant du texte libre)
 - number (input type number - entier ou réel)
-- html (champs de type "présentation" permettant de décorer le formulaire: peut contenir des balises html). 
+- html (champs de type "présentation" permettant de décorer le formulaire: peut contenir des balises html).
 - select (input type select. Les valeurs pour peupler l'input sont dans le champs "field_values" de la route)
 - radio (input type radio. Les valeurs pour peupler l'input sont dans le champs "field_values" de la route)
 - checkbox (input type checkbox. Les valeurs pour peupler l'input sont dans le champs "field_values" de la route. Ce widget renvoie toujours un tableau de valeurs.)
-- multiselect (input de type select à choix multiple.  Les valeurs pour peupler l'input sont dans le champs "field_values" de la route
+- multiselect (input de type select à choix multiple. Les valeurs pour peupler l'input sont dans le champs "field_values" de la route
 - nomenclature (un champ select renvoyant à une nomenclature GeoNature. Les valeurs de ce "select" sont donc à précharger en synchronisation. Le code de nomenclature se trouve à l'attribut "code_nomenclature_type")
 
 Widget non géré :
@@ -55,20 +51,18 @@ Widget non géré :
 - time : l'heure est déjà gérée par occtax mobile
 - date : idem
 
-Autres informations
--------------------
+## Autres informations
 
 - l'attribut "required" (booléen) défini si le champs est obligatoire. On ne doit pas pouvoir passer à l'écran suivant si un des champs obligatoire n'est pas rempli
 - l'attribut "order" (integer) défini l'ordre d'affichage des champs pour chacun des trois niveaux du formulaire. Ce champs n'est pas obligatoire et peut être null. Si null alors le champs apparaît après ceux qui sont ordonnés
 - l'attribut "value" défini la valeur par défaut de l'input. Celle-ci est préchargée à l'affichage du champ
 - les champs de type nomenclature peuvent être filtrés selon leurs "cd_nomenclature". Les cd_nomenclatures à filtrer se retrouve dans l'attribut "additional_attributes" puis "cd_nomenclatures" qui est un tableau. Le backend de geonature permet directement de filtrer ces cd_nomenclatures : <https://URL/geonature/api/nomenclatures/nomenclature/VENT?regne=&group2_inpn=&orderby=label_default&cd_nomenclature=VENT_2&cd_nomenclature=VENT_3> (voir postman). Ce filtre pourrait également être fait côté mobile, au choix
 
-Médias
-======
+# Médias
 
 La route à utiliser est la suivante : <https://URL/geonature/api/gn_commons/media>.
 
-L'idée est donc de d'abord poster l'occurence est ses dénombrement. L'API renvoie les dénombrements ainsi que les médias en conservant l'ordre de l'envoi. 
+L'idée est donc de d'abord poster l'occurence est ses dénombrement. L'API renvoie les dénombrements ainsi que les médias en conservant l'ordre de l'envoi.
 
 On récupère donc l'UUID du dénombrement pour l'utiliser dans la route de POST des médias.
 
@@ -76,12 +70,6 @@ Celle-ci attend :
 
 - id_table_location : <https://URL/geonature/api/gn_commons/get_id_table_location/pr_occtax.cor_counting_occtax>
 - id_nomenclature_media_type (on ne propose que "Photo" pour le mobile) : <https://URL/geonature/api/nomenclatures/nomenclature/TYPE_MEDIA?regne=&group2_inpn=&orderby=label_default>
-- title_fr : <datetime> nom du taxon 
+- title_fr : <datetime> nom du taxon
 - description : <taxon> observé le <date de l'obs>
-- auteur : la personne loggué 
-
-
-
-
-
-
+- auteur : la personne loggué

--- a/frontend/src/app/GN2CommonModule/GN2Common.module.ts
+++ b/frontend/src/app/GN2CommonModule/GN2Common.module.ts
@@ -96,10 +96,12 @@ import { SheetLayoutComponent } from './layouts/sheet-layout/sheet-layout.compon
 import { TabsLayoutComponent } from './layouts/tabs-layout/tabs-layout.component';
 
 // Directives
+import { AdditionalFieldsDirective } from './directive/additional-fields.directive';
 import { DisableControlDirective } from './form/disable-control.directive';
 import { DisplayMouseOverDirective } from './directive/display-mouse-over.directive';
 
 // Pipes
+import { AdditionalFieldValuePipe } from './pipe/additional-field-value.pipe';
 import { ReadablePropertiePipe } from './pipe/readable-propertie.pipe';
 import { SafeHtmlPipe } from './pipe/sanitizer.pipe';
 import { SafeStripHtmlPipe } from './pipe/strip-html.pipe';
@@ -156,6 +158,8 @@ import { IndividualsCreateComponent } from './form/individuals/create/individual
   ],
   declarations: [
     AcquisitionFrameworksComponent,
+    AdditionalFieldsDirective,
+    AdditionalFieldValuePipe,
     AdvancedSectionComponent,
     AreasComponent,
     NomenclatureComponent,
@@ -239,6 +243,8 @@ import { IndividualsCreateComponent } from './form/individuals/create/individual
   ],
   exports: [
     AcquisitionFrameworksComponent,
+    AdditionalFieldsDirective,
+    AdditionalFieldValuePipe,
     AdvancedSectionComponent,
     AreasComponent,
     MunicipalitiesComponent,

--- a/frontend/src/app/GN2CommonModule/directive/additional-fields.directive.ts
+++ b/frontend/src/app/GN2CommonModule/directive/additional-fields.directive.ts
@@ -1,0 +1,54 @@
+import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
+
+const LABEL_PREFIX = '_label_';
+
+export interface AdditionalFieldContext {
+  $implicit: {
+    name: string;
+    label: string;
+    value: any;
+  };
+}
+
+/**
+ * Structural directive itérant sur les champs d'un dict additional_fields, en
+ * masquant les entrées "_label_<champ>" (fusionnées dans leur champ d'origine)
+ * et en substituant la valeur brute d'un champ de type nomenclature par son
+ * libellé "_label_<champ>" quand celui-ci existe. Les champs sans libellé
+ * associé (texte, select, ...) restent affichés avec leur valeur brute.
+ *
+ * Usage:
+ * <ng-container *additionalFields="let field of releve.additional_fields">
+ *   <div>{{ field.label }} : {{ field.value }}</div>
+ * </ng-container>
+ */
+@Directive({
+  selector: '[additionalFields]',
+})
+export class AdditionalFieldsDirective {
+  constructor(
+    private templateRef: TemplateRef<AdditionalFieldContext>,
+    private viewContainerRef: ViewContainerRef
+  ) {}
+
+  @Input()
+  set additionalFieldsOf(fields: { [key: string]: any } | null | undefined) {
+    this.viewContainerRef.clear();
+    if (!fields) {
+      return;
+    }
+    Object.keys(fields)
+      .filter((key) => !key.startsWith(LABEL_PREFIX))
+      .forEach((name) => {
+        const labelKey = LABEL_PREFIX + name;
+        const hasLabel = Object.prototype.hasOwnProperty.call(fields, labelKey);
+        this.viewContainerRef.createEmbeddedView(this.templateRef, {
+          $implicit: {
+            name,
+            label: name,
+            value: hasLabel ? fields[labelKey] : fields[name],
+          },
+        });
+      });
+  }
+}

--- a/frontend/src/app/GN2CommonModule/form/data-form.service.ts
+++ b/frontend/src/app/GN2CommonModule/form/data-form.service.ts
@@ -670,7 +670,7 @@ export class DataFormService {
               objects: data.objects,
               modules: data.modules,
               datasets: data.datasets,
-              key_value: data.type_widget.widget_name === 'nomenclature' ? 'label_default' : null,
+              key_value: data.type_widget.widget_name === 'nomenclature' ? 'id_nomenclature' : null,
               ...data.additional_attributes,
             };
           });

--- a/frontend/src/app/GN2CommonModule/pipe/additional-field-value.pipe.ts
+++ b/frontend/src/app/GN2CommonModule/pipe/additional-field-value.pipe.ts
@@ -1,0 +1,23 @@
+import { PipeTransform, Pipe } from '@angular/core';
+
+const LABEL_PREFIX = '_label_';
+
+/**
+ * Résout la valeur à afficher pour un champ d'un dict additional_fields :
+ * le libellé "_label_<champ>" s'il existe (cas des champs de type
+ * nomenclature), sinon la valeur brute du champ.
+ *
+ * Usage: {{ releve.additional_fields | additionalFieldValue: 'mon_champ' }}
+ */
+@Pipe({ name: 'additionalFieldValue' })
+export class AdditionalFieldValuePipe implements PipeTransform {
+  transform(fields: { [key: string]: any } | null | undefined, fieldName: string): any {
+    if (!fields) {
+      return undefined;
+    }
+    const labelKey = LABEL_PREFIX + fieldName;
+    return Object.prototype.hasOwnProperty.call(fields, labelKey)
+      ? fields[labelKey]
+      : fields[fieldName];
+  }
+}

--- a/frontend/src/app/metadataModule/af/af-card.component.html
+++ b/frontend/src/app/metadataModule/af/af-card.component.html
@@ -277,7 +277,7 @@
                 [attr.data-qa]="'pnx-metadata-additional-field-' + additionalField.attribut_name"
               >
                 <b>{{ additionalField.attribut_label }} :</b>
-                {{ af?.additional_data[additionalField.attribut_name] }}
+                {{ af?.additional_data | additionalFieldValue: additionalField.attribut_name }}
               </div>
             </div>
           </ng-container>

--- a/frontend/src/app/metadataModule/datasets/dataset-card.component.html
+++ b/frontend/src/app/metadataModule/datasets/dataset-card.component.html
@@ -324,7 +324,7 @@
                 [attr.data-qa]="'pnx-metadata-additional-field-' + additionalField.attribut_name"
               >
                 <b>{{ additionalField.attribut_label }} :</b>
-                {{ dataset?.additional_data[additionalField.attribut_name] }}
+                {{ dataset?.additional_data | additionalFieldValue: additionalField.attribut_name }}
               </div>
             </div>
           </ng-container>

--- a/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.html
+++ b/frontend/src/app/shared/syntheseSharedModule/synthese-info-obs/synthese-info-obs.component.html
@@ -362,10 +362,16 @@
             <td>Identifiant unique SINP</td>
             <td>{{ selectedObs?.unique_id_sinp }}</td>
           </tr>
-          <tr>
-            <td>Champs additionnels</td>
-            <td>{{ selectedObs?.additional_data | json }}</td>
+          <tr class="bg-info font-weight-bold">
+            <td>Champs additionnels :</td>
+            <td></td>
           </tr>
+          <ng-container *additionalFields="let field of selectedObs?.additional_data">
+            <tr>
+              <td>{{ field.label | titlecase }}</td>
+              <td>{{ field.value }}</td>
+            </tr>
+          </ng-container>
         </table>
       </ng-container>
       <!-- </mat-tab> -->


### PR DESCRIPTION
Add a label on all additionnal (json)  nomenclature field: 
- additonnal nomenclature field are now duplicated : the id_nomenclature is store + the label under le `_label` prefix key 
- this commit add a custom marshmallow field to auto `load` the `label` key for additionnal fields 
- A data migration is done for occtax historical data (mobile and web)