### PR TITLE
occtax fix ng-select list position

### DIFF
--- a/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.component.scss
+++ b/contrib/occtax/frontend/app/occtax-form/occurrence/occurrence.component.scss
@@ -18,7 +18,7 @@ button .mat-spinner {
 // to make additional fields multiselect with long list
 // visible
 .mat-expansion-panel {
-  overflow: auto;
+  overflow: visible;
   border: 1px solid #cfcfcf;
   margin-right: 50px !important;
   box-shadow: none;

--- a/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.html
+++ b/frontend/src/app/GN2CommonModule/form/nomenclature/nomenclature.component.html
@@ -9,7 +9,6 @@
   [virtualScroll]="true"
   [formControl]="parentFormControl"
   [attr.qa-test]="label"
-  appendTo="body"
   [clearAllText]="'Actions.Clear' | translate"
 >
   <ng-template


### PR DESCRIPTION
Corrige le problème de l'affichage du ng-select dans occtax.
L'utilisation du appendTo="body" (https://github.com/PnX-SI/GeoNature/issues/4238#issuecomment-5527072209)  permettait de corriger le problème d'affichage tronqué de la liste du ng-select présent dans le mat-expansion-panel :
<img width="343" height="234" alt="image" src="https://github.com/user-attachments/assets/c35a6465-a08c-4a4a-b80d-34b929b885bf" />

par contre il générait des listes volantes. Cette PR clean le rendu des listes ng-select.