### PR TITLE
[occtax] corrige le titre "Dénombrement s"

### DIFF
--- a/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.component.html
+++ b/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.component.html
@@ -353,8 +353,7 @@
     [matBadge]="countings.length"
     matBadgeOverlap="false"
   >
-    {{ 'Occtax.Counting.Counting' | translate }}
-    <ng-container *ngIf="countings.length > 1">s</ng-container>
+    {{ (countings.length > 1 ? 'Occtax.Counting.Countings' : 'Occtax.Counting.Counting') | translate }}
   </span>
 </h5>
 


### PR DESCRIPTION
Corrige l'espace qui se met entre `dénombrement` et `s` dès qu'il y en a plusieurs :
<img width="318" height="202" alt="image" src="https://github.com/user-attachments/assets/dd19dd72-da36-4efb-a768-2daf38b2d825" />
