### PR TITLE
feat: Improve pre commit prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,14 @@ repos:
   - repo: local
     hooks:
       - id: prettier
-        name: Prettier format check
-        entry: bash -c ". ${NVM_DIR}/nvm.sh; cd frontend; nvm use; npm run format:check"
+        name: Prettier auto-format
+        entry: >-
+          bash -c '. ${NVM_DIR}/nvm.sh; nvm use --silent --prefix frontend;
+          npx --prefix frontend prettier --write "$@"' --
         language: system
+        files: ^frontend/.*\.(js|jsx|ts|tsx|css|scss|json|md)$
         pass_filenames: true
+
   - repo: https://github.com/commit-check/commit-check
     rev: v0.9.6
     hooks: # support hooks


### PR DESCRIPTION
Now we user prettier --write so it does the same thing as black (fail if need linting, but lint at the same time, you only have to add the file afterward). Also only pass the file that were changed, it improve massivelly the speed of pre-commit.