### PR TITLE
chore: add manual buid docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
       - develop
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build-backend:


### PR DESCRIPTION
L'idée est de pouvoir build une image depuis n'importe quelle branche, notamment pour pouvoir déployer des instances de tests qui ne sont pas basées sur develop. 

J'ai fais une PR vers develop mais le changement ne sera effectif que quand ce sera merge dans main 

https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow#running-a-workflow-on-github

> To trigger the workflow_dispatch event, your workflow must be in the default branch. 