### PR TITLE
fix extra_files

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -122,6 +122,7 @@ WORKDIR /dist/geonature
 
 COPY --chmod=755 /install/03b_populate_db.sh /populate_db.sh
 COPY --chmod=755 /install/assets/docker_entrypoint.sh /entrypoint.sh
+COPY /install/assets/gunicorn.conf.py .
 
 ENV GEONATURE_CONFIG_FILE=""
 

--- a/backend/geonature/core/command/main.py
+++ b/backend/geonature/core/command/main.py
@@ -11,8 +11,8 @@ import click
 from flask.cli import run_command
 
 import geonature
-from geonature.utils.env import GEONATURE_VERSION, ROOT_DIR
-from geonature.utils.module import iter_modules_dist
+from geonature.utils.env import GEONATURE_VERSION, CONFIG_FILE
+from geonature.utils.module import iter_modules_config, iter_modules_dist
 from geonature import create_app
 from geonature.utils.config import config
 from geonature.utils.config_schema import GnGeneralSchemaConf, GnPySchemaConf
@@ -64,11 +64,12 @@ def dev_back(ctx, host, port):
     """
     if not environ.get("FLASK_DEBUG"):
         environ["FLASK_DEBUG"] = "true"
+    extra_files = [CONFIG_FILE] + list(iter_modules_config())
     ctx.invoke(
         run_command,
         host=host,
         port=port,
-        extra_files=[file for file in glob.glob(join(ROOT_DIR, "config", "*.toml"))],
+        extra_files=extra_files,
     )
 
 

--- a/backend/geonature/utils/module.py
+++ b/backend/geonature/utils/module.py
@@ -25,6 +25,14 @@ def iter_modules_dist():
         yield module_code_entry.dist
 
 
+def iter_modules_config():
+    for dist in iter_modules_dist():
+        module_code = dist.entry_points["code"].load()
+        module_config_path = get_module_config_path(module_code)
+        if module_config_path:
+            yield (str(module_config_path))
+
+
 def get_module_config_path(module_code):
     config_path = os.environ.get(f"GEONATURE_{module_code}_CONFIG_FILE")
     if config_path:

--- a/install/assets/gunicorn.conf.py
+++ b/install/assets/gunicorn.conf.py
@@ -1,0 +1,5 @@
+from geonature.utils.env import CONFIG_FILE
+from geonature.utils.module import iter_modules_config
+
+reload = True
+reload_extra_files = [CONFIG_FILE] + list(iter_modules_config())


### PR DESCRIPTION
Use existing mechanisms to find right GeoNature & modules config paths.

Le mécanisme actuel qui regarde le sous dossier "config" est faux dès qu’on modifie le chemin d’accès du fichier de configuration `GEONATURE_CONFIG_FILE` (ou `GEONATURE_{MODULE}_CONFIG_FILE`)