### PR TITLE
fix(nginx): set absolute_redirect off

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -2,6 +2,9 @@ server {
     listen       ${NGINX_PORT};
     server_name  ${NGINX_HOST};
 
+    # Avoid redirection issue when proxy port is not the same as nginx one
+    absolute_redirect off;
+
     location ${NGINX_LOCATION} {
         alias  /usr/share/nginx/html/;
         index  index.html index.htm;


### PR DESCRIPTION
nginx automatically redirect /geonature to /geonature/, but it do it with a absolute URI (with proto & domain). Consequently, it always generate an URI using http, and port 80 (i.e. no port), even if your GeoNature is served by a proxy doing SSL (you will have an extra http to https redirection) or on a exoteric port (your attempt to reach GeoNature will completely fail).

Le cas le plus commun est bien sûr la redirection en HTTP au lieu d’HTTPS (pas si grave car l’HTTP sera à nouveau redirigé vers HTTPS), mais j’ai voulu faire un déploiement sur le port 8000 pour des tests, et dans ce cas je suis redirigé vers `http://localhost/geonature/` et donc ça ne marche pas du tout. 