### PR TITLE
fix(occtax): On edit we use same method than every other place to zoom on selected layer

### DIFF
--- a/contrib/gn_module_occhab/frontend/app/components/occhab-map-form/occhab-form.component.ts
+++ b/contrib/gn_module_occhab/frontend/app/components/occhab-map-form/occhab-form.component.ts
@@ -1,15 +1,16 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { OcchabFormService } from '../../services/form-service';
-import { OcchabStoreService } from '../../services/store.service';
-import { OccHabDataService } from '../../services/data.service';
-import { leafletDrawOption } from '@geonature_common/map/leaflet-draw.options';
-import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs/Subscription';
-import { CommonService } from '@geonature_common/service/common.service';
-import { filter } from 'rxjs/operators';
-import { ConfigService } from '@geonature/services/config.service';
-import { StationFeature } from '../../models';
-import { FormService } from '@geonature_common/form/form.service';
+import {Component, OnInit, OnDestroy} from '@angular/core';
+import {OcchabFormService} from '../../services/form-service';
+import {OcchabStoreService} from '../../services/store.service';
+import {OccHabDataService} from '../../services/data.service';
+import {leafletDrawOption} from '@geonature_common/map/leaflet-draw.options';
+import {ActivatedRoute, Router} from '@angular/router';
+import {Subscription} from 'rxjs/Subscription';
+import {CommonService} from '@geonature_common/service/common.service';
+import {filter} from 'rxjs/operators';
+import {ConfigService} from '@geonature/services/config.service';
+import {StationFeature} from '../../models';
+import {FormService} from '@geonature_common/form/form.service';
+import {MapService} from "@geonature_common/map/map.service";
 
 @Component({
   selector: 'pnx-occhab-form',
@@ -47,8 +48,10 @@ export class OccHabFormComponent implements OnInit, OnDestroy {
     private _router: Router,
     private _commonService: CommonService,
     public config: ConfigService,
-    public globalFormService: FormService
-  ) {}
+    public globalFormService: FormService,
+    private _mapService: MapService,
+  ) {
+  }
 
   ngOnInit() {
     this.leafletDrawOptions;
@@ -96,10 +99,12 @@ export class OccHabFormComponent implements OnInit, OnDestroy {
               this.occHabForm.stationForm.get('date_min').markAsDirty();
               this.occHabForm.stationForm.get('date_max').markAsDirty();
             }
+            this._mapService.zoomOnMarker(station.geometry);
           });
         }
       })
     );
+
   }
 
   formIsDisable() {

--- a/contrib/occtax/frontend/app/occtax-form/map/occtax-map.component.ts
+++ b/contrib/occtax/frontend/app/occtax-form/map/occtax-map.component.ts
@@ -1,16 +1,18 @@
-import {Component, OnInit, AfterViewInit, OnDestroy} from '@angular/core';
-import {leafletDrawOption} from '@geonature_common/map/leaflet-draw.options';
-import {CommonService} from '@geonature_common/service/common.service';
-import {MapService} from '@geonature_common/map/map.service';
-import {OcctaxFormMapService} from './occtax-map.service';
-import {OcctaxConfigService} from '../../services/occtax-config.service';
-import {filter} from 'rxjs/operators';
-import * as L from 'leaflet';
+import { Component, OnInit, AfterViewInit, OnDestroy } from "@angular/core";
+import { leafletDrawOption } from "@geonature_common/map/leaflet-draw.options";
+import { CommonService } from "@geonature_common/service/common.service";
+import { MapService } from "@geonature_common/map/map.service";
+import { OcctaxFormMapService } from "./occtax-map.service";
+import { OcctaxConfigService } from "../../services/occtax-config.service";
+import { filter } from "rxjs/operators";
+import * as L from "leaflet";
 @Component({
-  selector: 'pnx-occtax-form-map',
-  templateUrl: 'occtax-map.component.html',
+  selector: "pnx-occtax-form-map",
+  templateUrl: "occtax-map.component.html",
 })
-export class OcctaxFormMapComponent implements OnInit, AfterViewInit, OnDestroy {
+export class OcctaxFormMapComponent
+  implements OnInit, AfterViewInit, OnDestroy
+{
   public leafletDrawOptions: any;
   public firstFileLayerMessage = true;
 
@@ -22,9 +24,8 @@ export class OcctaxFormMapComponent implements OnInit, AfterViewInit, OnDestroy 
     public ms: OcctaxFormMapService,
     private _commonService: CommonService,
     private _mapService: MapService,
-    public occtaxConfig: OcctaxConfigService
-  ) {
-  }
+    public occtaxConfig: OcctaxConfigService,
+  ) {}
 
   ngOnInit() {
     // overight the leaflet draw object to set options
@@ -41,7 +42,7 @@ export class OcctaxFormMapComponent implements OnInit, AfterViewInit, OnDestroy 
     if (this._mapService.currentExtend) {
       this._mapService.map.setView(
         this._mapService.currentExtend.center,
-        this._mapService.currentExtend.zoom
+        this._mapService.currentExtend.zoom,
       );
     }
     let filelayerFeatures = this._mapService.fileLayerFeatureGroup.getLayers();
@@ -52,32 +53,24 @@ export class OcctaxFormMapComponent implements OnInit, AfterViewInit, OnDestroy 
     }
 
     filelayerFeatures.forEach((el) => {
-      if ((el as any).getLayers()[0].options.color == 'red') {
-        (el as any).setStyle({color: 'green', opacity: 0.2});
+      if ((el as any).getLayers()[0].options.color == "red") {
+        (el as any).setStyle({ color: "green", opacity: 0.2 });
       }
     });
     this.ms.geometry.valueChanges
       .pipe(filter((geojson) => geojson != null))
       .subscribe(() => {
-        setTimeout(() => this.fitToGeometry());
+        setTimeout(() => this._mapService.fitToGeometry());
       });
-
-    // if geom already set
-    if (this.ms.geometry.value) {
-      setTimeout(() => this.fitToGeometry());
-    }
-  }
-
-  private fitToGeometry() {
-      const layers = this._mapService.leafletDrawFeatureGroup?.getLayers();
-      if (layers && layers.length > 0)
-        this._mapService.zoomOnSelectedLayer(this._mapService.map, layers[0]);
   }
 
   // display help toaster for filelayer
   infoMessageFileLayer() {
     if (this.firstFileLayerMessage) {
-      this._commonService.translateToaster('info', 'Map.Messages.FileLayerInfo');
+      this._commonService.translateToaster(
+        "info",
+        "Map.Messages.FileLayerInfo",
+      );
     }
     this.firstFileLayerMessage = false;
   }

--- a/contrib/occtax/frontend/app/occtax-form/map/occtax-map.component.ts
+++ b/contrib/occtax/frontend/app/occtax-form/map/occtax-map.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit, AfterViewInit, OnDestroy } from '@angular/core';
-import { leafletDrawOption } from '@geonature_common/map/leaflet-draw.options';
-import { CommonService } from '@geonature_common/service/common.service';
-import { MapService } from '@geonature_common/map/map.service';
-import { OcctaxFormMapService } from './occtax-map.service';
-import { OcctaxConfigService } from '../../services/occtax-config.service';
-
+import {Component, OnInit, AfterViewInit, OnDestroy} from '@angular/core';
+import {leafletDrawOption} from '@geonature_common/map/leaflet-draw.options';
+import {CommonService} from '@geonature_common/service/common.service';
+import {MapService} from '@geonature_common/map/map.service';
+import {OcctaxFormMapService} from './occtax-map.service';
+import {OcctaxConfigService} from '../../services/occtax-config.service';
+import {filter} from 'rxjs/operators';
+import * as L from 'leaflet';
 @Component({
   selector: 'pnx-occtax-form-map',
   templateUrl: 'occtax-map.component.html',
@@ -22,7 +23,8 @@ export class OcctaxFormMapComponent implements OnInit, AfterViewInit, OnDestroy 
     private _commonService: CommonService,
     private _mapService: MapService,
     public occtaxConfig: OcctaxConfigService
-  ) {}
+  ) {
+  }
 
   ngOnInit() {
     // overight the leaflet draw object to set options
@@ -51,9 +53,25 @@ export class OcctaxFormMapComponent implements OnInit, AfterViewInit, OnDestroy 
 
     filelayerFeatures.forEach((el) => {
       if ((el as any).getLayers()[0].options.color == 'red') {
-        (el as any).setStyle({ color: 'green', opacity: 0.2 });
+        (el as any).setStyle({color: 'green', opacity: 0.2});
       }
     });
+    this.ms.geometry.valueChanges
+      .pipe(filter((geojson) => geojson != null))
+      .subscribe(() => {
+        setTimeout(() => this.fitToGeometry());
+      });
+
+    // if geom already set
+    if (this.ms.geometry.value) {
+      setTimeout(() => this.fitToGeometry());
+    }
+  }
+
+  private fitToGeometry() {
+      const layers = this._mapService.leafletDrawFeatureGroup?.getLayers();
+      if (layers && layers.length > 0)
+        this._mapService.zoomOnSelectedLayer(this._mapService.map, layers[0]);
   }
 
   // display help toaster for filelayer

--- a/frontend/src/app/GN2CommonModule/map-list/map-list.service.ts
+++ b/frontend/src/app/GN2CommonModule/map-list/map-list.service.ts
@@ -240,9 +240,7 @@ export class MapListService {
   }
 
   zoomOnSelectedLayer(map, layer) {
-    const tempFeatureGroup = new L.FeatureGroup();
-    tempFeatureGroup.addLayer(layer);
-    map.fitBounds(tempFeatureGroup.getBounds());
+    return this._ms.zoomOnSelectedLayer(map, layer);
   }
 
   zoomOnSeveralSelectedLayers(map, layers) {

--- a/frontend/src/app/GN2CommonModule/map/map.service.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.service.ts
@@ -88,14 +88,23 @@ export class MapService {
     this._geojsonCoord.next(geojsonCoord);
   }
 
-  zoomOnMarker(coordinates, zoomLevel = 15) {
-    this.map.setView(new L.LatLng(coordinates[1], coordinates[0]), zoomLevel);
+  zoomOnMarker(geom, zoomLevel = 15) {
+    // Kept zoomLevel for retro-compatibility
+    if (!geom) return;
+    const tempLayer = L.geoJSON(geom);
+    if (tempLayer.getLayers().length === 0) return;
+    this.zoomOnSelectedLayer(this.map, tempLayer);
   }
 
   zoomOnSelectedLayer(map, layer) {
     const tempFeatureGroup = new L.FeatureGroup();
     tempFeatureGroup.addLayer(layer);
     map.fitBounds(tempFeatureGroup.getBounds());
+  }
+
+  fitToGeometry() {
+    const layers = this.leafletDrawFeatureGroup?.getLayers();
+    if (layers && layers.length > 0) this.zoomOnSelectedLayer(this.map, layers[0]);
   }
 
   /**

--- a/frontend/src/app/GN2CommonModule/map/map.service.ts
+++ b/frontend/src/app/GN2CommonModule/map/map.service.ts
@@ -92,6 +92,12 @@ export class MapService {
     this.map.setView(new L.LatLng(coordinates[1], coordinates[0]), zoomLevel);
   }
 
+  zoomOnSelectedLayer(map, layer) {
+    const tempFeatureGroup = new L.FeatureGroup();
+    tempFeatureGroup.addLayer(layer);
+    map.fitBounds(tempFeatureGroup.getBounds());
+  }
+
   /**
    * Function who disable marker editing (click event and control) mode via an observable
    * @param isEditing : boolean
@@ -291,6 +297,7 @@ export class MapService {
       });
     }
   }
+
   removeLayerFeatureGroups(featureGroups: Array<any>) {
     featureGroups.forEach((featureGroup) => {
       if (featureGroup) {
@@ -325,8 +332,7 @@ export class MapService {
       });
 
       this.map.addLayer(this.marker);
-      // zoom to the layer
-      this.map.setView(this.marker.getLatLng(), 15);
+      this.zoomOnSelectedLayer(this.map, this.marker);
     } else {
       let layer;
       if (data.geometry.type === 'LineString') {


### PR DESCRIPTION
closes #3304 

Jusque là dans Occtax, on ne zoomait pas sur l'édition d'une observation. 

L'idée de cette PR est de faire en sorte que le zoom soit fait de manière uniforme pour tous les endroits où on clique sur une obs. 

Ma proposition est de se caler sur la methode `zoomOnSelectedLayer` déjà utilisée dans la liste des observations.

## Nouveau fonctionnement : 

### Selection d'une ligne : 

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/b2f86f39-db9a-4a9c-a0a1-aa1306ef7c69" />

### Page d'info:

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/367ee254-9c2c-4bf9-a269-24a67260d673" />

### Edition : 

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/2e9f99af-7f4b-4f00-9ab5-b35bf159b4e1" />

## Ancien fonctionnement : 

### Selection d'une ligne : 

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/526192f4-2db6-4c73-80e8-c24eb763aed8" />

### Page d'info:

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/8bfd03dd-cd04-48f5-97a2-f388e8558c15" />

### Edition: 

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/fd36cdaa-cebf-4caa-9260-89c212df2280" />
