### PR TITLE
fix(occtax): use namespaced i18n key for NonDigitalProof

### DIFF
--- a/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.component.html
+++ b/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.component.html
@@ -299,7 +299,7 @@
       }"
     >
       <div class="form-group">
-        <small>{{ 'Taxon.NonDigitalProof' | translate }}</small>
+        <small>{{ 'Occtax.Taxon.NonDigitalProof' | translate }}</small>
         <input
           [ngClass]="{
             'is-invalid':


### PR DESCRIPTION
La clé `Taxon.NonDigitalProof` n'a pas été migrée vers le namespace `Occtax` lors de la refonte i18n des modules lazy-loaded (#3522). Le formulaire d'occurrence affiche donc la clé brute au lieu du libellé traduit quand « preuve d'existence = Oui » est sélectionné.

La traduction existe déjà dans `contrib/occtax/frontend/assets/i18n/fr.json`.