### PR TITLE
fix(champs additionnels): un aller-retour GET/POST altère le libellé des champs nomenclature

### DIFF
--- a/backend/geonature/core/schemas.py
+++ b/backend/geonature/core/schemas.py
@@ -25,7 +25,14 @@ def _add_label_nomenclature_data_dict(value, module_code, object_code):
     nomenclature_fields_name = [
         field.field_name for field in fields if field.type_widget.widget_name == "nomenclature"
     ]
+    # Les libellés sont entièrement recalculés à partir des valeurs. Ceux que le
+    # client renvoie tels qu'il les a reçus sont donc écartés : conservés, ils
+    # écraseraient le libellé recalculé dès qu'ils apparaissent après leur valeur
+    # dans le JSON, et figeraient le libellé de la valeur précédente.
+    computed_label_keys = {f"_label_{name}" for name in nomenclature_fields_name}
     for key, val in (value or {}).items():
+        if key in computed_label_keys:
+            continue
         duplicate_key_dict[key] = val
         if key in nomenclature_fields_name:
             if nomenclature := db.session.get(TNomenclatures, val):

--- a/backend/geonature/tests/test_pr_occtax.py
+++ b/backend/geonature/tests/test_pr_occtax.py
@@ -501,6 +501,77 @@ class TestOcctaxReleve:
         )
         assert "_label_" + nomenclature_field.field_name not in releve.additional_fields
 
+    def test_releve_additional_fields_load_stale_label(
+        self,
+        app: Flask,
+        users: dict,
+        releve_data: dict[str, Any],
+        occtax_module: Any,
+        additional_fields_releve: dict[str, TAdditionalFields],
+    ):
+        """
+        A client editing a releve gets the "_label_" keys back in the GET
+        response and may post them back untouched. The label must always be
+        recomputed from the posted value, whatever its position in the payload.
+        """
+        g.current_module = occtax_module
+        nomenclature_field = additional_fields_releve["nomenclature"]
+        before, after = (
+            db.session.scalars(
+                select(TNomenclatures).order_by(TNomenclatures.id_nomenclature).limit(2)
+            )
+            .unique()
+            .all()
+        )
+
+        data = releve_data["properties"]
+        data["geom_4326"] = releve_data["geometry"]
+        data["observers"] = [users["user"].id_role]
+        # the label key comes after the value it describes, as a client
+        # resending an object it received from the API would send it
+        data["additional_fields"] = {
+            nomenclature_field.field_name: after.id_nomenclature,
+            "_label_" + nomenclature_field.field_name: before.label_default,
+        }
+
+        releve = ReleveSchema().load(data)
+
+        assert releve.additional_fields[nomenclature_field.field_name] == after.id_nomenclature
+        assert (
+            releve.additional_fields["_label_" + nomenclature_field.field_name]
+            == after.label_default
+        )
+
+    def test_releve_additional_fields_load_stale_label_unknown_nomenclature(
+        self,
+        app: Flask,
+        users: dict,
+        releve_data: dict[str, Any],
+        occtax_module: Any,
+        additional_fields_releve: dict[str, TAdditionalFields],
+    ):
+        """
+        A label posted along a value that matches no nomenclature must be
+        dropped rather than kept: it would describe a value that is gone.
+        """
+        g.current_module = occtax_module
+        nomenclature_field = additional_fields_releve["nomenclature"]
+        unexisting_id_nomenclature = (
+            db.session.execute(select(func.max(TNomenclatures.id_nomenclature))).scalar() or 0
+        ) + 1
+
+        data = releve_data["properties"]
+        data["geom_4326"] = releve_data["geometry"]
+        data["observers"] = [users["user"].id_role]
+        data["additional_fields"] = {
+            nomenclature_field.field_name: unexisting_id_nomenclature,
+            "_label_" + nomenclature_field.field_name: "libellé obsolète",
+        }
+
+        releve = ReleveSchema().load(data)
+
+        assert "_label_" + nomenclature_field.field_name not in releve.additional_fields
+
     def test_insertOrUpdate_releve(
         self,
         users: dict,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐛 Corrections
 
+- [Champs additionnels] Correction du libellé des champs de type nomenclature, qui restait figé sur la valeur précédente lorsque le client renvoyait la clé `_label_` reçue de l'API
 - Suppression de la section de configuration `ADDITIONAL_FIELDS` et des variables de configuration `IMPLEMENTED_MODULES` et `IMPLEMENTED_MODULES`, maintenant géré en base de donnée (la migration alambic gère la rétro-compatibilité)
 
 ## 2.17.2 (2026-06-09)


### PR DESCRIPTION
## Le constat

Depuis #4329, un champ additionnel de type `nomenclature` est stocké accompagné
de son libellé, sous une clé `_label_<champ>` que le serveur recalcule à chaque
enregistrement.

Cette clé est renvoyée telle quelle dans les réponses de l'API. Mais si un
client repose l'objet qu'il vient de recevoir, sans y toucher, la donnée est
altérée : **un aller-retour `GET` puis `POST` n'est pas neutre.**

L'identifiant de nomenclature est bien enregistré, mais le libellé qui
l'accompagne reste celui de la valeur précédente. La donnée persistée devient
incohérente, et l'incohérence est durable : rien ne viendra la corriger tant
que le champ ne sera pas modifié à nouveau. Comme le pipe `additionalFieldValue`
et la directive `additionalFields` affichent le `_label_` de préférence à la
valeur, l'utilisateur verrait indéfiniment le libellé de l'ancienne
nomenclature.

### Reproduction

Sur un module exposant `additional_data` — ici Occhab, avec un champ
`etat_biologique` sur le type `ETA_BIO` — deux `POST` successifs sur la même
station :

| Envoyé | Persisté |
|---|---|
| `{"etat_biologique": 153}` | `{"etat_biologique": 153, "_label_etat_biologique": "Non renseigné"}` ✔ |
| `{"etat_biologique": 152, "_label_etat_biologique": "Non renseigné"}` | `{"etat_biologique": 152, "_label_etat_biologique": "Non renseigné"}` ✘ |

La seconde ligne reprend exactement ce que le serveur a produit à la première,
en ne changeant que la valeur. Attendu : `"NSP"`, le libellé de la nomenclature
152.

## L'origine

`_add_label_nomenclature_data_dict` recopie d'abord chaque clé reçue, puis
ajoute le libellé recalculé :

```python
for key, val in (value or {}).items():
    duplicate_key_dict[key] = val
    if key in nomenclature_fields_name:
        if nomenclature := db.session.get(TNomenclatures, val):
            duplicate_key_dict[f"_label_{key}"] = nomenclature.label_default
```

Le résultat dépend donc de l'ordre des clés dans le JSON reçu. `<champ>` est
traité en premier et le bon libellé est écrit ; puis `_label_<champ>` arrive et
l'écrase avec celui du client.

Et cet ordre est défavorable **par construction**. Les colonnes concernées sont
toutes en `jsonb`, or PostgreSQL y normalise l'ordre des clés : d'abord par
longueur, puis par octet. Comme `_label_<champ>` fait exactement sept caractères
de plus que `<champ>`, le libellé suit toujours sa valeur, quel que soit l'ordre
d'insertion :

```sql
SELECT '{"_label_etat_biologique": "NSP", "etat_biologique": 152}'::jsonb;
-- {"etat_biologique": 152, "_label_etat_biologique": "NSP"}
```

Un client qui repose l'objet reçu tombe donc dans le mauvais cas à tous les
coups, pour tous les champs, sur toutes les installations.

## Origine de la PR

Elle fait suite à une remarque de @TheoLechemia en relecture de mon travail sur
les champs additionnels d'Occhab, où j'avais dû expurger les clés `_label_`
côté client avant envoi : « ce bout de code pourrait être géré (et factorisé)
dans le custom field Marshmallow `AdditionalDataWithNomenclatureField` ». C'est
exactement ce que fait ce correctif, et le test correspondant est lui aussi
remonté au niveau du champ partagé.

## Portée

Autant le dire : **à ma connaissance, aucun client ne déclenche ce défaut
aujourd'hui.** Cette PR relève du durcissement avant la 2.18, pas de la
correction d'un dysfonctionnement constaté en production.

Les clés `_label_` n'existent que depuis #4329, aucun client ne pouvait donc les
renvoyer auparavant. Côté web, Occtax (`releve.service.ts`) comme les
métadonnées (`dataset-form.service.ts`) partent d'un `fb.group({})` vide et n'y
placent que les champs additionnels déclarés : les clés `_label_` sont ignorées
au chargement, donc jamais réémises. Les applications mobiles construisent leur
requête depuis leur propre modèle et envoient l'`id_nomenclature`.

Ce qui me conduit tout de même à proposer le correctif :

- Les clients du cœur y échappent par leur architecture de formulaire, pas par
  une précaution délibérée. Rien n'avertit du piège, et chaque nouveau client
  devra le redécouvrir puis le contourner de son côté.
- C'est ce qui m'est arrivé en ajoutant les champs additionnels à Occhab : le
  formulaire y est réalimenté depuis la réponse de l'API, et j'ai dû écrire un
  filtre expurgeant les clés `_label_` avant envoi. Ce filtre devient inutile
  une fois le serveur corrigé.
- Corriger maintenant évite d'avoir à rattraper plus tard, par migration, des
  libellés incohérents en base — ce que #4329 vient précisément de faire deux
  fois, avec `b5b0d26c1fcc` et `a22f59a3912c`.

## La correction

Le libellé est une donnée entièrement dérivée de la valeur : il n'appartient
donc pas au client. Ceux qu'il fournit sont écartés avant reconstruction du
dictionnaire, et tous recalculés à partir des valeurs. Le résultat ne dépend
plus de l'ordre des clés reçues.

Un `_label_` orphelin, dont la valeur ne correspond à aucune nomenclature, n'est
plus conservé non plus : il décrirait une valeur disparue. C'est cohérent avec
le comportement déjà couvert par
`test_releve_additional_fields_load_unknown_nomenclature`.

Seules sont écartées les clés `_label_<champ>` où `<champ>` est un champ
additionnel de type nomenclature déclaré sur l'objet. Les autres clés du JSON
sont inchangées, y compris une clé que l'utilisateur aurait nommé ainsi de son
propre chef.

## Tests

Deux tests dans `test_pr_occtax.py`, qui échouent sans le correctif :

- `test_releve_additional_fields_load_stale_label` : libellé périmé posté après
  sa valeur, le libellé persisté doit suivre la nouvelle valeur ;
- `test_releve_additional_fields_load_stale_label_unknown_nomenclature` :
  libellé posté avec une valeur qui ne correspond à aucune nomenclature, il doit
  être écarté.

## Suivi possible, hors périmètre de cette PR

`_add_label_nomenclature_data_dict` rejoue sa requête sur `TAdditionalFields` à
chaque désérialisation : une fois par occurrence et par dénombrement sur un
relevé Occtax, une fois par habitat sur une station Occhab. Un cache par requête
HTTP serait bienvenu, mais relève d'une PR de performance distincte.
