### PR TITLE
fix: cron validation automatique 

### DIFF
--- a/contrib/gn_module_validation/backend/gn_module_validation/conf_schema_toml.py
+++ b/contrib/gn_module_validation/backend/gn_module_validation/conf_schema_toml.py
@@ -75,6 +75,6 @@ class GnModuleSchemaConf(Schema):
     MAIL_BODY = fields.String(load_default=MAIL_BODY)
     MAIL_SUBJECT = fields.String(load_default=MAIL_SUBJECT)
     COLUMN_LIST = fields.List(fields.Nested(ColumnSchema), load_default=COLUMN_LIST)
-    AUTO_VALIDATION_CRONTAB = fields.String(load_default="* 1 * * *")
+    AUTO_VALIDATION_CRONTAB = fields.String(load_default="0 * * * *")
     AUTO_VALIDATION_ENABLED = fields.Boolean(load_default=False)
     AUTO_VALIDATION_SQL_FUNCTION = fields.String(load_default="fct_auto_validation")

--- a/contrib/gn_module_validation/validation_config.toml.example
+++ b/contrib/gn_module_validation/validation_config.toml.example
@@ -4,7 +4,7 @@
 #AUTO_VALIDATION_ENABLED = true 
 
 ### Cron parameters for the auto-validation 
-#AUTO_VALIDATION_CRONTAB = "* 1 * * *"
+#AUTO_VALIDATION_CRONTAB = "0 * * * *"
 
 ## If the auto-validation function does not fit your usecase, be sure to create your own
 ## and indicate its name in the following variable

--- a/docs/admin-manual.rst
+++ b/docs/admin-manual.rst
@@ -2474,7 +2474,7 @@ Le processus de validation automatique est exécuté à une fréquence définie,
 
 Ce paramètre est composé de cinq valeurs, chacune séparée par un espace: minute, heure, jour du mois, mois de l'année, journée de la semaine. Dans l'exemple ci-dessus, il est indiqué que le processus d'auto-validation sera répété toutes les minutes. Pour plus d'informations, vous pouvez consulter la documentation de Celery à ce sujet : https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html#crontab-schedules.
 
-**Note** Si vous ne voulez pas définir un des paramètres de périodicité, utilisez un astérisque (``*``).
+**Note** Un astérisque (``*``) signifie « toutes les valeurs » pour le champ concerné, et non « valeur non définie ». Ainsi ``* 1 * * *`` déclenche le processus toutes les minutes entre 01h00 et 01h59 ; pour un unique passage quotidien à 01h00, écrivez ``0 1 * * *``.
 
 Modification de la fonction de validation automatique
 `````````````````````````````````````````````````````


### PR DESCRIPTION
## Problème

La valeur par défaut de `AUTO_VALIDATION_CRONTAB` est `"* 1 * * *"`. Dans `tasks.py`, cette
chaîne est découpée en champs cron standard puis passée à `celery.schedules.crontab` :

```python
minute, hour, day_of_month, month_of_year, day_of_week = ct.split(" ")
sender.add_periodic_task(
    crontab(minute=minute, hour=hour, ...), set_auto_validation.s(), name="auto validation"
)
```

Avec `minute="*"` et `hour="1"`, la tâche est planifiée toutes les minutes entre 01h00 et
01h59, soit 60 exécutions par nuit.

Or le manuel d'administration annonce :

> Le processus de validation automatique est exécuté à une fréquence définie, par défaut
> toutes les heures.

## Conséquence

Chaque exécution rejoue l'intégralité de la sélection de `fct_auto_validation` à travers
`gn_profiles.v_consistancy_data`, qui évalue pour chaque ligne un `ST_Contains`
(`check_profile_distribution`) et un `EXISTS` sur `vm_cor_taxon_phenology`
(`check_profile_phenology`).

Les observations validées sortent du périmètre dès le premier passage. Celles qui échouent
à l'un des trois contrôles restent au statut « En attente de validation » — elles attendent
un validateur humain — et sont donc réévaluées à chacune des 60 exécutions, chaque nuit.
Ce résidu s'accumule au fil des imports.

## Correctif

Le défaut passe à `"0 * * * *"`, soit le comportement horaire annoncé par la doc.
`validation_config.toml.example` est aligné : sinon un utilisateur qui décommente la ligne
d'exemple réintroduit le problème.